### PR TITLE
Switch from Android ndk26 to ndk27

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -194,7 +194,7 @@ function do_build
 
     ANDROID_CMAKE_ARGS=""
     if [[ $ANDROID_BUILD == true ]]; then
-      ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-$HOME/Library/Android/sdk/ndk/26.3.11579264}"
+      ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-$HOME/Library/Android/sdk/ndk/27.3.13750724}"
       if [ ! -d "$ANDROID_NDK_HOME" ]; then
         echo_err "ANDROID_NDK_HOME not found: $ANDROID_NDK_HOME"
         echo_err "Set ANDROID_NDK_HOME or install the NDK"

--- a/deps/oblib/src/CMakeLists.txt
+++ b/deps/oblib/src/CMakeLists.txt
@@ -63,7 +63,8 @@ if (OB_USE_CLANG)
     -Wno-unused-value -Wno-macro-redefined -Wno-reinterpret-base-class -Wno-register
     -Wno-implicit-fallthrough -Wno-deprecated-non-prototype
     -Wno-ambiguous-reversed-operator -Wno-invalid-partial-specialization
-    -Wno-string-concatenation)
+    -Wno-string-concatenation
+    -Wno-vla -Wno-vla-cxx-extension)
     
   target_compile_options(oblib_base_without_pass INTERFACE ${OBLIB_COMPILE_DEFINITIONS})
   if (ENABLE_SANITY)


### PR DESCRIPTION
- Update default NDK path to 27.3.13750724
- Add -Wno-vla -Wno-vla-cxx-extension to suppress VLA warnings promoted to errors by clang 18

<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
