### PR TITLE
Remove ob_oracle_* errno helpers and call sites

### DIFF
--- a/src/observer/mysql/obmp_packet_sender.cpp
+++ b/src/observer/mysql/obmp_packet_sender.cpp
@@ -371,8 +371,7 @@ int ObMPPacketSender::send_error_packet(int err,
   sql::ObSQLSessionInfo *session = NULL;
   BACKTRACE(ERROR, (OB_SUCCESS == err), "BUG send error packet but err code is 0");
   if (OB_ERR_PROXY_REROUTE != err) {
-    int client_error = lib::is_oracle_mode() ? common::ob_oracle_errno(err) :
-                      common::ob_mysql_errno(err);
+    int client_error = common::ob_mysql_errno(err);
     // OB error codes that are not compatible with mysql will be displayed using
     // OB error codes
     client_error = lib::is_mysql_mode() && client_error == -1 ? err : client_error;
@@ -409,7 +408,7 @@ int ObMPPacketSender::send_error_packet(int err,
                  && err <= OB_MAX_RAISE_APPLICATION_ERROR) {
         // do nothing ...
       } else {
-        snprintf(msg_buf, MAX_MSG_BUF_SIZE, "%s", ob_errpkt_strerror(err, lib::is_oracle_mode()));
+        snprintf(msg_buf, MAX_MSG_BUF_SIZE, "%s", ob_errpkt_strerror(err, false));
         message = ObString::make_string(msg_buf); // default error message
       }
     }
@@ -1262,4 +1261,3 @@ int ObMPPacketSender::release_read_handle()
 
 }; // end namespace observer
 }; // end namespace oceanbase
-

--- a/src/observer/mysql/obmp_stmt_prexecute.cpp
+++ b/src/observer/mysql/obmp_stmt_prexecute.cpp
@@ -1003,7 +1003,7 @@ int ObMPStmtPrexecute::response_fail_result(sql::ObSQLSessionInfo &session, int 
   for (int64_t i = 2; i < (arraybinding_row_->get_count() - 1); i++) {
     arraybinding_row_->get_cell(i).set_null();
   }
-  arraybinding_row_->get_cell(arraybinding_row_->get_count() - 1).set_varchar(ob_oracle_strerror(err_ret));
+  arraybinding_row_->get_cell(arraybinding_row_->get_count() - 1).set_varchar(ob_strerror(err_ret));
   if (OB_FAIL(response_row(session, *arraybinding_row_, arraybinding_columns_, false))) {
     LOG_WARN("fail to response fail row to client", K(ret));
   }
@@ -1052,7 +1052,7 @@ int ObMPStmtPrexecute::response_returning_rows(ObSQLSessionInfo &session,
       for (int i = 0; i < result_row->get_count(); i++) {
         arraybinding_row_->get_cell(i+2).set_null();
       }
-      arraybinding_row_->get_cell(arraybinding_row_->get_count() - 1).set_varchar(ob_oracle_strerror(ret));
+      arraybinding_row_->get_cell(arraybinding_row_->get_count() - 1).set_varchar(ob_strerror(ret));
       LOG_DEBUG("error occured before send arraybinding_row_", KPC(arraybinding_row_));
       if (OB_SUCCESS != (response_ret = response_row(session, *arraybinding_row_, arraybinding_columns_, false, &result.get_exec_context()))) {
         LOG_WARN("fail to response row to client", K(response_ret));

--- a/src/pl/ob_pl.cpp
+++ b/src/pl/ob_pl.cpp
@@ -2718,7 +2718,7 @@ int ObPL::insert_error_msg(int errcode)
   if (err_txt.empty()) {
     ObWarningBuffer *wb = common::ob_get_tsi_warning_buffer();
     if (OB_NOT_NULL(wb)) {
-      wb->set_error(common::ob_oracle_strerror(errcode), errcode);
+      wb->set_error(common::ob_strerror(errcode), errcode);
     }
   }
   return ret;

--- a/src/share/gen_errno.pl
+++ b/src/share/gen_errno.pl
@@ -468,11 +468,6 @@ constexpr int OB_ERR_SQL_END = -5999;
   const char *ob_strerror(const int oberr);
   const char *ob_str_user_error(const int oberr);
 
-  int ob_oracle_errno(const int oberr);
-  int ob_oracle_errno_with_check(const int oberr);
-  const char *ob_oracle_strerror(const int oberr);
-  const char *ob_oracle_str_user_error(const int oberr);
-
 #ifndef __ERROR_CODE_PARSER_
   int get_ob_errno_from_oracle_errno(const int error_no, const char *error_msg, int &ob_errno);
 #endif
@@ -641,19 +636,9 @@ inline const _error *get_error(int index)
   return _errors[index];
 }
 
-int get_oracle_errno(int index)
-{
-  return get_error(index)->oracle_errno;
-}
-
 int get_mysql_errno(int index)
 {
   return get_error(index)->mysql_errno;
-}
-
-const char* get_oracle_str_error(int index)
-{
-  return get_error(index)->oracle_str_error;
 }
 
 const char* get_mysql_str_error(int index)
@@ -761,73 +746,22 @@ print $fh_cpp '
     }
     return ret;
   }
