### PR TITLE
fix:redundant-parameters in SERVER_STORAGE_META_SERVICE.init()

### DIFF
--- a/src/observer/ob_server.cpp
+++ b/src/observer/ob_server.cpp
@@ -427,7 +427,7 @@ int ObServer::init(const ObServerOptions &opts, const ObPLogWriterCfg &log_cfg)
       LOG_ERROR("init tenant manager failed", KR(ret));
     } else if (OB_FAIL(startup_accel_handler_.init(SERVER_ACCEL))) {
       LOG_ERROR("init server startup task handler failed", KR(ret));
-    } else if (OB_FAIL(SERVER_STORAGE_META_SERVICE.init(GCTX.is_shared_storage_mode()))) {
+    } else if (OB_FAIL(SERVER_STORAGE_META_SERVICE.init())) {
       LOG_ERROR("init server storage meta handler failed", KR(ret));
     } else if (OB_FAIL(common::occam::ObThreadHungDetector::get_instance().init())) {
       LOG_ERROR("init sObThreadHungDetector failed", KR(ret));


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

Currently, there is a compilation error:
<img width="1409" height="479" alt="image" src="https://github.com/user-attachments/assets/e741a731-1d82-4362-8dd1-72df5de268c3" />

This compilation error was introduced by PR #141 .
### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->
in `src/observer/ob_server.cpp` 
```
    } else if (OB_FAIL(SERVER_STORAGE_META_SERVICE.init(GCTX.is_shared_storage_mode()))) {
```

remove `GCTX.is_shared_storage_mode()`
### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->