### PR TITLE
[CP] [CP] [vector index] fix load follower memory

### DIFF
--- a/src/share/vector_index/ob_plugin_vector_index_service.cpp
+++ b/src/share/vector_index/ob_plugin_vector_index_service.cpp
@@ -542,7 +542,7 @@ int ObPluginVectorIndexMgr::get_adapter_inst_by_ctx(ObVectorIndexAcquireCtx &ctx
                                                       vec_index_param,
                                                       dim,
                                                       allocator))) {
-      LOG_WARN("failed to get vector index adapter", K(ctx.embedded_tablet_id_), KR(ret));
+      LOG_WARN("failed to get vector index adapter", K(ctx.embedded_tablet_id_), KR(ret));    
     } else if (FALSE_IT(adapter = candidate.embedded_adatper_guard_.get_adatper())) {
     } else if (adapter->get_create_type() == CreateTypeFullPartial
                || adapter->get_create_type() == CreateTypeComplete) {
@@ -1041,7 +1041,6 @@ void ObPluginVectorIndexService::destroy()
       DESTROY_CONTEXT(memory_context_);
       memory_context_ = nullptr;
     }
-    alloc_.reset();
 
     // destroy vec async task
     if (OB_NOT_NULL(tenant_vec_async_task_sched_)) {
@@ -1081,8 +1080,7 @@ int ObPluginVectorIndexService::init(const uint64_t tenant_id,
                                               "VecIdxLSMgr",
                                               tenant_id))) {
     LOG_WARN("create ls mgr ", KR(ret), K(tenant_id));
-  } else if (FALSE_IT(alloc_.set_tenant_id(tenant_id))) {
-  } else if (OB_FAIL(allocator_.init(&alloc_, OB_MALLOC_MIDDLE_BLOCK_SIZE, mem_attr))) {
+  } else if (OB_FAIL(allocator_.init(nullptr, OB_MALLOC_MIDDLE_BLOCK_SIZE, mem_attr))) {
     LOG_WARN("ObTenantSrs allocator init failed.", K(ret));
   } else {
     ObSharedMemAllocMgr *shared_mem_mgr = MTL(ObSharedMemAllocMgr*);

--- a/src/share/vector_index/ob_plugin_vector_index_service.h
+++ b/src/share/vector_index/ob_plugin_vector_index_service.h
@@ -96,13 +96,13 @@ public:
 struct ObAdapterMapKeyValue
 {
 public:
-  ObAdapterMapKeyValue(ObTabletID tablet_id, ObPluginVectorIndexAdaptor *adapter)
-      : tablet_id_(tablet_id),
-        adapter_(adapter)
+  ObAdapterMapKeyValue(ObTabletID tablet_id, ObPluginVectorIndexAdaptor *adapter) 
+      : tablet_id_(tablet_id), 
+        adapter_(adapter) 
   {}
-  ObAdapterMapKeyValue()
-      : tablet_id_(),
-        adapter_(nullptr)
+  ObAdapterMapKeyValue() 
+      : tablet_id_(), 
+        adapter_(nullptr) 
   {}
   TO_STRING_KV(K_(tablet_id), K_(adapter));
 
@@ -483,7 +483,6 @@ private:
   storage::ObLSService *ls_service_;
   common::ObMySQLProxy *sql_proxy_;
   ObFIFOAllocator allocator_;
-  common::ObArenaAllocator alloc_;
   // do not use this memory context directly
   // use wrapped memory context in ob_tenant_vector_allocator.h and init by this memory context
   lib::MemoryContext memory_context_;


### PR DESCRIPTION
### Task Description
## Issue Description
fix memory load on ls follower

### Solution Description
use ObMalloc instead of ArenaAllocator of FIFOAllocator。
the FIFOAllocator used inside seekdb is still backed by ArenaAllocator. As a result, memory is not actually released on free; it is only truly freed when the tenant is dropped and a reset is performed. In other branches (e.g., 435/master/44x), FIFOAllocator has already been changed to allocate memory via the default ObMalloc, so memory is released on free instead of continuously accumulating until the tenant is deleted.
## Passed Regressions
## Workaround
## Upgrade Compatibility

### Passed Regressions

### Upgrade Compatibility

### Other Information
cherry-pick from merge point [e57de1789de616dc383c857878c46214233668d5]() in branch 4_3_5_release by ob flow
the prev code review : [259195]()
**Warning: This review got code conflicts when auto cherry-picking, please make sure the diff is effective**
- 
cherry-pick from merge point [23a53883176c9fd974e9b4f76b93f5ce7921abf7]() in project oceanbase by ob flow
the prev code review : [259207]()
**Warning: This review got code conflicts when auto cherry-picking, please make sure the diff is effective**
-

### Release Note