### PR TITLE
build DAT in thread pool

### DIFF
--- a/src/storage/fts/dict/ob_dic_loader.cpp
+++ b/src/storage/fts/dict/ob_dic_loader.cpp
@@ -174,36 +174,7 @@ int ObTenantDicLoader::try_load_dictionary_in_trans(const uint64_t tenant_id)
 int ObTenantDicLoader::check_need_load_dic(const uint64_t tenant_id, bool &is_need_load_dic)
 {
   int ret = OB_SUCCESS;
-  ObSqlString sql;
   is_need_load_dic = false;
-  if (OB_UNLIKELY(!is_inited_)) {
-    ret = OB_NOT_INIT;
-    LOG_WARN("the dic loader is not initialized", K(ret), K(tenant_id));
-  } else if (OB_UNLIKELY(!is_valid_tenant_id(tenant_id))) {
-    ret = OB_INVALID_ARGUMENT;
-    LOG_WARN("invalid tenant id", K(ret), K(tenant_id));
-  } else {
-    SMART_VAR(ObMySQLProxy::MySQLResult, res)
-    {
-      if (OB_FAIL(sql.assign_fmt("SELECT * FROM %s LIMIT 1", dic_tables_info_.at(0).table_name_))) {
-        LOG_WARN("fail to append sql", KR(ret), K(tenant_id));
-      } else if (OB_FAIL(GCTX.sql_proxy_->read(res, tenant_id, sql.ptr()))) {
-        LOG_WARN("fail to execute sql", KR(ret), K(sql), K(tenant_id));
-      } else if (OB_ISNULL(res.get_result())) {
-        ret = OB_ERR_UNEXPECTED;
-        LOG_WARN("fail to get sql result", KR(ret), K(sql), K(tenant_id));
-      } else if (OB_FAIL(res.get_result()->next())) {
-        if (OB_ITER_END != ret) {
-          LOG_WARN("fail to get next row", KR(ret), K(tenant_id));
-        } else {
-          ret = OB_SUCCESS;
-          is_need_load_dic = true;
-        }
-      } else {
-        is_need_load_dic = false;
-      }
-    }
-  }
   return ret;
 }
 

