### PR TITLE
fix #444: use unsigned bit fields in ObTableBackupFlag to prevent sign ove…

### DIFF
--- a/src/storage/blocksstable/ob_table_flag.h
+++ b/src/storage/blocksstable/ob_table_flag.h
@@ -83,9 +83,9 @@ public:
   union {
     int32_t flag_;
     struct {
-      ObTableHasBackupFlag::FLAG has_backup_flag_ : SF_BIT_HAS_BACKUP;
-      ObTableHasLocalFlag::FLAG has_local_flag_   : SF_BIT_HAS_LOCAL;
-      int64_t reserved_: SF_BIT_RESERVED;
+      uint32_t has_backup_flag_ : SF_BIT_HAS_BACKUP;
+      uint32_t has_local_flag_  : SF_BIT_HAS_LOCAL;
+      uint32_t reserved_: SF_BIT_RESERVED;
     };
   };
 };


### PR DESCRIPTION

The bit-field members has_backup_flag_, has_local_flag_, and reserved_ in ObTableBackupFlag were declared using signed types (ObTableHasBackupFlag::FLAG and int64_t). When stored in a 1-bit bit-field, signed types can only represent the values 0 and -1 (not 0 and 1), causing comparison logic like has_backup_flag_ == ObTableHasBackupFlag::HAS_BACKUP (which compares against 1) to always evaluate to false.

### Task Description

fixed #444 

### Solution Description


### Passed Regressions


### Upgrade Compatibility


### Other Information


### Release Note


