### PR TITLE
bundle third-party DLLs, fix zero datum descriptors and fix launch configurator on double-click MSI Remove path

### DIFF
--- a/cmake/BundleRuntimeDllsWindows.cmake
+++ b/cmake/BundleRuntimeDllsWindows.cmake
@@ -1,0 +1,122 @@
+# ---------------------------------------------------------------------------
+# BundleRuntimeDllsWindows.cmake
+#
+# Invoked at BUILD TIME via `cmake -P` to copy third-party runtime DLLs next
+# to the Windows executable so it can run directly from the build tree
+# without requiring the user's PATH to contain vcpkg / vsag bin directories.
+#
+# This mirrors the install-time bundling in cmake/Pack.cmake (which runs
+# during cpack/install), but targets the build tree so `build/.../seekdb.exe`
+# is usable immediately after a build.
+#
+# Required -D variables:
+#   EXE         : absolute path to the built executable (e.g. seekdb.exe)
+#   OUT_DIR     : directory to place bundled DLLs (usually dirname of EXE)
+#   SEARCH_DIRS : ';'-separated list of directories to search DLLs in
+#                 (typically ${OB_VCPKG_DIR}/bin and ${OB_VSAG_DIR}/bin)
+#
+# Notes:
+# - file(GET_RUNTIME_DEPENDENCIES) requires CMake >= 3.21.
+# - System DLLs (kernel32, advapi32, ...) are absent from SEARCH_DIRS and
+#   therefore silently skipped; they ship with every Windows installation.
+# - copy_if_different keeps incremental builds cheap.
+# ---------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.21)
+
+if(NOT EXE)
+  message(FATAL_ERROR "BundleRuntimeDllsWindows: -DEXE=<path> is required")
+endif()
+if(NOT OUT_DIR)
+  message(FATAL_ERROR "BundleRuntimeDllsWindows: -DOUT_DIR=<dir> is required")
+endif()
+if(NOT SEARCH_DIRS)
+  message(FATAL_ERROR "BundleRuntimeDllsWindows: -DSEARCH_DIRS=<dir;dir> is required")
+endif()
+
+file(TO_CMAKE_PATH "${EXE}" EXE)
+file(TO_CMAKE_PATH "${OUT_DIR}" OUT_DIR)
+
+set(_dirs "")
+foreach(_d IN LISTS SEARCH_DIRS)
+  if(_d STREQUAL "")
+    continue()
+  endif()
+  file(TO_CMAKE_PATH "${_d}" _d)
+  if(IS_DIRECTORY "${_d}")
+    list(APPEND _dirs "${_d}")
+  else()
+    message(STATUS "BundleRuntimeDllsWindows: skip missing dir '${_d}'")
+  endif()
+endforeach()
+
+if(NOT _dirs)
+  message(WARNING "BundleRuntimeDllsWindows: no valid SEARCH_DIRS; nothing to do")
+  return()
+endif()
+
+if(NOT EXISTS "${EXE}")
+  message(FATAL_ERROR "BundleRuntimeDllsWindows: executable not found: ${EXE}")
+endif()
+
+file(MAKE_DIRECTORY "${OUT_DIR}")
+
+file(GET_RUNTIME_DEPENDENCIES
+  EXECUTABLES
+    "${EXE}"
+  RESOLVED_DEPENDENCIES_VAR _resolved
+  UNRESOLVED_DEPENDENCIES_VAR _unresolved
+  CONFLICTING_DEPENDENCIES_PREFIX _conflicts
+  DIRECTORIES
+    ${_dirs}
+  PRE_EXCLUDE_REGEXES
+    "^api-ms-"
+    "^ext-ms-"
+  POST_EXCLUDE_REGEXES
+    "[Ss]ystem32"
+    "[Ss]yswow64"
+)
+
+set(_bundled 0)
+
+# Helper: copy ${_name} from the first SEARCH_DIR that contains it.
+function(_bundle_one _name)
+  foreach(_dir IN LISTS _dirs)
+    if(EXISTS "${_dir}/${_name}")
+      execute_process(
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${_dir}/${_name}" "${OUT_DIR}/${_name}"
+        RESULT_VARIABLE _rc)
+      if(_rc EQUAL 0)
+        math(EXPR _new "${_bundled} + 1")
+        set(_bundled ${_new} PARENT_SCOPE)
+      else()
+        message(WARNING "BundleRuntimeDllsWindows: failed to copy ${_name} from ${_dir}")
+      endif()
+      return()
+    endif()
+  endforeach()
+endfunction()
+
+foreach(_file IN LISTS _resolved)
+  get_filename_component(_name "${_file}" NAME)
+  _bundle_one("${_name}")
+endforeach()
+
+# Conflicting dependencies: same DLL present in multiple DIRECTORIES (e.g.
+# vcpkg and vsag both ship a copy). Prefer the first SEARCH_DIR wins order.
+foreach(_name IN LISTS _conflicts_FILENAMES)
+  _bundle_one("${_name}")
+endforeach()
+
+if(_unresolved)
+  # These are DLLs that couldn't be located in SEARCH_DIRS and aren't filtered
+  # as system libraries. They usually indicate a missing dependency in
+  # SEARCH_DIRS; report but don't fail the build.
+  list(REMOVE_DUPLICATES _unresolved)
+  foreach(_u IN LISTS _unresolved)
+    message(STATUS "BundleRuntimeDllsWindows: unresolved (likely system) ${_u}")
+  endforeach()
+endif()
+
+message(STATUS "BundleRuntimeDllsWindows: bundled ${_bundled} DLLs -> ${OUT_DIR}")