-  const char *ob_oracle_strerror(const int err)
-  {
-    const char *ret = "Unknown error";
-    if (OB_LIKELY(0 >= err && err > -OB_MAX_ERROR_CODE)) {
-      if (!g_enable_ob_error_msg_style) {
-        ret = get_error(-err)->oracle_str_error;
-      } else {
-        ret = get_error(-err)->ob_str_error;
-      }
-      if (OB_UNLIKELY(NULL == ret || \'\0\' == ret[0]))
-      {
-        ret = "Unknown Error";
-      }
-    }
-    return ret;
-  }
-  const char *ob_oracle_str_user_error(const int err)
-  {
-    const char *ret = NULL;
-    if (OB_LIKELY(0 >= err && err > -OB_MAX_ERROR_CODE)) {
-      if (!g_enable_ob_error_msg_style) {
-        ret = get_error(-err)->oracle_str_user_error;
-      } else {
-        ret = get_error(-err)->ob_str_user_error;
-      }
-      if (OB_UNLIKELY(NULL == ret || \'\0\' == ret[0])) {
-        ret = NULL;
-      }
-    }
-    return ret;
-  }
-  int ob_oracle_errno(const int err)
-  {
-    int ret = -1;
-    if (OB_ERR_PROXY_REROUTE == err) {
-      // Oracle Mode and MySQL mode should return same errcode for reroute sql
-      // thus we make the specialization here
-      ret = -1;
-    } else if (err >= OB_MIN_RAISE_APPLICATION_ERROR && err <= OB_MAX_RAISE_APPLICATION_ERROR) {
-      ret = err; // PL/SQL Raise Application Error
-    } else if (OB_LIKELY(0 >= err && err > -OB_MAX_ERROR_CODE)) {
-      ret = get_error(-err)->oracle_errno;
-    }
-    return ret;
-  }
-  int ob_oracle_errno_with_check(const int err)
-  {
-    int ret = ob_oracle_errno(err);
-    if (ret < 0) {
-      ret = -err;
-    }
-    return ret;
-  }
   int ob_errpkt_errno(const int err, const bool is_oracle_mode)
   {
-    return (is_oracle_mode ? ob_oracle_errno_with_check(err) : ob_mysql_errno_with_check(err));
+    (void)is_oracle_mode;
+    return ob_mysql_errno_with_check(err);
   }
   const char *ob_errpkt_strerror(const int err, const bool is_oracle_mode)
   {
-    return (is_oracle_mode ? ob_oracle_strerror(err) : ob_strerror(err));
+    (void)is_oracle_mode;
+    return ob_strerror(err);
   }
   const char *ob_errpkt_str_user_error(const int err, const bool is_oracle_mode)
   {
-    return (is_oracle_mode ? ob_oracle_str_user_error(err) : ob_str_user_error(err));
+    (void)is_oracle_mode;
+    return ob_str_user_error(err);
   }
 
 } // end namespace common
 } // end namespace oceanbase
 ';
-

--- a/src/share/ob_errno.cpp
+++ b/src/share/ob_errno.cpp
@@ -36659,19 +36659,9 @@ inline const _error *get_error(int index)
   return _errors[index];
 }
 
-int get_oracle_errno(int index)
-{
-  return get_error(index)->oracle_errno;
-}
-
 int get_mysql_errno(int index)
 {
   return get_error(index)->mysql_errno;
-}
-
-const char* get_oracle_str_error(int index)
-{
-  return get_error(index)->oracle_str_error;
 }
 
 const char* get_mysql_str_error(int index)
@@ -36776,70 +36766,20 @@ int g_all_ob_errnos[2440] = {0, -4000, -4001, -4002, -4003, -4004, -4005, -4006,
     }
     return ret;
   }
