### PR TITLE
perf: optimize ObMySQLRequestRecord construction with audit_record

### DIFF
--- a/src/observer/mysql/ob_mysql_request_manager.cpp
+++ b/src/observer/mysql/ob_mysql_request_manager.cpp
@@ -176,9 +176,7 @@ int ObMySQLRequestManager::record_request(const ObAuditRecordData &audit_record,
       }
       ret = OB_ALLOCATE_MEMORY_FAILED;
     } else {
-      record = new(buf)ObMySQLRequestRecord();
-      record->allocator_ = &allocator_;
-      record->data_ = audit_record;
+      record = new(buf)ObMySQLRequestRecord(&allocator_, audit_record);
       //deep copy sql
       if ((audit_record.sql_len_ > 0) && (NULL != audit_record.sql_)) {
         int64_t stmt_len = min(audit_record.sql_len_, query_record_size_limit);

--- a/src/observer/mysql/ob_mysql_request_manager.h
+++ b/src/observer/mysql/ob_mysql_request_manager.h
@@ -57,6 +57,9 @@ public:
 public:
   ObMySQLRequestRecord()
     : allocator_(nullptr) {}
+  ObMySQLRequestRecord(common::ObConcurrentFIFOAllocator *allocator,
+                       const sql::ObAuditRecordData &data)
+    : allocator_(allocator), data_(data) {}
   virtual ~ObMySQLRequestRecord();
 
 public:


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

Optimize the construction of ObMySQLRequestRecord in request recording path.
Previously, `ObMySQLRequestRecord` was default-constructed and then populated via manual field assignment, which caused redundant initialization of `ObAuditRecordData` and unnecessary overhead on the hot request recording path.

In [ob_exec_stat.h](https://github.com/oceanbase/seekdb/blob/develop/src/sql/monitor/ob_exec_stat.h)
```
struct ObAuditRecordData {
  ObAuditRecordData()
  {
    reset();
  }
  void reset()
  {
    MEMSET((void*)this, 0, sizeof(*this));
    consistency_level_ = common::INVALID_CONSISTENCY;
    ps_stmt_id_ = OB_INVALID_STMT_ID;
    ps_inner_stmt_id_ = OB_INVALID_STMT_ID;
    trans_id_ = 0;
    request_type_ = EXECUTE_INVALID;
    is_batched_multi_stmt_ = false;
    plan_hash_ = 0;
    trx_lock_for_read_elapse_ = 0;
    params_value_len_ = 0;
    partition_hit_ = true;
    is_perf_event_closed_ = false;
    pl_trace_id_.reset();
    stmt_type_ = sql::stmt::T_NONE;
    sql_memory_used_ = nullptr;
    ccl_rule_id_ = 0;
    ccl_match_time_ = 0;
  }
...
}
```

### Solution Description
`ObAuditRecordData` performs a full reset in its default constructor (via `reset()`), which zeroes and initializes all fields.

However, in `ObMySQLRequestManager::record_request`:[ob_mysql_request_manager](https://github.com/oceanbase/seekdb/blob/develop/src/observer/mysql/ob_mysql_request_manager.cpp), the default-constructed `ObMySQLRequestRecord` is immediately overwritten by assigning `audit_record`:
```
      record = new(buf)ObMySQLRequestRecord();
      record->allocator_ = &allocator_;
      record->data_ = audit_record;
```
This makes the default initialization of `data_` redundant.

To avoid this, construct `ObMySQLRequestRecord` directly using the parameterized constructor:
```
  ObMySQLRequestRecord(common::ObConcurrentFIFOAllocator *allocator,
                       const sql::ObAuditRecordData &data)
    : allocator_(allocator), data_(data) {}
```
This removes unnecessary default initialization while keeping behavior unchanged.

### Upgrade Compatibility

This change does not modify interfaces or persistent data structures.