### PR TITLE
fix:inconsistent indentation in '--help' output

### DIFF
--- a/src/observer/ob_command_line_parser.cpp
+++ b/src/observer/ob_command_line_parser.cpp
@@ -377,7 +377,7 @@ void ObCommandLineParser::print_help() const
   MPRINT("  --port, -P <port>               the port, default is 2881");
   MPRINT("  --use-ipv6, -6                  whether to use ipv6");
   MPRINT("  --base-dir <dir>                The base/work directory which seekdb process will run in(default: current directory). ");
-  MPRINT("                                      NOTE: You must specify this option if you will start seekdb at other directory.");
+  MPRINT("                                  NOTE: You must specify this option if you will start seekdb at other directory.");
   MPRINT("  --data-dir <dir>                The data directory which seekdb will store data in. Default is ${base-dir}/store in initialize mode.");
   MPRINT("  --redo-dir <dir>                The redo log directory which seekdb will store redo log in. Default is ${data-dir}/redo in initialize mode.");
   MPRINT("  --log-level <level>             The server log level. Can be one of [ERROR, WARN, INFO, EDIAG, WDIAG, TRACE, DEBUG]");


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description
close #12 
<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description
before:
<img width="1713" height="640" alt="31c956fcf7ff4e5b81eddc831fe155fc" src="https://github.com/user-attachments/assets/fb88dfb5-2b8e-4565-bbed-c1b0bc5b5955" />

after:
<img width="1799" height="594" alt="79dcf671b53700a735a159dcf4c29884" src="https://github.com/user-attachments/assets/393fc194-d382-4fdf-9a53-ff204f36637d" />

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