--- a/src/observer/CMakeLists.txt
+++ b/src/observer/CMakeLists.txt
@@ -607,7 +607,7 @@ add_library(oceanbase_static
   ${CMAKE_CURRENT_BINARY_DIR}/ob_version.cpp)
 
 target_link_libraries(oceanbase_static
-  PUBLIC ob_base "${ob_objects}" ob_sql_static ob_storage_static ob_share_static oblib objit ob_plugin)
+  PUBLIC ob_base "${ob_objects}" ob_sql_static ob_storage_static ob_share_static oblib objit ob_plugin ${HYPERSCAN_LIB})
 
 if (OB_GPERF_MODE)
   target_link_libraries(oceanbase_static
@@ -620,6 +620,7 @@ if (OB_SO_CACHE)
     IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/liboceanbase.so")
   target_link_libraries(oceanbase
     INTERFACE ob_base
+    ${HYPERSCAN_SHARED_LIB}
     ${STDC_SHARED_LIB})
 else()
   add_library(oceanbase
@@ -628,6 +629,7 @@ else()
     ${CMAKE_CURRENT_BINARY_DIR}/ob_version.cpp)
   target_link_libraries(oceanbase
     PUBLIC ob_base
+    ${HYPERSCAN_SHARED_LIB}
     INTERFACE
     ${STDC_SHARED_LIB}
     PRIVATE
@@ -764,6 +766,28 @@ else()
   endif()
   add_custom_target(seekdb ALL
     DEPENDS fake_observer)
+endif()
+
+# ── Bundle third-party runtime DLLs next to seekdb.exe in the build tree ──
+# Without this, running build/.../seekdb.exe directly requires the user's
+# PATH to include ${OB_VCPKG_DIR}/bin etc. After this POST_BUILD step the
+# build tree is self-contained for local smoke tests (--version, unit
+# launches, debugger runs). Install/package bundling is still handled
+# separately by cmake/Pack.cmake at cpack time.
+#
+# Attached to the `seekdb` target (not `observer`) so that:
+#   * `cmake --build . --target seekdb` alone produces a runnable exe
+#   * `observer` (which DEPENDS seekdb) still triggers bundling transitively
+#   * bundling runs only once per build, not once per downstream target
+if(WIN32)
+  add_custom_command(TARGET seekdb POST_BUILD
+    COMMAND ${CMAKE_COMMAND}
+      "-DEXE=${CMAKE_BINARY_DIR}/src/observer/seekdb.exe"
+      "-DOUT_DIR=${CMAKE_BINARY_DIR}/src/observer"
+      "-DSEARCH_DIRS=${OB_VCPKG_DIR}/bin;${OB_VSAG_DIR}/bin"
+      -P "${CMAKE_SOURCE_DIR}/cmake/BundleRuntimeDllsWindows.cmake"
+    COMMENT "Bundling runtime DLLs next to seekdb.exe"
+    VERBATIM)
 endif()
 
 if(WIN32)

--- a/src/sql/engine/expr/ob_expr.cpp
+++ b/src/sql/engine/expr/ob_expr.cpp
@@ -408,6 +408,8 @@ int ObExpr::eval_enumset(ObEvalCtx &ctx,
       if (!eval_info->evaluated_) {
         evaluated_flags->reset(ctx.get_batch_size());
         reset_datums_ptr(frame, ctx.get_batch_size());
+        // See `clear_datum_descriptors` below for the rationale.
+        clear_datum_descriptors(frame, ctx.get_batch_size());
         eval_info->evaluated_ = true;
         eval_info->cnt_ = ctx.get_batch_size();
         eval_info->point_to_frame_ = true;
@@ -719,6 +721,33 @@ void ObExpr::reset_datums_ptr(char *frame, const int64_t size) const
   }
 }
 
+// Zero out the datum descriptor part (len_/null_/flag_) on the
+// first-evaluation entry points. The datums array inside the expression frame
+// is intentionally excluded from the zero-init region (see
+// ObStaticEngineExprCG::create_tmp_frameinfo, whose zero_init_pos starts
+// after get_datums_header_size()). Readers such as ObUniformBase::to_rows are
+// expected to gate access on evaluated_flags / skip bits, but some operators
+// (e.g. window function + sort fed by an internal SQL with smaller batches)
+// can end up touching slots that were never written by the current batch. On
+// Linux the arena memory is frequently zero by accident, so a misbehaving
+// reader silently sees (ptr=reserve_buf, len=0); on Windows the same arena
+// returns non-zero garbage and we crash with a huge len_ inside MEMCPY.
+//
+// We clear the descriptor only here (right after reset_datums_ptr, which has
+// already anchored ptr_ to the reserve buffer) on the !info->evaluated_
+// branches. Subsequent writers - including eval_vector_func_ /
+// eval_batch_func_ and cast_to_uniform - will overwrite pack_ with the real
+// length before any reader observes the slot, so later init_vector calls
+// (which may see slots already populated by cast_to_uniform) must NOT clear
+// pack_ themselves.
+void ObExpr::clear_datum_descriptors(char *frame, const int64_t size) const
+{
+  ObDatum *datum = reinterpret_cast<ObDatum *>(frame + datum_off_);
+  for (int64_t i = 0; i < size; i++) {
+    datum[i].pack_ = 0;
+  }
+}
+
 void ObExpr::reset_datum_ptr(char *frame, const int64_t size, const int64_t idx) const
 {
   ObDatum *datum = reinterpret_cast<ObDatum *>(frame + datum_off_);
@@ -761,6 +790,8 @@ int ObExpr::eval_one_datum_of_batch(ObEvalCtx &ctx, common::ObDatum *&datum) con
     need_evaluate = true;
     to_bit_vector(frame + eval_flags_off_)->reset(ctx.get_batch_size());
     reset_datums_ptr(frame, ctx.get_batch_size());
+    // See `clear_datum_descriptors` below for the rationale.
+    clear_datum_descriptors(frame, INNER_BATCH_SIZE());
     reset_attrs_datums(ctx);
     info->evaluated_ = true;
     info->cnt_ = ctx.get_batch_size();
@@ -848,6 +879,8 @@ int ObExpr::do_eval_batch(ObEvalCtx &ctx,
     // FIXME bin.lb: maybe we can optimize this by ObEvalInfo::point_to_frame_
     if (!info->evaluated_) {
       reset_datums_ptr(frame, size);
+      // See `clear_datum_descriptors` below for the rationale.
+      clear_datum_descriptors(frame, size);
       reset_attrs_datums(ctx);
       info->notnull_ = false;
       info->point_to_frame_ = true;
@@ -1056,8 +1089,16 @@ int ObExpr::init_vector(ObEvalCtx &ctx,
     int32_t *lens = get_discrete_vector_lens(ctx);
     ObBitVector &nulls = get_nulls(ctx);
     nulls.reset(size);
+#ifdef _WIN32
+    // TODO(windows-uninit-discrete): frame layout (see ObStaticEngineExprCG::create_tmp_frameinfo)
+    // intentionally excludes ptr_arr/len_arr from zero-init; correct callers must gate access on
+    // (row_idx in valid range && !nulls[row_idx]). On Linux arena memory is frequently zero by
+    // accident, so a misbehaving producer/reader silently reads (ptr=NULL, len=0); on Windows the
+    // same arena returns non-zero garbage and we crash. Temporarily zero-fill on Windows to keep
+    // the build running; remove this once the real offending operator is located.
     MEMSET(ptrs, 0, sizeof(char *) * size);
     MEMSET(lens, 0, sizeof(int32_t) * size);
+#endif
     // for collection expr, we need reset ptr to frame, so that we can write collection cells
     if (use_reserve_buf || is_nested_expr()) {
       reset_discretes_ptr(ctx.frames_[frame_idx_], size, get_discrete_vector_ptrs(ctx));

--- a/src/sql/engine/expr/ob_expr.h
+++ b/src/sql/engine/expr/ob_expr.h
@@ -822,6 +822,9 @@ private:
   // reset datums pointer to reserved buffer.
   void reset_datums_ptr(char *frame, const int64_t size) const;
   void reset_datum_ptr(char *frame, const int64_t size, const int64_t idx) const;
+  // Zero the datum descriptor (pack_) for `size` datums in the frame. See
+  // the implementation comment in ob_expr.cpp for the full rationale.
+  void clear_datum_descriptors(char *frame, const int64_t size) const;
 
   void reset_discretes_ptr(char *frame, const int64_t size, char** ptrs) const;
   int eval_one_datum_of_batch(ObEvalCtx &ctx, common::ObDatum *&datum) const;

--- a/tools/windows/installer/wix_launch_configurator.wxs
+++ b/tools/windows/installer/wix_launch_configurator.wxs
@@ -12,6 +12,32 @@
     failed to link for some reason.
   -->
   <Fragment>
+    <!-- Read the configurator exe path persisted to the registry during
+         install.  AppSearch runs early in every session (install, uninstall,
+         repair) so the property is available when custom actions fire.
+         This is critical for uninstall: the Directory-table default for
+         INSTALL_ROOT may revert to the compile-time default, but this
+         property always reflects the ACTUAL installed location.
+
+         Secure="yes" whitelists this property for client -> server transfer.
+         Without it, MSI drops the property with
+           "Ignoring disallowed property SEEKDB_CONFIGURATOR_EXE"
+         during the hop from the non-elevated client UI process to the
+         elevated server Execute process.  Because server-side AppSearch is
+         skipped whenever client-side AppSearch already ran, the property
+         would otherwise be empty when RunConfiguratorRemove is evaluated,
+         silently failing the condition and never launching the uninstall
+         configurator (observed specifically on the
+           double-click MSI -> Maintenance -> Remove  code path).
+         A standalone  <Property Id="SecureCustomProperties" ...>  doesn't
+         work here because CPack WiX already emits that property and ours
+         gets silently dropped on duplicate id; Secure="yes" is the robust
+         way; WiX merges it into the final SecureCustomProperties list. -->
+    <Property Id="SEEKDB_CONFIGURATOR_EXE" Secure="yes">
+      <RegistrySearch Id="FindConfiguratorExe" Root="HKLM"
+                      Key="Software\SeekDB" Name="ConfiguratorExe" Type="raw" />
+    </Property>
+
     <!-- Wire the ExitDialog's Finish button to fire LaunchApplication
          when the checkbox is checked.  WixUI shows the checkbox but
          does NOT include this Publish by default — we must add it.
@@ -22,27 +48,74 @@
                Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed" />
     </UI>
 
-    <!-- Type 34 custom action: fire-and-forget launch of Configurator (install). -->
+    <!-- Type 34 custom action: fire-and-forget launch of Configurator (install).
+         During install [INSTALL_ROOT] is always correctly resolved by the
+         session, so Type 34 (Directory + ExeCommand) works fine here. -->
     <CustomAction Id="LaunchApplication"
                   Directory="INSTALL_ROOT"
                   ExeCommand="&quot;[INSTALL_ROOT]bin\seekdbConfigurator.exe&quot;"
                   Execute="immediate"
                   Return="asyncNoWait" />
 
-    <!-- Type 34 custom action: launch Configurator in remove mode (uninstall).
-         Runs synchronously so removal completes before MSI deletes files.
+    <!-- Type 50 custom action: launch Configurator in remove mode (uninstall).
+         Uses the SEEKDB_CONFIGURATOR_EXE property set by the SetProperty
+         element below immediately before this action fires.
          Return="ignore" ensures uninstall proceeds even if user cancels. -->
     <CustomAction Id="RunConfiguratorRemove"
-                  Directory="INSTALL_ROOT"
-                  ExeCommand="&quot;[INSTALL_ROOT]bin\seekdbConfigurator.exe&quot; --remove"
+                  Property="SEEKDB_CONFIGURATOR_EXE"
+                  ExeCommand="--remove"
                   Execute="immediate"
                   Return="ignore" />
 
+    <!-- (Re)compute SEEKDB_CONFIGURATOR_EXE on the SERVER side right before
+         RunConfiguratorRemove fires.
+
+         Background: AppSearch on the client populates SEEKDB_CONFIGURATOR_EXE
+         from HKLM\Software\SeekDB\ConfiguratorExe, but the property does NOT
+         survive the client -> server hop (CPack's SecureCustomProperties
+         list doesn't include it, and  Secure="yes"  on a Fragment-level
+         property gets silently dropped by CPack's template).  Server-side
+         AppSearch is also skipped because MSI believes client-side AppSearch
+         already ran.  Net result: the property is empty on the server and
+         the  RunConfiguratorRemove  Type 50 CA has no exe path to launch.
+
+         INSTALL_ROOT, however, IS in SecureCustomProperties (added by CPack)
+         and its value (also populated by AppSearch from
+         HKLM\Software\SeekDB\InstallRoot) does reach the server process
+         correctly even when the user installed to a non-default directory.
+         We leverage that to reconstruct the full exe path here.
+
+         NOTE: we use WiX 4's  <SetProperty>  element rather than a hand-
+         authored  <CustomAction Property Value>  + separate  <Custom>  pair,
+         because in this codebase the latter got silently dropped by CPack's
+         WiX 4 linker (it did not appear in the final MSI's CustomAction
+         table).  SetProperty creates both the CA and the sequence entry as
+         one atomic unit that the linker keeps. -->
+    <SetProperty Id="SEEKDB_CONFIGURATOR_EXE"
+                 Value="[INSTALL_ROOT]bin\seekdbConfigurator.exe"
+                 Sequence="execute"
+                 Before="RunConfiguratorRemove"
+                 Condition="Installed AND REMOVE AND (NOT UPGRADINGPRODUCTCODE)" />
+
     <!-- Schedule the removal configurator before files are deleted.
-         Only runs on full uninstall (not upgrades). -->
+         Only runs on uninstall (not fresh install, not upgrades).
+
+         We deliberately avoid  REMOVE="ALL"  string matching because the value
+         differs between code paths:
+           - msiexec /x {ProductCode} (Control Panel / ARP)   -> REMOVE = "ALL"
+           - msiexec /i pkg.msi  + MaintenanceTypeDlg Remove  -> REMOVE = "CM_C_server,ProductFeature"
+         and a case-sensitive compare silently skips the CA in the second case.
+         Case-insensitive compare (~= / =~) is finicky across MSI versions and
+         once caused install-time error 2717 (bad action condition).
+
+         Instead we rely on  Installed AND REMOVE  which is unambiguous: REMOVE
+         is only set (to any non-empty value) when msiexec is actually tearing
+         something down, and Installed guards against running during the very
+         first install session.  UPGRADINGPRODUCTCODE filters out major-upgrade
+         uninstalls where we want a silent handover to the new version. -->
     <InstallExecuteSequence>
       <Custom Action="RunConfiguratorRemove" Before="RemoveFiles"
-              Condition="(REMOVE=&quot;ALL&quot;) AND (NOT UPGRADINGPRODUCTCODE)" />
+              Condition="Installed AND REMOVE AND (NOT UPGRADINGPRODUCTCODE)" />
     </InstallExecuteSequence>
 
     <!-- Add bin/ to system PATH (cleanly removed on uninstall). -->
@@ -52,6 +125,10 @@
                      Permanent="no" Part="last" Action="set" System="yes" />
         <RegistryValue Root="HKLM" Key="Software\SeekDB" Name="PathConfigured"
                        Type="integer" Value="1" KeyPath="yes" />
+        <RegistryValue Root="HKLM" Key="Software\SeekDB" Name="InstallRoot"
+                       Type="string" Value="[INSTALL_ROOT]" />
+        <RegistryValue Root="HKLM" Key="Software\SeekDB" Name="ConfiguratorExe"
+                       Type="string" Value="[INSTALL_ROOT]bin\seekdbConfigurator.exe" />
       </Component>
     </DirectoryRef>
   </Fragment>

--- a/tools/windows/seekdbConfigurator/App.xaml.cs
+++ b/tools/windows/seekdbConfigurator/App.xaml.cs
@@ -46,16 +46,17 @@ public partial class App : System.Windows.Application
         if (!isAdmin)
         {
             Log("Not admin, attempting UAC re-launch...");
+            Process? child = null;
             try
             {
-                var p = Process.Start(new ProcessStartInfo
+                child = Process.Start(new ProcessStartInfo
                 {
                     UseShellExecute = true,
                     FileName = Environment.ProcessPath!,
                     Arguments = argsStr,
                     Verb = "runas",
                 });
-                Log($"Re-launched as admin, child pid={p?.Id}");
+                Log($"Re-launched as admin, child pid={child?.Id}");
             }
             catch (Exception ex)
             {
@@ -63,6 +64,30 @@ public partial class App : System.Windows.Application
                 if (removeMode) { Shutdown(); return; }
                 new MainWindow().Show();
                 return;
+            }
+
+            // When invoked from the MSI uninstall custom action (Type 50,
+            // Execute="immediate"), msiexec launches this exe and waits for
+            // THIS process to exit before advancing to the next action
+            // (RemoveFiles, then the Finish dialog).  Our current process is
+            // only a UAC stub; the real work runs in the elevated child.
+            // If we Shutdown() immediately after spawning it, MSI thinks the
+            // CA is done and the installer UI jumps straight to the Finish
+            // page while the user is still interacting with the configurator.
+            // Block here until the elevated child exits so the installer
+            // stays in sync with the configurator's progress.
+            if (child != null)
+            {
+                try
+                {
+                    Log($"Waiting for elevated child (pid={child.Id}) to exit...");
+                    child.WaitForExit();
+                    Log($"Elevated child exited with code {child.ExitCode}.");
+                }
+                catch (Exception ex)
+                {
+                    Log($"WaitForExit failed: {ex.Message}");
+                }
             }
 
             Shutdown();


### PR DESCRIPTION
### Task Description
## Issue Description
1. seekdb --version lack dll
2. datum core
3. click msi remove can not open configurator

### Solution Description
1. bundle third-party DLLs next to seekdb.exe in build tree
2. fix: zero datum descriptors on first evaluation to prevent garbage len_ crash on Windows
3. fix(windows): launch configurator on double-click MSI Remove path
## Passed Regressions
core test
## Workaround
## Upgrade Compatibility

### Passed Regressions

### Upgrade Compatibility

### Other Information

### Release Note