### PR TITLE
Fix: Replace invalid Discord badge with static join badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
         <img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg" />
     </a>
     <a href="https://discord.gg/74cF8vbNEs">
-        <img alt="Discord" src="https://img.shields.io/discord/74cF8vbNEs?label=Discord&logo=discord&style=flat-square&color=5865F2" />
+        <img alt="Join Discord" src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&style=flat-square" />
     </a>
     <a href="https://pepy.tech/projects/pylibseekdb">
         <img height="20" alt="Downloads" src="https://static.pepy.tech/badge/pylibseekdb" />


### PR DESCRIPTION
This PR resolves issue #42 regarding the invalid Discord badge shown in the README.md.

The previous badge used the Shields.io endpoint:

```https://img.shields.io/discord/<server_id>```


This endpoint requires the Discord Server Widget to be enabled. Since the widget is currently disabled for the server, the badge displayed:

```invalid / widget disabled```


To avoid dependency on server settings, the badge has been replaced with a static Discord "Join Chat" badge that works universally.

---

## Changes
Updated ```README.md```

Replaced the old Discord shield badge with a static join badge:
```<img alt="Join Discord" src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&style=flat-square" />```

---

## Screenshot Preview
<table>
<tr>
<td>
Before
<img width="121" height="38" alt="Screenshot 2025-11-29 at 2 05 23 PM" src="https://github.com/user-attachments/assets/3e4a167f-f938-4922-9718-85ecbd15afe8" />
</td>
<td>
After
<img width="137" height="44" alt="Screenshot 2025-11-29 at 2 06 23 PM" src="https://github.com/user-attachments/assets/668ba739-fb52-4d9a-a63b-9eeb4c99edb3" />
</td>
</tr>
</table>

---

## Expected Behavior

The ```README``` now displays a functional Discord badge linking visitors to the server invite without showing errors.

---

## Related Issue

Fixes #42 

---

## Additional Notes

If server administrators later enable the Discord widget API, the original dynamic member-count badge may be restored. This ensures reliability for now.

---

# Ready for review

Looking forward to feedback or approval.