### PR TITLE
[CP] fix: resolve 4016 error in semantic index refresh due to empty model_name

### DIFF
--- a/src/share/vector_index/ob_hybrid_vector_refresh_task.cpp
+++ b/src/share/vector_index/ob_hybrid_vector_refresh_task.cpp
@@ -21,6 +21,7 @@
 #include "src/storage/ls/ob_ls.h"
 #include "src/storage/tx/ob_trans_service.h"
 #include "sql/das/ob_das_dml_vec_iter.h"
+#include "sql/engine/expr/ob_expr_ai/ob_ai_func_utils.h"
 
 namespace oceanbase
 {
@@ -220,7 +221,7 @@ int ObHybridVectorRefreshTask::do_work()
         exec_finish = true;
         break;
       }
-      default :
+      default : 
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("unexpected task status", K(ret), K(current_status()), KPC(get_task_ctx()));
         break;
@@ -435,9 +436,9 @@ int ObHybridVectorRefreshTask::get_embedded_table_column_ids(ObPluginVectorIndex
   return ret;
 }
 
-int ObHybridVectorRefreshTask::init_dml_param(uint64_t table_id,
-    ObDMLBaseParam &dml_param,
-    share::schema::ObTableDMLParam &table_param,
+int ObHybridVectorRefreshTask::init_dml_param(uint64_t table_id, 
+    ObDMLBaseParam &dml_param, 
+    share::schema::ObTableDMLParam &table_param, 
     ObIArray<uint64_t> &dml_column_ids,
     transaction::ObTxDesc *tx_desc,
     oceanbase::transaction::ObTxReadSnapshot &snapshot,
@@ -486,6 +487,8 @@ int ObHybridVectorRefreshTask::init_dml_param(uint64_t table_id,
 int ObHybridVectorRefreshTask::init_endpoint(ObPluginVectorIndexAdaptor &adaptor)
 {
   int ret = OB_SUCCESS;
+  bool use_request_model_name = false;
+  ObAIFuncExprInfo *ai_func_info = nullptr;
   omt::ObTenantAiService *ai_service = MTL(omt::ObTenantAiService *);
   ObHybridVectorRefreshTaskCtx *task_ctx = static_cast<ObHybridVectorRefreshTaskCtx *>(get_task_ctx());
   if (OB_ISNULL(ai_service) || OB_ISNULL(task_ctx)) {
@@ -495,6 +498,16 @@ int ObHybridVectorRefreshTask::init_endpoint(ObPluginVectorIndexAdaptor &adaptor
     LOG_WARN("failed to get ai service guard", K(ret), KPC(task_ctx));
   } else if (OB_FAIL(task_ctx->ai_service_.get_ai_endpoint_by_ai_model_name(adaptor.get_endpoint(), task_ctx->endpoint_, false /*need_check*/))) {
     LOG_WARN("failed to get endpoint info", K(ret), K(adaptor));
+  } else if (OB_FALSE_IT(use_request_model_name = !task_ctx->endpoint_->get_request_model_name().empty())) {
+  } else if (use_request_model_name && OB_FAIL(ob_write_string(task_ctx->allocator_, task_ctx->endpoint_->get_request_model_name(), task_ctx->request_model_name_))) {
+    LOG_WARN("failed to copy request_model_name", K(ret));
+  } else if (!use_request_model_name && OB_FAIL(ObAIFuncUtils::get_ai_func_info(task_ctx->allocator_, adaptor.get_endpoint(), ai_func_info))) {
+    LOG_WARN("failed to get ai func info", K(ret), K(adaptor.get_endpoint()));
+  } else if (!use_request_model_name && OB_ISNULL(ai_func_info)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("ai func info is null", K(ret));
+  } else if (!use_request_model_name && OB_FAIL(ob_write_string(task_ctx->allocator_, ai_func_info->model_, task_ctx->request_model_name_))) {
+    LOG_WARN("failed to copy model_name from ai func info", K(ret));
   }
   return ret;
 }
@@ -544,7 +557,7 @@ int ObHybridVectorRefreshTask::prepare_for_embedding(ObPluginVectorIndexAdaptor 
     } else if (FALSE_IT(table_param = new(table_param)schema::ObTableParam(task_ctx->allocator_))) {
     } else if (FALSE_IT(ctx_->task_status_.target_scn_.convert_from_ts(ObTimeUtility::current_time()))) {
     } else if (OB_FAIL(ObPluginVectorIndexUtils::read_local_tablet(ls_id_,
-        &adaptor,
+        &adaptor, 
         ctx_->task_status_.target_scn_,
         INDEX_TYPE_VEC_DELTA_BUFFER_LOCAL,
         task_ctx->allocator_,
@@ -570,7 +583,7 @@ int ObHybridVectorRefreshTask::prepare_for_embedding(ObPluginVectorIndexAdaptor 
         task_ctx->batch_cnt_ = MAX(task_ctx->batch_cnt_ / 4, ObHybridVectorRefreshTaskCtx::MIN_BATCH_CNT);
       }
     }
-
+  
     int cur_row_count = 0;
     ObSEArray<ObString, 4> chunk_array;
     ObSEArray<ObString, 4> tmp_chunk_array;
@@ -663,7 +676,7 @@ int ObHybridVectorRefreshTask::prepare_for_embedding(ObPluginVectorIndexAdaptor 
             LOG_WARN("failed to get access key", K(ret));
           } else if (OB_FAIL(ob_write_string(task_ctx->allocator_, endpoint->get_url(), url, true))) {
             LOG_WARN("fail to write string", K(ret));
-          } else if (OB_FAIL(task_ctx->embedding_task_->init(url, endpoint->get_request_model_name(),
+          } else if (OB_FAIL(task_ctx->embedding_task_->init(url, task_ctx->request_model_name_,
                              endpoint->get_provider(), access_key, chunk_array, dim, http_timeout_us, http_max_retries))) {
             LOG_WARN("failed to init embedding task", K(ret), KPC(endpoint));
           } else {
@@ -703,10 +716,10 @@ int ObHybridVectorRefreshTask::check_embedding_finish(bool &finish)
 }
 
 int ObHybridVectorRefreshTask::do_refresh_only(
-    ObPluginVectorIndexAdaptor &adaptor,
-    transaction::ObTxDesc *tx_desc,
-    oceanbase::transaction::ObTxReadSnapshot &snapshot,
-    storage::ObStoreCtxGuard &store_ctx_guard,
+    ObPluginVectorIndexAdaptor &adaptor, 
+    transaction::ObTxDesc *tx_desc, 
+    oceanbase::transaction::ObTxReadSnapshot &snapshot, 
+    storage::ObStoreCtxGuard &store_ctx_guard, 
     storage::ObValueRowIterator &index_id_iter,
     storage::ObValueRowIterator &delta_delete_iter)
 {
@@ -734,7 +747,7 @@ int ObHybridVectorRefreshTask::do_refresh_only(
       LOG_WARN("failed to insert rows to index id table", K(ret), K(adaptor.get_vbitmap_table_id()));
     }
     store_ctx_guard.reset();
-
+  
     // delete from 3 table.
     affected_rows = 0;
     if (OB_FAIL(ret)) {
@@ -843,7 +856,7 @@ int ObHybridVectorRefreshTask::delete_embedded_table(ObPluginVectorIndexAdaptor 
       common::ObNewRowIterator *scan_iter = nullptr;
       ObStorageDatumUtils util;
       ObArenaAllocator scan_allocator("VecEmbedding", OB_MALLOC_NORMAL_BLOCK_SIZE, MTL_ID());
-      if (OB_FAIL(ObPluginVectorIndexUtils::read_local_tablet(ls_id_,
+      if (OB_FAIL(ObPluginVectorIndexUtils::read_local_tablet(ls_id_, 
           &adaptor,
           snapshot.version(),
           INDEX_TYPE_HYBRID_INDEX_EMBEDDED_LOCAL,
@@ -975,7 +988,7 @@ int ObHybridVectorRefreshTask::after_embedding(ObPluginVectorIndexAdaptor &adapt
       int64_t loop_cnt = 0;
       if (OB_FAIL(new_row.init(task_ctx->embedded_table_column_ids_.count()))) {
         LOG_WARN("fail to init datum row", K(ret), K(task_ctx->embedded_table_column_ids_), K(new_row));
-      } else if (adaptor.get_is_need_vid() && OB_FAIL(ObPluginVectorIndexUtils::read_local_tablet(ls_id_,
+      } else if (adaptor.get_is_need_vid() && OB_FAIL(ObPluginVectorIndexUtils::read_local_tablet(ls_id_, 
               &adaptor,
               ctx_->task_status_.target_scn_,
               INDEX_TYPE_VEC_VID_ROWKEY_LOCAL,
@@ -1053,7 +1066,7 @@ int ObHybridVectorRefreshTask::after_embedding(ObPluginVectorIndexAdaptor &adapt
             ObTableScanIterator *embedded_table_scan_iter = nullptr;
             ObArenaAllocator embedde_scan_allocator("VecEmbedding", OB_MALLOC_NORMAL_BLOCK_SIZE, MTL_ID());
             ObRowkey rowkey(obj_ptr, embedded_rowkey_count);
-            if (OB_FAIL(ObPluginVectorIndexUtils::read_local_tablet(ls_id_,
+            if (OB_FAIL(ObPluginVectorIndexUtils::read_local_tablet(ls_id_, 
                 &adaptor,
                 snapshot.version(),
                 INDEX_TYPE_HYBRID_INDEX_EMBEDDED_LOCAL,
@@ -1098,7 +1111,7 @@ int ObHybridVectorRefreshTask::after_embedding(ObPluginVectorIndexAdaptor &adapt
             }
           }
         }
-
+        
         CHECK_TASK_CANCELLED_IN_PROCESS(ret, loop_cnt, ctx_);
       }
       if (OB_NOT_NULL(tsc_service)) {

--- a/src/share/vector_index/ob_hybrid_vector_refresh_task.h
+++ b/src/share/vector_index/ob_hybrid_vector_refresh_task.h
@@ -16,7 +16,7 @@
 
  #ifndef OCEANBASE_OBSERVER_TABLE_OB_HYBRID_VECTOR_REFRESH_TASK_H_
  #define OCEANBASE_OBSERVER_TABLE_OB_HYBRID_VECTOR_REFRESH_TASK_H_
-
+ 
 #include "lib/string/ob_string.h"
 #include "share/scn.h"
 #include "lib/thread/thread_mgr_interface.h"
@@ -29,7 +29,7 @@
 #include "share/ai_service/ob_ai_service_struct.h"
 #include "storage/ob_value_row_iterator.h"
 #include "src/observer/omt/ob_tenant_ai_service.h"
-
+ 
 namespace oceanbase
 {
 namespace share
@@ -44,14 +44,14 @@ enum ObHybridVectorRefreshTaskStatus
   TASK_FINISH = 4,
 };
 
-class ObVecEmbeddingAsyncTaskExecutor final : public ObVecAsyncTaskExector
+class ObVecEmbeddingAsyncTaskExecutor final : public ObVecAsyncTaskExector 
 {
-public:
+public: 
   ObVecEmbeddingAsyncTaskExecutor() : ObVecAsyncTaskExector()
   {}
   virtual ~ObVecEmbeddingAsyncTaskExecutor() {}
   virtual int load_task(uint64_t &task_trace_base_num) override;
-private:
+private:  
   bool check_operation_allow() override;
 };
 
@@ -104,6 +104,7 @@ public:
   ObSEArray<uint64_t, 4> embedded_table_update_ids_;
   omt::ObAiServiceGuard ai_service_;
   const ObAiModelEndpointInfo *endpoint_;
+  ObString request_model_name_;
   ObPluginVectorIndexAdapterGuard adp_guard_;
   bool task_started_;
   uint32_t part_key_num_; // is part key but rowkey
@@ -123,7 +124,7 @@ public:
     }
   }
   virtual int do_work() override;
-  ObHybridVectorRefreshTaskStatus current_status() {
+  ObHybridVectorRefreshTaskStatus current_status() { 
     ObHybridVectorRefreshTaskStatus status = ObHybridVectorRefreshTaskStatus::INVALID_TASK_STATUS;
     ObHybridVectorRefreshTaskCtx *ctx = static_cast<ObHybridVectorRefreshTaskCtx *>(get_task_ctx());
     if (OB_NOT_NULL(ctx)) {
@@ -146,21 +147,21 @@ private:
   int get_index_id_column_ids(ObPluginVectorIndexAdaptor &adaptor);
   int get_embedded_table_column_ids(ObPluginVectorIndexAdaptor &adaptor);
   int init_dml_param(
-      uint64_t table_id,
-      ObDMLBaseParam &dml_param,
-      share::schema::ObTableDMLParam &table_param,
-      ObIArray<uint64_t> &dml_column_ids,
-      transaction::ObTxDesc *tx_desc,
-      oceanbase::transaction::ObTxReadSnapshot &snapshot,
+      uint64_t table_id, 
+      ObDMLBaseParam &dml_param, 
+      share::schema::ObTableDMLParam &table_param, 
+      ObIArray<uint64_t> &dml_column_ids, 
+      transaction::ObTxDesc *tx_desc, 
+      oceanbase::transaction::ObTxReadSnapshot &snapshot, 
       storage::ObStoreCtxGuard &store_ctx_guard);
   int init_endpoint(ObPluginVectorIndexAdaptor &adaptor);
   int prepare_for_embedding(ObPluginVectorIndexAdaptor &adaptor);
   int prepare_index_id_data(storage::ObValueRowIterator &index_id_iter, storage::ObValueRowIterator &delta_delete_iter);
   int do_refresh_only(
-      ObPluginVectorIndexAdaptor &adaptor,
-      transaction::ObTxDesc *tx_desc,
-      oceanbase::transaction::ObTxReadSnapshot &snapshot,
-      storage::ObStoreCtxGuard &store_ctx_guard,
+      ObPluginVectorIndexAdaptor &adaptor, 
+      transaction::ObTxDesc *tx_desc, 
+      oceanbase::transaction::ObTxReadSnapshot &snapshot, 
+      storage::ObStoreCtxGuard &store_ctx_guard, 
       storage::ObValueRowIterator &index_id_iter,
       storage::ObValueRowIterator &delta_delete_iter);
   int delete_embedded_table(ObPluginVectorIndexAdaptor &adaptor, transaction::ObTxDesc *tx_desc, oceanbase::transaction::ObTxReadSnapshot &snapshot, storage::ObStoreCtxGuard &store_ctx_guard);

--- a/src/storage/ddl/ob_hnsw_embedmgr.cpp
+++ b/src/storage/ddl/ob_hnsw_embedmgr.cpp
@@ -35,7 +35,7 @@ bool ObEmbeddingConfig::is_valid() const
   }
   return is_valid;
 }
-void ObEmbeddingConfig::set_config(const ObString &model_url, const ObString &model_name,
+void ObEmbeddingConfig::set_config(const ObString &model_url, const ObString &model_name, 
                                     const ObString &user_key, const ObString &provider)
 {
   model_url_ = model_url;
@@ -210,7 +210,7 @@ int ObTaskBatchInfo::init(const int64_t batch_size, const int64_t vec_dim)
     batch_size_ = batch_size;
     vec_dim_ = vec_dim;
     current_count_ = 0;
-
+    
     if (OB_FAIL(results_.reserve(batch_size))) {
       LOG_WARN("reserve results array failed", K(ret), K(batch_size));
     } else {
@@ -255,7 +255,7 @@ int ObTaskBatchInfo::add_item(const blocksstable::ObStorageDatum &text,
         need_embedding_count_++;
       }
     }
-
+    
     // pre-allocate space (will be filled by embedding task)
     if (OB_SUCC(ret)) {
       float *vec_buf = static_cast<float*>(allocator_.alloc(vec_dim_ * sizeof(float)));
@@ -309,7 +309,7 @@ int ObTaskSlotRing::init(const int64_t capacity)
 {
   int ret = OB_SUCCESS;
   ObSpinLockGuard guard(lock_);
-
+  
   if (capacity <= 0) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid capacity", K(ret), K(capacity));
@@ -359,7 +359,7 @@ int ObTaskSlotRing::mark_ready(const int64_t slot_idx, const int ret_code)
 {
   int ret = OB_SUCCESS;
   ObSpinLockGuard guard(lock_);
-
+  
   if (slot_idx < 0 || slot_idx >= slots_.count()) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid slot idx", K(ret), K(slot_idx), K(slots_.count()));
@@ -375,7 +375,7 @@ int ObTaskSlotRing::pop_ready_in_order(ObTaskBatchInfo *&batch_info, int &ret_co
   int ret = OB_SUCCESS;
   batch_info = nullptr;
   ObSpinLockGuard guard(lock_);
-
+  
   if (head_idx_ != next_idx_ && slots_.at(head_idx_).ready_) {
     Slot &slot = slots_.at(head_idx_);
     if (!slot.ready_) {
@@ -396,7 +396,7 @@ int ObTaskSlotRing::pop_ready_in_order(ObTaskBatchInfo *&batch_info, int &ret_co
       slot.task_->release_if_managed();
       slot.task_ = nullptr;
     }
-
+    
     if (OB_SUCC(ret) || OB_NOT_NULL(batch_info)) {
       slot.ready_ = false;
       head_idx_ = (head_idx_ + 1) % slots_.count();
@@ -462,7 +462,7 @@ int ObTaskSlotRing::wait_for_head_completion()
 {
   int ret = OB_SUCCESS;
   share::ObEmbeddingTask *task_to_wait = nullptr;
-
+  
   {
     ObSpinLockGuard guard(lock_);
     if (head_idx_ != next_idx_) {
@@ -472,7 +472,7 @@ int ObTaskSlotRing::wait_for_head_completion()
       }
     }
   }
-
+  
   if (OB_NOT_NULL(task_to_wait)) {
     if (OB_FAIL(task_to_wait->wait_for_completion())) {
       LOG_WARN("wait for head embedding task completion failed", K(ret));
@@ -643,7 +643,7 @@ int ObEmbeddingTaskMgr::submit_batch_info(ObTaskBatchInfo *&batch_info)
           }
         }
       }
-
+      
       if (OB_SUCC(ret) && embedding_count > 0) {
         // Only create embedding task if there are items to embed
         void *cb_buf = ob_malloc(sizeof(ObEmbeddingIOCallback), ObMemAttr(MTL_ID(), "EmbedCb"));
@@ -654,7 +654,7 @@ int ObEmbeddingTaskMgr::submit_batch_info(ObTaskBatchInfo *&batch_info)
           ObEmbeddingIOCallback *cb = new (cb_buf) ObEmbeddingIOCallback();
           ObEmbeddingIOCallbackHandle *cb_handle = nullptr;
           share::ObEmbeddingTask *task = nullptr;
-
+          
           if (OB_ISNULL(cb_handle = ObEmbeddingIOCallbackHandle::create(cb))) {
             ret = OB_ALLOCATE_MEMORY_FAILED;
             LOG_WARN("create callback handle failed", K(ret));
@@ -666,13 +666,13 @@ int ObEmbeddingTaskMgr::submit_batch_info(ObTaskBatchInfo *&batch_info)
             } else {
               task = new (task_mem) share::ObEmbeddingTask();
               const int64_t vec_dim = results.at(0)->get_vector_dim();
-              if (OB_FAIL(task->init(cfg_.model_url_, cfg_.model_name_, cfg_.provider_,
+              if (OB_FAIL(task->init(cfg_.model_url_, cfg_.model_name_, cfg_.provider_, 
                                    cfg_.user_key_, texts, vec_dim, model_request_timeout_us_, model_max_retries_, cb_handle))) {
                 LOG_WARN("failed to initialize EmbeddingTask", K(ret));
               }
             }
           }
-
+          
           if (OB_SUCC(ret) && OB_NOT_NULL(task)) {
             if (OB_FAIL(cb->init(this, slot_idx, batch_info, task, results.at(0)->get_vector_dim()))) {
               LOG_WARN("init callback failed", K(ret));
@@ -684,7 +684,7 @@ int ObEmbeddingTaskMgr::submit_batch_info(ObTaskBatchInfo *&batch_info)
               }
             }
           }
-
+          
           if (OB_SUCC(ret)) {
             slot_ring_.set_task(slot_idx, task);
             slot_ring_.set_batch_info(slot_idx, batch_info); // Take ownership
@@ -750,6 +750,7 @@ int ObEmbeddingTaskMgr::get_ai_config(const common::ObString &model_id)
     const share::ObAiModelEndpointInfo *endpoint_info = nullptr;
     omt::ObAiServiceGuard ai_service_guard;
     omt::ObTenantAiService *ai_service = MTL(omt::ObTenantAiService*);
+    bool use_request_model_name = false;
     if (OB_FAIL(ObAIFuncUtils::get_ai_func_info(allocator_, const_cast<common::ObString&>(model_id), info))) {
       LOG_WARN("failed to get ai func info", K(ret), K(model_id));
     } else if (OB_ISNULL(info)) {
@@ -762,9 +763,12 @@ int ObEmbeddingTaskMgr::get_ai_config(const common::ObString &model_id)
       LOG_WARN("failed to get ai service guard", K(ret));
     } else if (OB_FAIL(ai_service_guard.get_ai_endpoint_by_ai_model_name(model_id, endpoint_info))) {
       LOG_WARN("failed to get endpoint info", K(ret), K(model_id));
+    } else if (OB_FALSE_IT(use_request_model_name = !endpoint_info->get_request_model_name().empty())) {
     } else if (OB_FAIL(ob_write_string(allocator_, endpoint_info->get_url(), cfg_.model_url_))) {
       LOG_WARN("failed to copy model_url", K(ret));
-    } else if (OB_FAIL(ob_write_string(allocator_, info->model_, cfg_.model_name_))) {
+    } else if (use_request_model_name && OB_FAIL(ob_write_string(allocator_, endpoint_info->get_request_model_name(), cfg_.model_name_))) {
+      LOG_WARN("failed to copy model_name", K(ret));
+    } else if (!use_request_model_name && OB_FAIL(ob_write_string(allocator_, info->model_, cfg_.model_name_))) {
       LOG_WARN("failed to copy model_name", K(ret));
     } else if (OB_FAIL(endpoint_info->get_unencrypted_access_key(allocator_, cfg_.user_key_))) {
       LOG_WARN("failed to copy user_key", K(ret));


### PR DESCRIPTION
### Task Description
## Issue Description
创建 text-embedding-v4 模型的语义向量索引后，执行 `refresh index` 报错 4016。
原因：refresh 任务在调用 embedding 接口时，直接使用 `endpoint->get_request_model_name()` 获取模型名称，但部分场景下（如通过 AI function 创建的索引）该字段为空，导致请求模型服务时因空 model_name 返回 4016 错误。

### Solution Description
修改 model_name 获取策略：优先使用 endpoint 的 `request_model_name`，若为空则通过 `ObAIFuncUtils::get_ai_func_info()` 从 ai_model 表回退获取。
**修改文件：**
1. `src/share/vector_index/ob_hybrid_vector_refresh_task.cpp`
- `init_endpoint()`: 新增 model_name fallback 逻辑，结果存入 `task_ctx->request_model_name_`
- `prepare_for_embedding()`: 使用 `task_ctx->request_model_name_` 替代 `endpoint->get_request_model_name()`
2. `src/share/vector_index/ob_hybrid_vector_refresh_task.h`
- `ObHybridVectorRefreshTaskContext` 新增字段 `ObString request_model_name_`
3. `src/storage/ddl/ob_hnsw_embedmgr.cpp`
- `get_ai_config()`: 同步修改 model_name 获取逻辑，优先 request_model_name，为空时回退到 ai_func_info
## Passed Regressions
- [*] 向量索引 refresh 场景验证
- [*] 
## Workaround
用户可通过手动设置 endpoint 的 request_model_name 字段规避。
## Upgrade Compatibility
无升级兼容性影响，纯逻辑修复。

### Passed Regressions

### Upgrade Compatibility

### Other Information
N/A
cherry-pick from merge point [5b81527431b9e7e7f5b70898b96fd25f4605ab0a]() in project oceanbase by ob flow
the prev code review : [262513]()
**Warning: This review got code conflicts when auto cherry-picking, please make sure the diff is effective**
-

### Release Note