### PR TITLE
fix: render User Guide link correctly inside HTML div block

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Edge devices—from mobile to vehicle and industrial terminals—operate with co
 
 <br/>
 
-Please refer to the [User Guide](https://www.oceanbase.ai/docs/seekdb-overview/) for more details.
+Please refer to the <a href="https://www.oceanbase.ai/docs/seekdb-overview/">User Guide</a> for more details.
 
 
 </div>


### PR DESCRIPTION
## Summary

Fixes #138 — The "User Guide" markdown link inside the `<div align="center">` block was not rendering as a clickable hyperlink because markdown syntax is not processed inside HTML block elements per the CommonMark specification.

## Changes

Converted the markdown link to an HTML `<a>` tag in the integrations section:

```diff
- Please refer to the [User Guide](https://www.oceanbase.ai/docs/seekdb-overview/) for more details.
+ Please refer to the <a href="https://www.oceanbase.ai/docs/seekdb-overview/">User Guide</a> for more details.
```

The other "User Guide" link (line 263, inside a `<details>` block after a code fence closing) already renders correctly since it's outside the HTML block context.