-  const char *ob_oracle_strerror(const int err)
-  {
-    const char *ret = "Unknown error";
-    if (OB_LIKELY(0 >= err && err > -OB_MAX_ERROR_CODE)) {
-      if (!g_enable_ob_error_msg_style) {
-        ret = get_error(-err)->oracle_str_error;
-      } else {
-        ret = get_error(-err)->ob_str_error;
-      }
-      if (OB_UNLIKELY(NULL == ret || '\0' == ret[0]))
-      {
-        ret = "Unknown Error";
-      }
-    }
-    return ret;
-  }
-  const char *ob_oracle_str_user_error(const int err)
-  {
-    const char *ret = NULL;
-    if (OB_LIKELY(0 >= err && err > -OB_MAX_ERROR_CODE)) {
-      if (!g_enable_ob_error_msg_style) {
-        ret = get_error(-err)->oracle_str_user_error;
-      } else {
-        ret = get_error(-err)->ob_str_user_error;
-      }
-      if (OB_UNLIKELY(NULL == ret || '\0' == ret[0])) {
-        ret = NULL;
-      }
-    }
-    return ret;
-  }
-  int ob_oracle_errno(const int err)
-  {
-    int ret = -1;
-    if (OB_ERR_PROXY_REROUTE == err) {
-      // Oracle Mode and MySQL mode should return same errcode for reroute sql
-      // thus we make the specialization here
-      ret = -1;
-    } else if (err >= OB_MIN_RAISE_APPLICATION_ERROR && err <= OB_MAX_RAISE_APPLICATION_ERROR) {
-      ret = err; // PL/SQL Raise Application Error
-    } else if (OB_LIKELY(0 >= err && err > -OB_MAX_ERROR_CODE)) {
-      ret = get_error(-err)->oracle_errno;
-    }
-    return ret;
-  }
-  int ob_oracle_errno_with_check(const int err)
-  {
-    int ret = ob_oracle_errno(err);
-    if (ret < 0) {
-      ret = -err;
-    }
-    return ret;
-  }
   int ob_errpkt_errno(const int err, const bool is_oracle_mode)
   {
-    return (is_oracle_mode ? ob_oracle_errno_with_check(err) : ob_mysql_errno_with_check(err));
+    (void)is_oracle_mode;
+    return ob_mysql_errno_with_check(err);
   }
   const char *ob_errpkt_strerror(const int err, const bool is_oracle_mode)
   {
-    return (is_oracle_mode ? ob_oracle_strerror(err) : ob_strerror(err));
+    (void)is_oracle_mode;
+    return ob_strerror(err);
   }
   const char *ob_errpkt_str_user_error(const int err, const bool is_oracle_mode)
   {
-    return (is_oracle_mode ? ob_oracle_str_user_error(err) : ob_str_user_error(err));
+    (void)is_oracle_mode;
+    return ob_str_user_error(err);
   }
 
 } // end namespace common

--- a/src/share/ob_errno.h
+++ b/src/share/ob_errno.h
@@ -2006,8 +2006,8 @@ constexpr int OB_ERR_UPDATE_TWICE = -30926;
 constexpr int OB_ERR_FLASHBACK_QUERY_WITH_UPDATE = -32491;
 constexpr int OB_ERR_UPDATE_ON_EXPR = -38104;
 constexpr int OB_ERR_SPECIFIED_ROW_NO_LONGER_EXISTS = -38105;
-constexpr int OB_ERR_INVALID_DATE_MSG_FMT_V2 = -4219;
 constexpr int OB_ERR_DATA_TOO_LONG_MSG_FMT_V2 = -5167;
+constexpr int OB_ERR_INVALID_DATE_MSG_FMT_V2 = -4219;
 
 
 #define OB_SUCCESS__USER_ERROR_MSG "Success"
@@ -4450,8 +4450,8 @@ constexpr int OB_ERR_DATA_TOO_LONG_MSG_FMT_V2 = -5167;
 #define OB_ERR_FLASHBACK_QUERY_WITH_UPDATE__USER_ERROR_MSG "snapshot expression not allowed here"
 #define OB_ERR_UPDATE_ON_EXPR__USER_ERROR_MSG "Columns referenced in the ON Clause cannot be updated:'%.*s'.'%.*s'"
 #define OB_ERR_SPECIFIED_ROW_NO_LONGER_EXISTS__USER_ERROR_MSG "specified row no longer exists"
-#define OB_ERR_INVALID_DATE_MSG_FMT_V2__USER_ERROR_MSG "Incorrect datetime value for column '%.*s' at row %ld"
 #define OB_ERR_DATA_TOO_LONG_MSG_FMT_V2__USER_ERROR_MSG "Data too long for column '%.*s' at row %ld"
