### PR TITLE
extend simple thread pool timeout to 1s

### DIFF
--- a/deps/oblib/src/lib/queue/ob_lighty_queue.cpp
+++ b/deps/oblib/src/lib/queue/ob_lighty_queue.cpp
@@ -64,6 +64,15 @@ int ObLightyQueue::init(const uint64_t capacity,
   return ret;
 }
 
+void ObLightyQueue::wake_all()
+{
+  if (NULL != cond_) {
+    for (uint64_t i = 0; i < n_cond_; i++) {
+      cond_[i].signal();
+    }
+  }
+}
+
 void ObLightyQueue::destroy()
 {
   if (NULL != data_) {

--- a/deps/oblib/src/lib/queue/ob_lighty_queue.h
+++ b/deps/oblib/src/lib/queue/ob_lighty_queue.h
@@ -62,6 +62,8 @@ public:
   bool is_inited() const { return NULL != data_; }
   int push(void* p);
   int pop(void*& p, int64_t timeout = 0);
+  // Broadcast to all per-seq conds so every worker currently blocked in pop()
+  void wake_all();
 private:
   static uint64_t calc_n_cond(uint64_t capacity)
   {

--- a/deps/oblib/src/lib/queue/ob_priority_queue.h
+++ b/deps/oblib/src/lib/queue/ob_priority_queue.h
@@ -121,6 +121,12 @@ public:
       ;
   }
 
+  // Broadcast to wake up every worker currently blocked in pop().
+  void wake_all()
+  {
+    (void)sem_.signal(INT32_MAX);
+  }
+
   QueueType* get_queue(const int i)
   {
     return &queue_[i];

--- a/deps/oblib/src/lib/thread/ob_dynamic_thread_pool.cpp
+++ b/deps/oblib/src/lib/thread/ob_dynamic_thread_pool.cpp
@@ -375,6 +375,8 @@ void ObSimpleDynamicThreadPool::stop()
 {
   IGNORE_RETURN ObSimpleThreadPoolDynamicMgr::get_instance().unbind(this);
   lib::ThreadPool::stop();
+  // Wake all workers blocked in queue pop so they can check the stop flag immediately
+  notify_stop();
 }
 
 void ObSimpleDynamicThreadPool::destroy()
@@ -390,6 +392,7 @@ void ObSimpleDynamicThreadPool::destroy()
     ob_usleep((useconds_t)10L * 1000L);
   }
   lib::ThreadPool::stop();
+  notify_stop();
   lib::ThreadPool::wait();
 }
 
@@ -450,8 +453,13 @@ int ObSimpleDynamicThreadPool::set_max_thread_count(int64_t max_thread_cnt)
 int ObSimpleDynamicThreadPool::set_thread_count_and_try_recycle(int64_t cnt)
 {
   int ret = OB_SUCCESS;
+  const int64_t old_thread_count = get_thread_count();
   ret = Threads::do_set_thread_count(cnt, true/*async_recycle*/);
   if (OB_SUCC(ret)) {
+    // When shrinking, wake up all workers to check stop flags
+    if (cnt < old_thread_count) {
+      notify_stop();
+    }
     ret = Threads::try_thread_recycle();
   }
   return ret;
@@ -467,6 +475,7 @@ void ObSimpleDynamicThreadPool::try_expand_thread_count()
   } else if ((queue_size = get_queue_num()) <= 0) {
     // unneed to expand thread count
   } else if (OB_SUCC(update_threads_lock_.trylock())) {
+    IGNORE_RETURN Threads::try_thread_recycle();
     int64_t cur_thread_count = get_thread_count();
     int inc_cnt = 0;
     if (cur_thread_count > 0) {

--- a/deps/oblib/src/lib/thread/ob_dynamic_thread_pool.h
+++ b/deps/oblib/src/lib/thread/ob_dynamic_thread_pool.h
@@ -117,6 +117,7 @@ public:
   int64_t get_running_thread_cnt() const { return running_thread_cnt_; }
   int set_thread_count(int64_t n_threads);
   int set_max_thread_count(int64_t max_thread_cnt);
+  virtual void notify_stop() {}
   void inc_ref() { ATOMIC_INC(&ref_cnt_); }
   void dec_ref() { ATOMIC_SAF(&ref_cnt_, 1); }
   int64_t get_ref_cnt() { return ATOMIC_LOAD(&ref_cnt_); }

--- a/deps/oblib/src/lib/thread/ob_simple_thread_pool.h
+++ b/deps/oblib/src/lib/thread/ob_simple_thread_pool.h
@@ -27,46 +27,6 @@ namespace oceanbase
 {
 namespace common
 {
-
-class ObAdaptiveStrategy
-{
-public:
-  ObAdaptiveStrategy()
-    : least_thread_num_(0),
-      estimate_ts_(0),
-      expand_rate_(0),
-      shrink_rate_(0) {}
-  ObAdaptiveStrategy(const int64_t least_thread_num,
-                     const int64_t estimate_ts,
-                     const int64_t expand_rate,
-                     const int64_t shrink_rate)
-    : least_thread_num_(least_thread_num),
-      estimate_ts_(estimate_ts),
-      expand_rate_(expand_rate),
-      shrink_rate_(shrink_rate) {}
-  ~ObAdaptiveStrategy() {}
-public:
-  int64_t get_least_thread_num() const { return least_thread_num_; }
-  int64_t get_estimate_ts() const { return estimate_ts_; }
-  int64_t get_expand_rate() const { return expand_rate_; }
-  int64_t get_shrink_rate() const { return shrink_rate_; }
-  bool is_valid() const
-  {
-    return least_thread_num_ > 0 &&
-           estimate_ts_ > 0 &&
-           expand_rate_ > 0 &&
-           shrink_rate_ > 0 &&
-           expand_rate_ > shrink_rate_;
-  }
-public:
-  TO_STRING_KV(K_(least_thread_num), K_(estimate_ts), K_(expand_rate), K_(shrink_rate));
-private:
-  int64_t least_thread_num_;
-  int64_t estimate_ts_;
-  int64_t expand_rate_;
-  int64_t shrink_rate_;
-};
-
 template <class T = ObLightyQueue>
 struct QueueTypeMap {
   using TaskType = void;
@@ -85,7 +45,7 @@ class ObSimpleThreadPoolBase
 {
   using TaskType = typename QueueTypeMap<T>::TaskType;
   using QElemType = typename QueueTypeMap<T>::QElemType;
-  static const int64_t QUEUE_WAIT_TIME = 100 * 1000;
+  static const int64_t QUEUE_WAIT_TIME = 1000 * 1000;
 public:
   ObSimpleThreadPoolBase();
   virtual ~ObSimpleThreadPoolBase();
@@ -97,7 +57,10 @@ public:
   {
     return queue_.size();
   }
-  int set_adaptive_strategy(const ObAdaptiveStrategy &strategy);
+  virtual void notify_stop() override
+  {
+    queue_.wake_all();
+  }
 private:
   virtual void handle(TaskType *task) = 0;
   virtual void handle_drop(TaskType *task) {
@@ -112,10 +75,6 @@ private:
   const char* name_;
   bool is_inited_;
   T queue_;
-  int64_t total_thread_num_;
-  int64_t active_thread_num_;
-  ObAdaptiveStrategy adaptive_strategy_;
-  int64_t last_adjust_ts_;
 };
 
 using ObSimpleThreadPool = ObSimpleThreadPoolBase<ObLightyQueue>;


### PR DESCRIPTION
### Task Description
## Task Description

#### simple thread pool pop 超时时间调整为 1s
ObSimpleThreadPool/ObLinkQueueThreadPool pop 任务的超时时间调整为 1s

直接调整 pop 接口的入参后发现存在 mysqltest 执行时间变慢的问题，以 mysql_function_index_sqlqa.func_index_sysfun_ok3_mysql 为例，执行时间由 123.03s 增加至 165.64s，经过定位发现为 DiskCB 线程导致，在线程缩容时，会先设置 stop 标识位，如果线程阻塞在 pop 上需要等待 timeout 才能退出。在设置 stop 标识位后，新增唤醒逻辑，立即唤醒阻塞的线程，加快线程退出可。

#### simple thread pool  max_thread_num = 1，min_thread_num = 0 线程缩容后无法再扩容
当最小线程数设置为 0，最大线程数设置为 1 时，线程池完成一次缩容后，无法再扩容。原因是，线程的回收是异步的，当线程空闲触发缩容时会先设置 stop 标志，设置后立马进行一次回收 (wait/destroy) 等，但此时工作线程可能还阻塞在 pop 上，无法回收，此后即使该工作线程已经退出，也没有位置可以再次触发线程回收，后台看到的线程数始终为 1。

## Solution Description
## Passed Regressions
## Upgrade Compatibility

### Solution Description

### Passed Regressions

### Upgrade Compatibility

### Other Information

### Release Note