### PR TITLE
Fix/issue 530

### DIFF
--- a/src/rootserver/ob_alter_table_constraint_checker.cpp
+++ b/src/rootserver/ob_alter_table_constraint_checker.cpp
@@ -93,7 +93,7 @@ int ObAlterTableConstraintChecker::check_can_add_cst_on_multi_column(
       } else if (OB_UNLIKELY(1 != (*iter)->get_column_cnt())) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("unexpected column count of not null constraint", K(ret), KPC(*iter));
-      } else if (OB_INVALID_ID == *(*iter)->cst_col_begin()) {
+      } else if (OB_INVALID_ID != *(*iter)->cst_col_begin()) {
         can_add_cst_on_multi_column = false;
       }
     }

--- a/src/storage/blocksstable/ob_table_flag.h
+++ b/src/storage/blocksstable/ob_table_flag.h
@@ -83,9 +83,9 @@ public:
   union {
     int32_t flag_;
     struct {
-      ObTableHasBackupFlag::FLAG has_backup_flag_ : SF_BIT_HAS_BACKUP;
-      ObTableHasLocalFlag::FLAG has_local_flag_   : SF_BIT_HAS_LOCAL;
-      int64_t reserved_: SF_BIT_RESERVED;
+      uint32_t has_backup_flag_ : SF_BIT_HAS_BACKUP;
+      uint32_t has_local_flag_  : SF_BIT_HAS_LOCAL;
+      uint32_t reserved_: SF_BIT_RESERVED;
     };
   };
 };


### PR DESCRIPTION
fix: ALTER TABLE modifying multiple NOT NULL constraints in one statement does not error as expected

Change the condition in
ObAlterTableConstraintChecker::check_can_add_cst_on_multi_column()
from OB_INVALID_ID == *(*iter)->cst_col_begin() to
OB_INVALID_ID != *(*iter)->cst_col_begin().

OB_INVALID_ID means the NOT NULL constraint belongs to a newly added
column whose column id has not been assigned yet. Multi-column ADD
NOT NULL should only be allowed for that case. The old check treated
multi-column MODIFY ... NOT NULL on existing columns as a valid
multi-column ADD path, so ALTER TABLE succeeded instead of reporting
the expected not supported error.

ref: #530 