--- a/src/storage/fts/dict/ob_ft_dict_hub.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_hub.cpp
@@ -78,7 +78,7 @@ int ObFTDictHub::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &
 
     if (OB_FAIL(ret)) {
       if (OB_ENTRY_NOT_EXIST == ret) {
-        if (OB_FAIL(ObFTRangeDict::build_cache(desc, container))) {
+        if (OB_FAIL(ObFTRangeDict::build_cache_from_ik_dict(desc, container))) {
           LOG_WARN("Failed to build cache", K(ret));
         } else if (FALSE_IT(info.range_count_ = container.get_handles().size())) {
         } else if (OB_FAIL(put_dict_info(key, info))) {

--- a/src/storage/fts/dict/ob_ft_range_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_range_dict.cpp
@@ -16,6 +16,7 @@
 
 #include "storage/fts/dict/ob_ft_range_dict.h"
 
+#include "storage/fts/dict/ob_ik_dic.h"
 #include "lib/allocator/page_arena.h"
 #include "lib/charset/ob_charset.h"
 #include "lib/mysqlclient/ob_isql_client.h"
@@ -41,6 +42,194 @@ namespace oceanbase
 {
 namespace storage
 {
+
+
+int ObFTRangeDict::build_cache_from_ik_dict(const ObFTDictDesc &desc, ObFTCacheRangeContainer &range_container)
+{
+  int ret = OB_SUCCESS;
+
+  ObIKDictLoader::RawDict raw_dict;
+  switch (desc.type_) {
+  case ObFTDictType::DICT_IK_MAIN: {
+    raw_dict = ObIKDictLoader::dict_text();
+  } break;
+  case ObFTDictType::DICT_IK_QUAN: {
+    raw_dict = ObIKDictLoader::dict_quen_text();
+  } break;
+  case ObFTDictType::DICT_IK_STOP: {
+    raw_dict = ObIKDictLoader::dict_stop();
+  } break;
+  default:
+    ret = OB_NOT_SUPPORTED;
+    LOG_WARN("Not supported dict type.", K(ret));
+  }
+
+  if (OB_SUCC(ret)) {
+    ObIKDictIterator iter(raw_dict);
+    if (OB_FAIL(iter.init())) {
+      LOG_WARN("Failed to init iterator.", K(ret));
+    } else if (OB_FAIL(ObFTRangeDict::build_ranges_concurrently_thread_pool(desc, iter, range_container))) {
+      LOG_WARN("Failed to build ranges.", K(ret));
+    }
+  }
+
+  return ret;
+}
+
+// Thread pool for building DATs concurrently
+class DATBuilderThreadPool : public lib::Threads
+{
+public:
+  DATBuilderThreadPool()
+      : all_tries_(nullptr),
+        desc_(nullptr),
+        container_(nullptr),
+        error_code_(OB_SUCCESS)
+  {}
+
+  void set_tries(ObVector<ObFTTrie<void> *, ObArenaAllocator> *tries) { all_tries_ = tries; }
+  void set_desc(const ObFTDictDesc *desc) { desc_ = desc; }
+  void set_container(ObFTCacheRangeContainer *container) { container_ = container; }
+  int64_t get_range_count() const { return all_tries_ ? all_tries_->size() : 0; }
+  int get_error_code() const { return error_code_.load(); }
+
+  void run1() override
+  {
+    int ret = OB_SUCCESS;
+    int64_t idx = get_thread_idx();
+
+    if (OB_ISNULL(all_tries_) || idx >= static_cast<int64_t>(all_tries_->size())) {
+      return;
+    }
+
+    ObFTTrie<void> *trie = (*all_tries_)[idx];
+    ObArenaAllocator dat_alloc(lib::ObMemAttr(OB_SERVER_TENANT_ID, "DATBuild"));
+    ObFTDATBuilder<void> builder(dat_alloc);
+
+    ObFTDAT *dat_buff = nullptr;
+    size_t buffer_size = 0;
+    ObFTCacheRangeHandle *info = nullptr;
+
+    if (OB_FAIL(builder.init(*trie))) {
+      LOG_WARN("Failed to init builder.", K(ret), K(idx));
+    } else if (OB_FAIL(builder.build_from_trie(*trie))) {
+      LOG_WARN("Failed to build datrie.", K(ret), K(idx));
+    } else if (OB_FAIL(builder.get_mem_block(dat_buff, buffer_size))) {
+      LOG_WARN("Failed to get mem block.", K(ret), K(idx));
+    } else if (OB_FAIL(container_->fetch_info_for_dict(info))) {
+      LOG_WARN("Failed to fetch info for dict.", K(ret), K(idx));
+    } else if (OB_FAIL(ObFTCacheDict::make_and_fetch_cache_entry(*desc_,
+                                                                  dat_buff,
+                                                                  buffer_size,
+                                                                  static_cast<int32_t>(idx),
+                                                                  info->value_,
+                                                                  info->handle_))) {
+      LOG_WARN("Failed to put dict into kv cache", K(ret), K(idx));
+    }
+
+    if (OB_FAIL(ret)) {
+      int expected = OB_SUCCESS;
+      error_code_.compare_exchange_strong(expected, ret);
+    }
+
+    dat_alloc.reset();
+  }
+
+private:
+  ObVector<ObFTTrie<void> *, ObArenaAllocator> *all_tries_;
+  const ObFTDictDesc *desc_;
+  ObFTCacheRangeContainer *container_;
+  std::atomic<int> error_code_;
+};
+
+int ObFTRangeDict::build_ranges_concurrently_thread_pool(const ObFTDictDesc &desc,
+                                                         ObIFTDictIterator &iter,
+                                                         ObFTCacheRangeContainer &range_container)
+{
+  int ret = OB_SUCCESS;
+
+  // Phase 1: Collect words into tries range by range
+  ObArenaAllocator tmp_alloc(lib::ObMemAttr(MTL_ID(), "Tmp Allocator"));
+  ObVector<ObFTTrie<void> *, ObArenaAllocator> all_tries(&tmp_alloc);
+
+  bool build_next_range = true;
+  while (OB_SUCC(ret) && build_next_range) {
+    ObFTTrie<void> *trie = OB_NEWx(ObFTTrie<void>, &tmp_alloc, tmp_alloc, desc.coll_type_);
+    if (OB_ISNULL(trie)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("Failed to allocate ObFTTrie", K(ret));
+      break;
+    }
+
+    int count = 0;
+    int64_t first_char_len = 0;
+    ObFTSingleWord end_char;
+    bool range_end = false;
+
+    while (OB_SUCC(ret) && !range_end) {
+      ObString key;
+      if (OB_FAIL(iter.get_key(key))) {
+        LOG_WARN("Failed to get key", K(ret));
+      } else {
+        ++count;
+
+        if (count >= DEFAULT_KEY_PER_RANGE
+            && OB_FAIL(ObCharset::first_valid_char(desc.coll_type_,
+                                                   key.ptr(),
+                                                   key.length(),
+                                                   first_char_len))) {
+          LOG_WARN("First char is not valid.");
+        } else if (DEFAULT_KEY_PER_RANGE == count
+                   && OB_FAIL(end_char.set_word(key.ptr(), first_char_len))) {
+          LOG_WARN("Failed to record first char.", K(ret));
+        } else if (count > DEFAULT_KEY_PER_RANGE
+                   && (end_char.get_word() != ObString(first_char_len, key.ptr()))) {
+          range_end = true;
+        } else {
+          if (OB_FAIL(trie->insert(key, {}))) {
+            LOG_WARN("Failed to insert key to trie", K(ret));
+          } else if (OB_FAIL(iter.next()) && OB_ITER_END != ret) {
+            LOG_WARN("Failed to step to next word entry.", K(ret));
+          }
+        }
+      }
+    }
+
+    if (OB_ITER_END == ret) {
+      build_next_range = false;
+      ret = OB_SUCCESS;
+    }
+
+    if (OB_SUCC(ret) && trie->node_num() > 0) {
+      if (OB_FAIL(all_tries.push_back(trie))) {
+        LOG_WARN("Failed to push back trie", K(ret));
+      }
+    }
+  }
+
+  // Phase 2: Build DATs concurrently using DATBuilderThreadPool
+  if (OB_SUCC(ret) && all_tries.size() > 0) {
+    DATBuilderThreadPool pool;
+    pool.set_tries(&all_tries);
+    pool.set_desc(&desc);
+    pool.set_container(&range_container);
+    pool.set_thread_count(static_cast<int64_t>(all_tries.size()));
+
+    if (OB_FAIL(pool.start())) {
+      LOG_WARN("Failed to start thread pool", K(ret));
+    } else {
+      pool.wait();
+      ret = pool.get_error_code();
+      if (OB_FAIL(ret)) {
+        LOG_WARN("Thread pool encountered error", K(ret));
+      }
+    }
+  }
+
+  LOG_INFO("build_ranges_concurrently_thread_pool completed", K(ret), K(all_tries.size()));
+  return ret;
+}
+
 int ObFTRangeDict::build_one_range(const ObFTDictDesc &desc,
                                    const int32_t range_id,
                                    ObIFTDictIterator &iter,

--- a/src/storage/fts/dict/ob_ft_range_dict.h
+++ b/src/storage/fts/dict/ob_ft_range_dict.h
@@ -68,6 +68,8 @@ public:
                             ObFTCacheRangeContainer &range_container);
   static int build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &range_container);
 
+  static int build_cache_from_ik_dict(const ObFTDictDesc &desc, ObFTCacheRangeContainer &range_container);
+
 private:
   // build cache
   static int build_ranges(const ObFTDictDesc &desc,
@@ -80,6 +82,10 @@ private:
                              ObIFTDictIterator &iter,
                              ObFTCacheRangeContainer &container,
                              bool &build_next_range);
+
+  static int build_ranges_concurrently_thread_pool(const ObFTDictDesc &desc,
+                                                   ObIFTDictIterator &iter,
+                                                   ObFTCacheRangeContainer &range_container);
 
 private:
   void destroy()


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

Reduce IK Parser Load Time

### Solution Description

<!-- Please clearly and consice descipt the solution. -->
- Read IK dictionaries directly from ob_ik_dic.cpp
- Build double array trie concurrently in a thread pool

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
