### PR TITLE
fix: always print malloc sample info regardless of FATAL_ERROR_HANG m…

### DIFF
--- a/deps/oblib/src/lib/alloc/memory_dump.cpp
+++ b/deps/oblib/src/lib/alloc/memory_dump.cpp
@@ -627,9 +627,7 @@ void ObMemoryDump::handle(void *task)
       ma->print_tenant_ctx_memory_usage(tenant_id);
     }
 
-#ifdef FATAL_ERROR_HANG
     print_malloc_sample_info();
-#endif
   } else {
     int fd = -1;
     if (-1 == (fd = ::open(LOG_FILE,


### PR DESCRIPTION
…acro

Remove the FATAL_ERROR_HANG macro guard around print_malloc_sample_info() so that memory allocation statistics are always printed. The overhead is very light and this information is useful for debugging.

Fixes #13

<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
