### PR TITLE
Support get_cpu_time on windows and fix hung and core when drop column

### DIFF
--- a/deps/oblib/src/lib/container/ob_bitmap.h
+++ b/deps/oblib/src/lib/container/ob_bitmap.h
@@ -29,7 +29,9 @@ OB_INLINE int64_t popcount64(uint64_t v)
 {
   int64_t cnt = 0;
 #if __POPCNT__
-  cnt = __builtin_popcountl(v);
+  // v is uint64_t; use popcountll because `unsigned long` is 32-bit on
+  // Windows LLP64 and popcountl would drop the high 32 bits.
+  cnt = __builtin_popcountll(v);
 #else
   if (0 != v) {
     v = v - ((v >> 1) & 0x5555555555555555UL);

--- a/deps/oblib/src/lib/container/ob_concurrent_bitset.h
+++ b/deps/oblib/src/lib/container/ob_concurrent_bitset.h
@@ -203,7 +203,10 @@ int ObConcurrentBitset<SIZE, IS_USE_LOCK>::find_and_set_first_zero_without_lock(
                && !is_succ) {
           uint64_t start_pos_in_word = i == 0 ? start_pos % PER_WORD_BIT_NUM : 0;
           found_word = cur_word | ((1ULL << start_pos_in_word) - 1);//set [lowest_bit, start_pos_in_word) = 1
-          first_zero_idx = __builtin_ctzl(~found_word);
+          // found_word is uint64_t; __builtin_ctzl on Windows LLP64 would
+          // only look at the low 32 bits and return wrong indices for bits
+          // in the upper half of the word. Use __builtin_ctzll instead.
+          first_zero_idx = __builtin_ctzll(~found_word);
           uint64_t new_word = cur_word | (1ULL << first_zero_idx);
           is_succ = ATOMIC_BCAS(&word_array_[valid_idx], cur_word ,new_word);
         }
@@ -242,7 +245,8 @@ int ObConcurrentBitset<SIZE, IS_USE_LOCK>::find_and_set_first_zero_with_lock(uin
         uint64_t start_pos_in_word = i == 0 ? start_pos_ % PER_WORD_BIT_NUM : 0;
         found_word = word_array_[valid_idx] | ((1ULL << start_pos_in_word) - 1);//set [lowest_bit, start_pos_in_word) = 1
         if ((found_word & FULL_WORD_VALUE) != FULL_WORD_VALUE) {//if start_pos_in_word is highest bit and equal to 1, stop judgement.
-          first_zero_idx = __builtin_ctzl(~found_word);
+          // see above: use ctzll for uint64_t on Windows LLP64 correctness.
+          first_zero_idx = __builtin_ctzll(~found_word);
           word_array_[valid_idx] |= (1ULL << first_zero_idx);
           is_found = true;
         }

--- a/deps/oblib/src/lib/container/ob_id_map.h
+++ b/deps/oblib/src/lib/container/ob_id_map.h
@@ -91,7 +91,9 @@ inline int calc_clz(const uint32_t s)
 inline int calc_clz(const uint64_t s)
 {
   OB_ASSERT(0ULL != s);
-  return __builtin_clzl(s);
+  // __builtin_clzl takes `unsigned long` which is 32-bit on Windows LLP64.
+  // For a uint64_t we must use __builtin_clzll to avoid truncation.
+  return __builtin_clzll(s);
 }
 
 template<typename T, typename ID_TYPE, int64_t TSI_HOLD_NUM>

--- a/deps/oblib/src/lib/lock/cond.cpp
+++ b/deps/oblib/src/lib/lock/cond.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "lib/lock/cond.h"
+#include "lib/ob_abort.h"
 
 using namespace oceanbase::common;
 
@@ -26,6 +27,14 @@ Cond::Cond()
     int rt = pthread_condattr_init(&_attr);
     if (0 != rt) {
       _OB_LOG_RET(WARN, OB_ERR_SYS, "Failed to init cond attr, err=%d", rt);
+#ifdef _WIN32
+      // On Windows (pthreads4w), pthread_cond_t is an opaque pointer. If init
+      // fails (e.g. kernel object exhaustion, errno=ENOSPC=28), subsequent
+      // signal/broadcast/wait on the uninitialized _cond dereferences a NULL
+      // internal pointer inside pthreadVC3.dll and causes a native crash.
+      // Fast-fail here to produce a clear failure instead of a follow-up AV.
+      ob_abort();
+#endif
     }
     // Set the attribute to use CLOCK_MONOTONIC clock source
     // Note: pthread_condattr_setclock is Linux-specific, not available on macOS
@@ -43,6 +52,9 @@ Cond::Cond()
     rt = pthread_cond_init(&_cond, &_attr);
     if (0 != rt) {
       _OB_LOG_RET(WARN, OB_ERR_SYS, "Failed to init cond, err=%d", rt);
+#ifdef _WIN32
+      ob_abort();
+#endif
     }
 }
 

--- a/deps/oblib/src/lib/lock/mutex.cpp
+++ b/deps/oblib/src/lib/lock/mutex.cpp
@@ -1,12 +1,25 @@
 #include "lib/lock/mutex.h"
 #include "lib/oblog/ob_log.h"
+#include "lib/ob_abort.h"
 using namespace oceanbase::common;
 namespace obutil
 {
 ObUtilMutex::ObUtilMutex()
 {
   const int rt = pthread_mutex_init(&_mutex, NULL);
-#ifdef _NO_EXCEPTION
+#ifdef _WIN32
+  // On Windows (pthreads4w), pthread_mutex_t is an opaque pointer and init
+  // may fail with ENOSPC (errno=28) when the kernel object (CreateEvent)
+  // limit is reached. Leaving _mutex uninitialized and continuing would
+  // cause later lock/unlock to dereference NULL inside pthreadVC3.dll and
+  // produce an unrecoverable AccessViolation. Fast-fail instead so the
+  // failure is visible and does not cascade into thread-specific native
+  // crashes that corrupt the whole process.
+  if (rt != 0) {
+    _OB_LOG_RET(ERROR, OB_ERR_SYS, "%s. rt:%d", "ThreadSyscallException", rt);
+    ob_abort();
+  }
+#elif defined(_NO_EXCEPTION)
   if ( rt != 0 ) {
     _OB_LOG_RET(ERROR,OB_ERR_SYS, "%s. rt:%d", "ThreadSyscallException", rt);
   }

--- a/deps/oblib/src/lib/thread_local/ob_tsi_utils.cpp
+++ b/deps/oblib/src/lib/thread_local/ob_tsi_utils.cpp
@@ -136,7 +136,9 @@ int64_t detect_max_itid()
   for (int i = 1023; i >= 0; i--) {
     uint64_t slot = ATOMIC_LOAD(&itid_slots[i]);
     if (slot != 0) {
-      int pos = __builtin_clzl(slot);
+      // Use __builtin_clzll: slot is uint64_t, and `unsigned long` is only
+      // 32-bit on Windows LLP64 which would make __builtin_clzl truncate.
+      int pos = __builtin_clzll(slot);
       idx = 64 * i + (64 - pos - 1);
       break;
     }

--- a/deps/oblib/src/lib/utility/ob_bits_utils.h
+++ b/deps/oblib/src/lib/utility/ob_bits_utils.h
@@ -61,7 +61,9 @@ OB_INLINE uint64_t ob_popcount64(uint64_t v)
 {
   int64_t cnt = 0;
 #if __POPCNT__
-  cnt = __builtin_popcountl(v);
+  // v is uint64_t; __builtin_popcountl takes `unsigned long` which is only
+  // 32-bit on Windows LLP64. Use __builtin_popcountll to count all 64 bits.
+  cnt = __builtin_popcountll(v);
 #else
   if (0 != v) {
     v -= ((v >> 1) & 0x5555555555555555UL);

--- a/src/observer/omt/ob_tenant.cpp
+++ b/src/observer/omt/ob_tenant.cpp
@@ -17,6 +17,12 @@
 #define USING_LOG_PREFIX SERVER_OMT
 #include "ob_tenant.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/resource.h>
+#endif
+
 #include "share/resource_manager/ob_resource_manager.h"
 #include "sql/engine/px/ob_px_target_mgr.h"
 #include "sql/dtl/ob_dtl_fc_server.h"
@@ -714,8 +720,7 @@ ObTenant::ObTenant(const int64_t id,
       ctx_(nullptr),
       st_metrics_(),
       sql_limiter_(),
-      worker_us_(0),
-      cpu_time_us_(0)
+      worker_us_(0)
 {
   token_usage_check_ts_ = ObTimeUtility::current_time();
 }
@@ -1767,11 +1772,6 @@ void ObTenant::check_worker_count()
     }
     IGNORE_RETURN workers_lock_.unlock();
   }
-
-  if (GCONF._enable_new_sql_nio && GCONF._enable_tenant_sql_net_thread &&
-      (is_sys_tenant(id_) || is_user_tenant(id_))) {
-    GCTX.net_frame_->reload_tenant_sql_thread_config(id_);
-  }
 }
 
 void ObTenant::check_group_worker_count()
@@ -1936,22 +1936,30 @@ void ObTenant::update_token_usage()
     token_usage_ = std::max(.0, 1.0 * (total_us - idle_us) / total_us);
     IGNORE_RETURN ATOMIC_FAA(&worker_us_, total_us - idle_us);
   }
+}
 
-  if (OB_NOT_NULL(GCTX.cgroup_ctrl_) && GCTX.cgroup_ctrl_->is_valid()) {
-    //do nothing
-  } else if (duration >= 1000 * 1000 && OB_SUCC(thread_list_lock_.trylock())) {  // every second
-    int64_t cpu_time_inc = 0;
-    DLIST_FOREACH_REMOVESAFE(thread_list_node_, thread_list_)
-    {
-      Thread *thread = thread_list_node_->get_data();
-      int64_t inc = 0;
-      if (OB_SUCC(thread->get_cpu_time_inc(inc))) {
-        cpu_time_inc += inc;
-      }
-    }
-    thread_list_lock_.unlock();
-    IGNORE_RETURN ATOMIC_FAA(&cpu_time_us_, cpu_time_inc);
+int64_t ObTenant::get_cpu_time() const
+{
+#ifdef _WIN32
+  FILETIME creation, exit, kernel, user;
+  if (!GetProcessTimes(GetCurrentProcess(), &creation, &exit, &kernel, &user)) {
+    return 0;
   }
+  auto filetime_to_us = [](const FILETIME &ft) -> int64_t {
+    ULARGE_INTEGER u;
+    u.LowPart = ft.dwLowDateTime;
+    u.HighPart = ft.dwHighDateTime;
+    return static_cast<int64_t>(u.QuadPart / 10); // 100ns -> us
+  };
+  return filetime_to_us(user) + filetime_to_us(kernel);
+#else
+  struct rusage usage;
+  if (getrusage(RUSAGE_SELF, &usage) != 0) {
+    return 0;
+  }
+  return (int64_t)usage.ru_utime.tv_sec * 1000000LL + usage.ru_utime.tv_usec
+       + (int64_t)usage.ru_stime.tv_sec * 1000000LL + usage.ru_stime.tv_usec;
+#endif
 }
 
 void ObTenant::periodically_check()

--- a/src/sql/engine/aggregate/ob_exec_hash_struct.h
+++ b/src/sql/engine/aggregate/ob_exec_hash_struct.h
@@ -452,7 +452,9 @@ public:
       if (OB_FAIL(bits_.reserve(cnt_))) {
         SQL_ENG_LOG(WARN, "bit set reserve failed", K(ret));
       } else {
-        h2_shift_ = sizeof(cnt_) * CHAR_BIT - __builtin_clzl(cnt_);
+        // cnt_ is int64_t; __builtin_clzl takes `unsigned long` which is
+        // 32-bit on Windows LLP64 and would truncate. Use __builtin_clzll.
+        h2_shift_ = sizeof(cnt_) * CHAR_BIT - __builtin_clzll(cnt_);
       }
     }
     return ret;

--- a/src/sql/engine/aggregate/ob_exec_hash_struct_vec.h
+++ b/src/sql/engine/aggregate/ob_exec_hash_struct_vec.h
@@ -1289,7 +1289,9 @@ public:
       if (OB_FAIL(bits_.reserve(cnt_))) {
         SQL_ENG_LOG(WARN, "bit set reserve failed", K(ret));
       } else {
-        h2_shift_ = sizeof(cnt_) * CHAR_BIT - __builtin_clzl(cnt_);
+        // see note in ob_exec_hash_struct.h: use clzll for 64-bit cnt_
+        // because Windows LLP64 has 32-bit `unsigned long`.
+        h2_shift_ = sizeof(cnt_) * CHAR_BIT - __builtin_clzll(cnt_);
       }
     }
     return ret;

--- a/src/sql/engine/expr/vector_cast/cast_to_float.ipp
+++ b/src/sql/engine/expr/vector_cast/cast_to_float.ipp
@@ -62,7 +62,9 @@ static void InitDecintInfo(const wide::ObWideInteger<Bits, Signed> &val, ObScale
   while (num.items_[cnt] == 0 && cnt > 0) {
     cnt--;
   }
-  binary_digits_cnt = (64 - __builtin_clzl(num.items_[cnt])) + cnt * 64;
+  // items_ are uint64_t; must use __builtin_clzll because `unsigned long`
+  // is 32-bit on Windows LLP64 and would silently truncate the argument.
+  binary_digits_cnt = (64 - __builtin_clzll(num.items_[cnt])) + cnt * 64;
   scale_factor = MAX(0, static_cast<int64_t>(binary_digits_cnt * LOG10_2- EPSILON) - 18);
   decint_info.exponent += scale_factor;
   while (scale_factor > 0) {

--- a/src/sql/engine/expr/vector_cast/float_to_decimal_impl.cpp
+++ b/src/sql/engine/expr/vector_cast/float_to_decimal_impl.cpp
@@ -90,7 +90,9 @@ int ObFloatToDecimal::float2decimal(double x, const bool is_oracle_mode, ob_gcvt
       binary_cnt = DOUBlE_MANTISSA_BITS;
       real_exponent = exponent - DOUBLE_EXPONENT_BIAS - DOUBlE_MANTISSA_BITS;
     } else { //subnormal double case
-      binary_cnt = mantissa ? 64 - __builtin_clzl(mantissa) : 0;
+      // mantissa is uint64_t; use __builtin_clzll because `unsigned long`
+      // is 32-bit on Windows LLP64 and would truncate the value.
+      binary_cnt = mantissa ? 64 - __builtin_clzll(mantissa) : 0;
       real_exponent = 1 - DOUBLE_EXPONENT_BIAS - DOUBlE_MANTISSA_BITS;
     }
     /* Get the decimal_cnt with binary_cnt and real_exponent,

--- a/src/sql/engine/ob_bit_vector.h
+++ b/src/sql/engine/ob_bit_vector.h
@@ -445,7 +445,9 @@ OB_INLINE int64_t ObBitVectorImpl<WordType>::popcount64(uint64_t v)
 {
   int64_t cnt = 0;
 #if __POPCNT__
-  cnt = __builtin_popcountl(v);
+  // v is uint64_t; use popcountll because on Windows LLP64 `unsigned long`
+  // is 32-bit and __builtin_popcountl would drop the high 32 bits.
+  cnt = __builtin_popcountll(v);
 #else
   if (0 != v) {
     v = v - ((v >> 1) & 0x5555555555555555UL);

--- a/src/storage/blocksstable/cs_encoding/ob_cs_encoding_util.cpp
+++ b/src/storage/blocksstable/cs_encoding/ob_cs_encoding_util.cpp
@@ -35,7 +35,11 @@ int64_t ObCSEncodingUtil::get_bit_size(const uint64_t v)
 {
   int64_t bit_size = 1;
   if (v > 0) {
-    bit_size = sizeof(v) * CHAR_BIT - __builtin_clzl(v);
+    // NOTE: must use __builtin_clzll (not __builtin_clzl) for a uint64_t
+    // argument. On Windows LLP64 `unsigned long` is 32-bit, so clzl silently
+    // truncates the value and under-counts the required bit width, which can
+    // cause bit_packing encoders to lose bits and corrupt stored data.
+    bit_size = sizeof(v) * CHAR_BIT - __builtin_clzll(v);
   }
   return bit_size;
 }

--- a/src/storage/blocksstable/encoding/ob_encoding_bitset.h
+++ b/src/storage/blocksstable/encoding/ob_encoding_bitset.h
@@ -125,7 +125,11 @@ private:
     } else {
       int64_t wc_before = which_word(pos);
       for (int64_t i = 0; i < wc_before; ++i) {
-        ret += __builtin_popcountl(words_[i]);
+        // each word is uint64_t; __builtin_popcountl takes `unsigned long`
+        // which is 32-bit on Windows LLP64 and would undercount bits in
+        // the upper 32 bits. Use __builtin_popcountll for a full 64-bit
+        // count that is correct on both LP64 and LLP64.
+        ret += __builtin_popcountll(words_[i]);
       }
       ret += popcnt64(words_[wc_before], pos - wc_before * BITS_PER_WORD);
     }
@@ -140,7 +144,8 @@ private:
     } else {
       int64_t wc_before = which_word(pos);
       for (int64_t i = 0; i < wc_before; ++i) {
-        ret += __builtin_popcountl(words[i]);
+        // see note above: use 64-bit builtin to stay correct on Windows.
+        ret += __builtin_popcountll(words[i]);
       }
       ret += popcnt64(words[wc_before], pos - wc_before * BITS_PER_WORD);
     }
@@ -149,7 +154,10 @@ private:
 
   inline static int64_t popcnt64(const uint64_t word, const int64_t pos)
   {
-    return (0 == pos) ? 0 : __builtin_popcountl(word << (BITS_PER_WORD - pos));
+    // word is uint64_t. Must use the 64-bit variant __builtin_popcountll;
+    // on Windows LLP64 `unsigned long` is 32-bit and popcountl would
+    // silently drop the upper half of the word.
+    return (0 == pos) ? 0 : __builtin_popcountll(word << (BITS_PER_WORD - pos));
   }
 
 private:

--- a/src/storage/blocksstable/encoding/ob_encoding_util.cpp
+++ b/src/storage/blocksstable/encoding/ob_encoding_util.cpp
@@ -47,7 +47,14 @@ int64_t get_packing_size(bool &bit_packing, const uint64_t v, bool enable_bit_pa
       // at least one bit
       bit_size = 1;
     } else {
-      bit_size = sizeof(v) * CHAR_BIT - __builtin_clzl(v);
+      // NOTE: `v` is uint64_t (64-bit). Must use __builtin_clzll, because
+      // on Windows (LLP64, clang-cl) `unsigned long` is 32-bit and
+      // __builtin_clzl silently truncates `v` to 32 bits, producing a
+      // wrong bit_size for values whose high 32 bits are non-zero.
+      // This causes bit_packing to lose bits and corrupt data (e.g. the
+      // DOUBLE column during DDL complement, which was the trigger for
+      // OB_ERR_COMPRESS_DECOMPRESS_DATA -4257 seen on Windows).
+      bit_size = sizeof(v) * CHAR_BIT - __builtin_clzll(v);
     }
     size = bit_size / CHAR_BIT;
     int64_t ext = bit_size % CHAR_BIT;
@@ -80,7 +87,9 @@ int64_t get_int_size(const uint64_t v)
 {
   int64_t bit_size = 1;
   if (v > 0) {
-    bit_size = sizeof(v) * CHAR_BIT - __builtin_clzl(v);
+    // see note in get_packing_size: must be __builtin_clzll for uint64_t
+    // because `unsigned long` is 32-bit on Windows LLP64.
+    bit_size = sizeof(v) * CHAR_BIT - __builtin_clzll(v);
   }
   return (bit_size + CHAR_BIT - 1) / CHAR_BIT;
 }

--- a/src/storage/memtable/ob_nop_bitmap.h
+++ b/src/storage/memtable/ob_nop_bitmap.h
@@ -84,17 +84,21 @@ public:
     const int64_t block_cnt = size_ >> shift_bits;
     int64_t start_block = rowkey_cnt_ >> shift_bits;
     int64_t offset = rowkey_cnt_ & mask;
-    bitmap_[start_block] &= ~0LU << offset;
+    // NOTE: bitmap_ is 64-bit. On Windows LLP64 `unsigned long` is 32-bit,
+    // so `~0LU`, `1LU << pos` and `__builtin_ctzl` would all operate on
+    // only the low 32 bits and corrupt bits in the upper half. Use the
+    // 64-bit variants (`~0ULL`, `1ULL`, `__builtin_ctzll`).
+    bitmap_[start_block] &= ~0ULL << offset;
     int64_t left = (64 - (cnt_ & mask)) & mask;
-    bitmap_[block_cnt - 1] &= ~0LU >> left;
+    bitmap_[block_cnt - 1] &= ~0ULL >> left;
     for (int64_t i = start_block; i < block_cnt; ++i) {
       uint64_t tmp = bitmap_[i];
       const int64_t base = i << shift_bits;
       int pos = 0;
       while (0 != tmp) {
-        pos = __builtin_ctzl(tmp);
+        pos = __builtin_ctzll(tmp);
         obj_ptr[pos + base].set_nop_value();
-        tmp ^= (1LU << pos);
+        tmp ^= (1ULL << pos);
       }
     }
     return common::OB_SUCCESS;
@@ -105,17 +109,17 @@ public:
     const int64_t block_cnt = size_ >> shift_bits;
     int64_t start_block = rowkey_cnt_ >> shift_bits;
     int64_t offset = rowkey_cnt_ & mask;
-    bitmap_[start_block] &= ~0LU << offset;
+    bitmap_[start_block] &= ~0ULL << offset;
     int64_t left = (64 - (cnt_ & mask)) & mask;
-    bitmap_[block_cnt - 1] &= ~0LU >> left;
+    bitmap_[block_cnt - 1] &= ~0ULL >> left;
     for (int64_t i = start_block; i < block_cnt; ++i) {
       uint64_t tmp = bitmap_[i];
       const int64_t base = i << shift_bits;
       int pos = 0;
       while (0 != tmp) {
-        pos = __builtin_ctzl(tmp);
+        pos = __builtin_ctzll(tmp);
         datum_ptr[pos + base].set_nop();
-        tmp ^= (1LU << pos);
+        tmp ^= (1ULL << pos);
       }
     }
     return common::OB_SUCCESS;


### PR DESCRIPTION
### Task Description
The seekdb process hung and then cored when dropping a column.

### Solution Description
1. Added `get_cpu_time`.
2. Fixed an issue where Windows LLP64 truncation in clz/ctz/popcount builtins was causing DDL data corruption.

### Passed Regressions
Core test.

### Upgrade Compatibility
No specific compatibility concerns mentioned.

### Other Information

### Release Note
Fixed a data corruption issue on Windows (LLP64) that could occur during DDL operations like dropping a column, which previously caused the database process to hang and crash.