### PR TITLE
Improve embed error messages

### DIFF
--- a/src/observer/embed/python/ob_embed_impl.cpp
+++ b/src/observer/embed/python/ob_embed_impl.cpp
@@ -300,8 +300,14 @@ ObString format_embed_error(int ret)
 {
   static thread_local char err_buf[1024];
   int64_t pos = 0;
-  ObString errmsg = handle_err_msg(ret);
-  const int err_no = ob_errpkt_errno(ret, false);
+  const int err_no = ob_mysql_errno_with_check(ret);
+  const char *user_msg = ob_str_user_error(ret);
+  if (nullptr == user_msg || '\0' == user_msg[0]) {
+    user_msg = ob_errpkt_str_user_error(ret, false);
+  }
+  ObString errmsg = (nullptr != user_msg && user_msg[0] != '\0')
+      ? ObString(strlen(user_msg), user_msg)
+      : ObString();
   const char *err_name = ob_error_name(ret);
   if (nullptr == err_name || '\0' == err_name[0]) {
     err_name = "UnknownError";


### PR DESCRIPTION
## Summary
- prefer user-facing messages from warning buffer and ob_errpkt_str_user_error in embed errors
- include error name and errno in embed exceptions for clarity
- centralize formatting in embed error helper

## Testing
- not run (not requested)

Refs #8