+#define OB_ERR_INVALID_DATE_MSG_FMT_V2__USER_ERROR_MSG "Incorrect datetime value for column '%.*s' at row %ld"
 
 
 #define OB_SUCCESS__ORA_USER_ERROR_MSG "ORA-00600: internal error code, arguments: 0, Success"
@@ -9334,10 +9334,10 @@ constexpr int OB_ERR_DATA_TOO_LONG_MSG_FMT_V2 = -5167;
 #define OB_ERR_UPDATE_ON_EXPR__OBE_USER_ERROR_MSG "OBE-38104: Columns referenced in the ON Clause cannot be updated:'%.*s'.'%.*s'"
 #define OB_ERR_SPECIFIED_ROW_NO_LONGER_EXISTS__ORA_USER_ERROR_MSG "ORA-08006: specified row no longer exists"
 #define OB_ERR_SPECIFIED_ROW_NO_LONGER_EXISTS__OBE_USER_ERROR_MSG "OBE-08006: specified row no longer exists"
-#define OB_ERR_INVALID_DATE_MSG_FMT_V2__ORA_USER_ERROR_MSG "ORA-01861: Incorrect datetime value for column '%.*s' at row %ld"
-#define OB_ERR_INVALID_DATE_MSG_FMT_V2__OBE_USER_ERROR_MSG "OBE-01861: Incorrect datetime value for column '%.*s' at row %ld"
 #define OB_ERR_DATA_TOO_LONG_MSG_FMT_V2__ORA_USER_ERROR_MSG "ORA-12899: value too large for column %.*s (actual: %ld, maximum: %ld)"
 #define OB_ERR_DATA_TOO_LONG_MSG_FMT_V2__OBE_USER_ERROR_MSG "OBE-12899: value too large for column %.*s (actual: %ld, maximum: %ld)"
+#define OB_ERR_INVALID_DATE_MSG_FMT_V2__ORA_USER_ERROR_MSG "ORA-01861: Incorrect datetime value for column '%.*s' at row %ld"
+#define OB_ERR_INVALID_DATE_MSG_FMT_V2__OBE_USER_ERROR_MSG "OBE-01861: Incorrect datetime value for column '%.*s' at row %ld"
 
 extern int g_all_ob_errnos[2440];
 
@@ -9350,11 +9350,6 @@ extern int g_all_ob_errnos[2440];
   const char *ob_sqlstate(const int oberr);
   const char *ob_strerror(const int oberr);
   const char *ob_str_user_error(const int oberr);
-
-  int ob_oracle_errno(const int oberr);
-  int ob_oracle_errno_with_check(const int oberr);
-  const char *ob_oracle_strerror(const int oberr);
-  const char *ob_oracle_str_user_error(const int oberr);
 
 #ifndef __ERROR_CODE_PARSER_
   int get_ob_errno_from_oracle_errno(const int error_no, const char *error_msg, int &ob_errno);

--- a/src/sql/engine/dml/ob_err_log_service.cpp
+++ b/src/sql/engine/dml/ob_err_log_service.cpp
@@ -50,10 +50,10 @@ int ObErrLogService::gen_insert_sql_str(ObIAllocator &alloc,
   int64_t default_column_name_pos = 0;
   int64_t default_column_value_pos = 0;
 
-  const int err_no = ob_oracle_errno(first_err_ret);
+  const int err_no = ob_mysql_errno_with_check(first_err_ret);
   // ObString msg = ob_get_tsi_err_msg(first_err_ret);
   // Because there are escape characters in dynamic_msg, use static error messages now
-  ObString msg = ObString::make_string(ob_oracle_strerror(first_err_ret));
+  ObString msg = ObString::make_string(ob_strerror(first_err_ret));
 
   // %.*s 1:database_name
   // %.*s 2:table_name

--- a/src/sql/resolver/ddl/ob_create_view_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_create_view_resolver.cpp
@@ -436,7 +436,7 @@ int ObCreateViewResolver::try_add_error_info(const uint64_t error_number,
   if (ERROR_STATUS_HAS_ERROR == error_info.get_error_status()) {
     /* do nothing */
   } else {
-    ObString err_txt(common::ob_oracle_strerror(error_number));
+    ObString err_txt(common::ob_strerror(error_number));
     error_info.set_error_number(error_number);
     error_info.set_error_status(ERROR_STATUS_HAS_ERROR);
     if (err_txt.empty()) {


### PR DESCRIPTION
## Summary
- remove ob_oracle_* errno helpers from generator and generated files
- switch call sites to MySQL errno and strerror helpers
- make ob_errpkt_* always use MySQL error mapping

## Testing
- not run (not requested)

Refs #116