### PR TITLE
docs: fix broken markdown link inside HTML p tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,9 +426,9 @@ Edge devices—from mobile to vehicle and industrial terminals—operate with co
     </a>
 </p>
 
-<p>
-Please refer to the <a href="docs/user-guide/README.md">User Guide</a> for more details.
-</p>
+<br/>
+
+Please refer to the [User Guide](https://www.oceanbase.ai/docs/seekdb-overview/) for more details.
 
 
 </div>

--- a/README_CN.md
+++ b/README_CN.md
@@ -382,9 +382,9 @@ seekdb 继承了 OceanBase 单机存储引擎、执行引擎、事务引擎、�
     </a>
 </p>
 
-<p>
-更多详情请参考[用户指南](docs/user-guide/README.md)。
-</p>
+<br/>
+
+更多详情请参考[用户指南](https://www.oceanbase.ai/docs/seekdb-overview/)。
 
 
 </div>


### PR DESCRIPTION
The Markdown link syntax inside an HTML <p> tag in the README won't render as a clickable link. This PR replaces it with a proper HTML anchor tag as suggested in issue #138.