### PR TITLE
Filter fork unlock dependent-task check to DDL_FORK_TABLE

### DIFF
--- a/src/storage/ddl/ob_ddl_lock.cpp
+++ b/src/storage/ddl/ob_ddl_lock.cpp
@@ -812,8 +812,9 @@ int ObDDLLock::check_has_dependent_task(
   ObISQLClient::ReadResult res;
   sqlclient::ObMySQLResult *result = NULL;
 
-  if (OB_FAIL(sql_string.assign_fmt("SELECT EXISTS(SELECT 1 FROM %s WHERE task_id != %ld AND (object_id = %lu OR target_object_id = %lu)) as has",
-      share::OB_ALL_DDL_TASK_STATUS_TNAME, current_task_id, table_id, table_id))) {
+  if (OB_FAIL(sql_string.assign_fmt("SELECT EXISTS(SELECT 1 FROM %s WHERE task_id != %ld AND ddl_type = %d "
+                                    "AND (object_id = %lu OR target_object_id = %lu)) as has",
+      OB_ALL_DDL_TASK_STATUS_TNAME, current_task_id, share::ObDDLType::DDL_FORK_TABLE, table_id, table_id))) {
     LOG_WARN("assign sql string failed", K(ret));
   } else {
     ObInnerSQLConnection *iconn = static_cast<ObInnerSQLConnection *>(trans.get_connection());

--- a/tools/deploy/mysql_test/test_suite/fork_table/r/mysql/fork_table_with_index.result
+++ b/tools/deploy/mysql_test/test_suite/fork_table/r/mysql/fork_table_with_index.result
@@ -119,8 +119,8 @@ Outputs & filters:
       force partition granule
   3 - output([t2_fork.id], [t2_fork.name], [t2_fork.age], [t2_fork.email]), filter(nil), rowset=16
       access([t2_fork.id], [t2_fork.name], [t2_fork.age], [t2_fork.email]), partitions(p[0-1])
-      is_index_back=true, is_global_index=false,
-      range_key([t2_fork.name], [t2_fork.id]), range(Alice,MIN ; Alice,MAX),
+      is_index_back=true, is_global_index=false, 
+      range_key([t2_fork.name], [t2_fork.id]), range(Alice,MIN ; Alice,MAX), 
       range_cond([t2_fork.name = 'Alice'])
 explain select * from t2_fork where age = 30;
 Query Plan
@@ -141,8 +141,8 @@ Outputs & filters:
       force partition granule
   3 - output([t2_fork.id], [t2_fork.age], [t2_fork.name], [t2_fork.email]), filter(nil), rowset=16
       access([t2_fork.id], [t2_fork.age], [t2_fork.name], [t2_fork.email]), partitions(p[0-1])
-      is_index_back=true, is_global_index=false,
-      range_key([t2_fork.age], [t2_fork.id]), range(30,MIN ; 30,MAX),
+      is_index_back=true, is_global_index=false, 
+      range_key([t2_fork.age], [t2_fork.id]), range(30,MIN ; 30,MAX), 
       range_cond([t2_fork.age = 30])
 ============================================
 2.1 Fork Table with Index Building
@@ -248,6 +248,63 @@ t2c_fork	CREATE TABLE `t2c_fork` (
   PRIMARY KEY (`id`),
   VECTOR KEY `idx_vec_emb` (`emb`) WITH (DISTANCE=L2, TYPE=HNSW, LIB=VSAG, M=16, EF_CONSTRUCTION=200, EF_SEARCH=64) BLOCK_SIZE 16384
 ) ORGANIZATION INDEX DEFAULT CHARSET = utf8mb4 ROW_FORMAT = DYNAMIC COMPRESSION = 'zstd_1.3.8' REPLICA_NUM = replica_num BLOCK_SIZE = 16384 USE_BLOOM_FILTER = FALSE ENABLE_MACRO_BLOCK_BLOOM_FILTER = FALSE TABLET_SIZE = 134217728 PCTFREE = 0
+============================================
+2.4 Fork未完成时删除源表向量索引（debug sync）
+============================================
+drop table if exists t2d;
+Warnings:
+Note	1051	Unknown table 'db_fork_index.t2d'
+drop table if exists t2d_fork;
+Warnings:
+Note	1051	Unknown table 'db_fork_index.t2d_fork'
+create table t2d (
+id int primary key,
+name varchar(50),
+age int,
+email varchar(100),
+emb vector(3)
+);
+insert into t2d values (1, 'Alice', 25, 'alice@example.com', '[0.203846,0.205289,0.880265]');
+insert into t2d values (2, 'Bob', 30, 'bob@example.com', '[0.1,0.2,0.3]');
+create vector index idx_vec_race on t2d(emb) with (distance=l2, type=hnsw, lib=vsag);
+# 获取源表table_id（用于等待fork任务阶段）
+# 卡在FORK_TABLE_SUCCESS：RS 侧任务已到 SUCCESS 但未执行完 cleanup（fork 仍未完成）
+alter system set debug_sync_timeout = '120s';
+set ob_global_debug_sync = 'reset';
+set ob_global_debug_sync = 'FORK_TABLE_SUCCESS wait_for signal_fork_success_resume execute 10000';
+# fork table 客户端返回后 RS 侧任务继续；此处与 lock 用例一致不使用 --send
+fork table t2d to t2d_fork;
+set ob_trx_timeout = 100000000;
+set ob_query_timeout = 100000000;
+use db_fork_index;
+# fork未完成：发起删除源表向量索引（与 fork cleanup 并发；历史问题：可能卡死/泄漏锁）
+# drop index 会等待 fork 在 SUCCESS 卡点之前仍持有的 DDL/表锁；同步执行会与 signal 死锁，故对 drop 使用 --send
+drop index idx_vec_race on t2d;;
+set ob_global_debug_sync = 'FORK_TABLE_SUCCESS clear';
+set ob_global_debug_sync = 'now signal signal_fork_success_resume';
+# 验证：源表向量索引已删除；fork表仍保留向量索引定义
+show create table t2d;
+Table	Create Table
+t2d	CREATE TABLE `t2d` (
+  `id` int(11) NOT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `age` int(11) DEFAULT NULL,
+  `email` varchar(100) DEFAULT NULL,
+  `emb` VECTOR(3) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ORGANIZATION INDEX DEFAULT CHARSET = utf8mb4 ROW_FORMAT = DYNAMIC COMPRESSION = 'zstd_1.3.8' REPLICA_NUM = replica_num BLOCK_SIZE = 16384 USE_BLOOM_FILTER = FALSE ENABLE_MACRO_BLOCK_BLOOM_FILTER = FALSE TABLET_SIZE = 134217728 PCTFREE = 0
+show create table t2d_fork;
+Table	Create Table
+t2d_fork	CREATE TABLE `t2d_fork` (
+  `id` int(11) NOT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `age` int(11) DEFAULT NULL,
+  `email` varchar(100) DEFAULT NULL,
+  `emb` VECTOR(3) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  VECTOR KEY `idx_vec_race` (`emb`) WITH (DISTANCE=L2, TYPE=HNSW, LIB=VSAG, M=16, EF_CONSTRUCTION=200, EF_SEARCH=64) BLOCK_SIZE 16384
+) ORGANIZATION INDEX DEFAULT CHARSET = utf8mb4 ROW_FORMAT = DYNAMIC COMPRESSION = 'zstd_1.3.8' REPLICA_NUM = 1 BLOCK_SIZE = 16384 USE_BLOOM_FILTER = FALSE ENABLE_MACRO_BLOCK_BLOOM_FILTER = FALSE TABLET_SIZE = 134217728 PCTFREE = 0
+set ob_global_debug_sync = 'reset';
 ============================================
 3. Fork Table with Unique Index
 ============================================
@@ -381,6 +438,8 @@ drop table if exists t2b;
 drop table if exists t2b_fork;
 drop table if exists t2c;
 drop table if exists t2c_fork;
+drop table if exists t2d;
+drop table if exists t2d_fork;
 drop table if exists t3;
 drop table if exists t3_fork;
 drop table if exists t4;

--- a/tools/deploy/mysql_test/test_suite/fork_table/t/fork_table_with_index.test
+++ b/tools/deploy/mysql_test/test_suite/fork_table/t/fork_table_with_index.test
@@ -1,7 +1,7 @@
 ##owner: fankun.fan
 ##owner group: 底层引擎部-轻量版
 ##description: Fork Table索引处理测试
-##tags: fork_table index
+##tags: fork_table index debug_sync vector_index drop_index
 ##author: fankun.fan
 
 --disable_warnings
@@ -239,6 +239,90 @@ connection default;
 show create table t2c_fork;
 
 --echo ============================================
+--echo 2.4 Fork未完成时删除源表向量索引（debug sync）
+--echo ============================================
+
+drop table if exists t2d;
+drop table if exists t2d_fork;
+
+create table t2d (
+    id int primary key,
+    name varchar(50),
+    age int,
+    email varchar(100),
+    emb vector(3)
+);
+
+insert into t2d values (1, 'Alice', 25, 'alice@example.com', '[0.203846,0.205289,0.880265]');
+insert into t2d values (2, 'Bob', 30, 'bob@example.com', '[0.1,0.2,0.3]');
+
+create vector index idx_vec_race on t2d(emb) with (distance=l2, type=hnsw, lib=vsag);
+
+--echo # 获取源表table_id（用于等待fork任务阶段）
+--disable_query_log
+let $table_t2d_id = query_get_value(select table_id from oceanbase.__all_table where table_name = 't2d' and database_id = (select database_id from oceanbase.__all_database where database_name = 'db_fork_index'), table_id, 1);
+--enable_query_log
+
+--echo # 卡在FORK_TABLE_SUCCESS：RS 侧任务已到 SUCCESS 但未执行完 cleanup（fork 仍未完成）
+connection obsys;
+alter system set debug_sync_timeout = '120s';
+sleep 1;
+set ob_global_debug_sync = 'reset';
+set ob_global_debug_sync = 'FORK_TABLE_SUCCESS wait_for signal_fork_success_resume execute 10000';
+sleep 1;
+connection default;
+
+--echo # fork table 客户端返回后 RS 侧任务继续；此处与 lock 用例一致不使用 --send
+fork table t2d to t2d_fork;
+
+--disable_query_log
+let $table_t2d_fork_id = query_get_value(select table_id from oceanbase.__all_table where table_name = 't2d_fork' and database_id = (select database_id from oceanbase.__all_database where database_name = 'db_fork_index'), table_id, 1);
+--enable_query_log
+
+connect (conn_drop,$OBMYSQL_MS0,root@sys,,db_fork_index,$OBMYSQL_PORT);
+connection conn_drop;
+set ob_trx_timeout = 100000000;
+set ob_query_timeout = 100000000;
+use db_fork_index;
+
+connection default;
+let $wait_src_table_id= $table_t2d_id;
+let $wait_dest_table_id= $table_t2d_fork_id;
+let $wait_status= SUCCESS;
+--source mysql_test/test_suite/fork_table/include/wait_fork_table.inc
+
+--echo # fork未完成：发起删除源表向量索引（与 fork cleanup 并发；历史问题：可能卡死/泄漏锁）
+--echo # drop index 会等待 fork 在 SUCCESS 卡点之前仍持有的 DDL/表锁；同步执行会与 signal 死锁，故对 drop 使用 --send
+connection conn_drop;
+--send drop index idx_vec_race on t2d;
+
+connection obsys;
+set ob_global_debug_sync = 'FORK_TABLE_SUCCESS clear';
+set ob_global_debug_sync = 'now signal signal_fork_success_resume';
+connection default;
+
+let $wait_src_table_id= $table_t2d_id;
+let $wait_dest_table_id= $table_t2d_fork_id;
+--source mysql_test/test_suite/fork_table/include/wait_fork_table.inc
+
+connection conn_drop;
+--reap
+
+connection default;
+
+--echo # 验证：源表向量索引已删除；fork表仍保留向量索引定义
+--replace_regex /REPLICA_NUM = [0-9]*/REPLICA_NUM = replica_num/g
+show create table t2d;
+show create table t2d_fork;
+
+disconnect conn_drop;
+connection default;
+
+connection obsys;
+set ob_global_debug_sync = 'reset';
+connection default;
+
+--echo ============================================
 --echo 3. Fork Table with Unique Index
 --echo ============================================
 
@@ -352,8 +436,11 @@ drop table if exists t2b;
 drop table if exists t2b_fork;
 drop table if exists t2c;
 drop table if exists t2c_fork;
+drop table if exists t2d;
+drop table if exists t2d_fork;
 drop table if exists t3;
 drop table if exists t3_fork;
 drop table if exists t4;
 drop table if exists t4_fork;
 drop database if exists db_fork_index;
+


### PR DESCRIPTION
### Task Description
## Issue Description
`ObDDLLock::check_has_dependent_task` used an `EXISTS` query on `__all_ddl_task_status` keyed only by `task_id` and `object_id` / `target_object_id`, so unrelated DDL work on the same table could be treated as a “dependent task” and interfere with fork-table lock handling (e.g. long waits or lock cleanup issues). There was no `mysql_test` coverage for dropping a source vector index while a fork job is still in the `FORK_TABLE_SUCCESS` debug window.

### Solution Description
- `src/storage/ddl/ob_ddl_lock.cpp`: Extend the `check_has_dependent_task` `EXISTS` subquery with `ddl_type = ObDDLType::DDL_FORK_TABLE` so only fork-table tasks are considered dependents. Use `OB_ALL_DDL_TASK_STATUS_TNAME` in the `assign_fmt` call.
- `tools/deploy/mysql_test/test_suite/fork_table/t/fork_table_with_index.test`: Add section 2.4: enable `FORK_TABLE_SUCCESS` debug sync, run `fork table` on the default connection, use `wait_fork_table.inc` for `SUCCESS` and completion, issue `drop index` on a second connection with `--send` / `--reap` to avoid deadlocking on DDL locks before the sync signal, then `show create table` for `t2d` / `t2d_fork`. Update `##tags`, and drop `t2d` / `t2d_fork` in the cleanup section.
- `tools/deploy/mysql_test/test_suite/fork_table/r/mysql/fork_table_with_index.result`: Record the new case and cleanup `drop` lines.
## Passed Regressions
## Workaround
## Upgrade Compatibility

### Passed Regressions

### Upgrade Compatibility

### Other Information

### Release Note