### PR TITLE
Windows debug vesion is unstable due to the backtrace difference between windows and linux.

### DIFF
--- a/deps/oblib/src/lib/thread/thread.cpp
+++ b/deps/oblib/src/lib/thread/thread.cpp
@@ -124,7 +124,7 @@ int Thread::start()
       pret = pthread_attr_setstacksize(&attr, stack_size_);
       if (pret != 0) {
         // Fallback to default if setstacksize fails
-        pret = 0;
+        pret = 0; 
       } else {
         size_t actual_stack_size = 0;
         pthread_attr_getstacksize(&attr, &actual_stack_size);
@@ -207,7 +207,7 @@ void Thread::stop()
 uint64_t Thread::get_tenant_id() const
 {
   uint64_t tenant_id = OB_SERVER_TENANT_ID;
-  IRunWrapper *run_wrapper_ = threads_->get_effective_run_wrapper();
+  IRunWrapper *run_wrapper_ = threads_->get_run_wrapper();
   if (OB_NOT_NULL(run_wrapper_)) {
     tenant_id = run_wrapper_->id();
   }
@@ -219,7 +219,7 @@ void Thread::run()
   if (OB_NUMA_SHARED_INDEX != numa_node_) {
     AFFINITY_CTRL.thread_bind_to_node(numa_node_);
   }
-  IRunWrapper *run_wrapper_ = threads_->get_effective_run_wrapper();
+  IRunWrapper *run_wrapper_ = threads_->get_run_wrapper();
   if (OB_NOT_NULL(run_wrapper_)) {
     {
       ObDisableDiagnoseGuard disable_guard;
@@ -362,17 +362,15 @@ void Thread::destroy()
 
 void Thread::destroy_stack()
 {
-#ifdef _WIN32
-  pth_ = pthread_null();
-#else
-#if !defined(OB_USE_ASAN)
+#if !defined(_WIN32) && !defined(OB_USE_ASAN)
   if (stack_addr_ != nullptr) {
     g_stack_allocer.dealloc(stack_addr_);
     stack_addr_ = nullptr;
   }
 #endif
-  pth_ = 0;
-#endif
+  // pthread_t is a struct on Windows (pthreads4w), an integer elsewhere;
+  // use pthread_null() so the same code compiles on every platform.
+  pth_ = pthread_null();
 }
 
 void* Thread::__th_start(void *arg)

--- a/deps/oblib/src/lib/thread/thread.cpp
+++ b/deps/oblib/src/lib/thread/thread.cpp
@@ -362,15 +362,15 @@ void Thread::destroy()
 
 void Thread::destroy_stack()
 {
-#if !defined(_WIN32) && !defined(OB_USE_ASAN)
+#ifdef _WIN32
+  pth_ = pthread_null();
+#elif !defined(OB_USE_ASAN)
   if (stack_addr_ != nullptr) {
     g_stack_allocer.dealloc(stack_addr_);
     stack_addr_ = nullptr;
   }
 #endif
-  // pthread_t is a struct on Windows (pthreads4w), an integer elsewhere;
-  // use pthread_null() so the same code compiles on every platform.
-  pth_ = pthread_null();
+  pth_ = 0;
 }
 
 void* Thread::__th_start(void *arg)

--- a/deps/oblib/src/lib/utility/ob_backtrace.cpp
+++ b/deps/oblib/src/lib/utility/ob_backtrace.cpp
@@ -36,6 +36,25 @@ namespace common
 {
 int light_backtrace(void **buffer, int size)
 {
+#ifdef _WIN32
+  // The frame-pointer walking implementation below assumes the System V
+  // x86_64 / AArch64 ABI in which RBP / X29 is a real frame pointer and each
+  // frame is laid out as [saved_fp][return_addr][...]. On Windows x64 (MS
+  // ABI) RBP is just an ordinary non-volatile register and can hold any
+  // value the compiler wants (often a base address into a stack object), so
+  // dereferencing it as a saved-FP chain reads arbitrary memory and crashes
+  // with AccessViolation as soon as the chased value lands outside the
+  // mapped stack region. Use the unwind-table based RtlCaptureStackBackTrace
+  // (the kernel-mode-safe Win32 API) instead.
+  if (OB_UNLIKELY(buffer == nullptr || size <= 0)) {
+    return 0;
+  }
+  USHORT frames = ::CaptureStackBackTrace(/*FramesToSkip=*/1,
+                                          static_cast<ULONG>(size),
+                                          buffer,
+                                          /*BackTraceHash=*/nullptr);
+  return static_cast<int>(frames);
+#else
   int64_t rbp = 0;
 #if defined(__x86_64__)
   asm("mov %%rbp, %0" : "=r"(rbp));
@@ -43,10 +62,19 @@ int light_backtrace(void **buffer, int size)
   asm("mov %0, x29" : "=r"(rbp));
 #endif
   return light_backtrace(buffer, size, rbp);
+#endif
 }
 
 int light_backtrace(void **buffer, int size, int64_t rbp)
 {
+#ifdef _WIN32
+  // The provided rbp is meaningless under the Windows x64 ABI; fall back to
+  // the same unwind-table based capture as the 2-arg overload. This keeps
+  // the signal-handler call site (which only fires on POSIX) compiling on
+  // Windows without exposing it to the broken frame-pointer walk.
+  (void)rbp;
+  return light_backtrace(buffer, size);
+#else
   int rv = 0;
   if (rv < size) {
     int (*fp)(void**, int, int64_t) = light_backtrace;
@@ -57,6 +85,13 @@ int light_backtrace(void **buffer, int size, int64_t rbp)
   if (OB_LIKELY(OB_SUCCESS == get_stackattr(stack_addr, stack_size))) {
 #define addr_in_stack(addr) (addr >= (int64_t)stack_addr && addr < (int64_t)stack_addr + stack_size)
     while (rbp != 0 && rv < size) {
+      // Validate rbp itself before dereferencing it -- otherwise a bogus
+      // saved-FP value silently chained from the previous iteration can
+      // point at unmapped memory and the deref below would crash before
+      // the addr_in_stack check on its loaded value can run.
+      if (!addr_in_stack(rbp)) {
+        break;
+      }
 #if defined(__aarch64__)
       if (!addr_in_stack(*(int64_t*)rbp) &&
           !FALSE_IT(rbp += 16) &&
@@ -71,8 +106,10 @@ int light_backtrace(void **buffer, int size, int64_t rbp)
         rbp = *(int64_t*)rbp;
       }
     }
+#undef addr_in_stack
   }
   return rv;
+#endif
 }
 
 bool read_min_max_addr(int64_t &min_addr, int64_t &max_addr)

--- a/src/objit/CMakeLists.txt
+++ b/src/objit/CMakeLists.txt
@@ -57,13 +57,10 @@ endif()
 # Find the libraries that correspond to the LLVM components
 # that we wish to use
 if(NOT BUILD_EMBED_MODE)
-  # On Windows ${ARCHITECTURE} is taken from $env:PROCESSOR_ARCHITECTURE which
-  # is "amd64" on 64-bit Windows (see cmake/Env.cmake), so treat both
-  # "x86_64" and "amd64" as the X86_64 family.
-  if( ${ARCHITECTURE} STREQUAL "x86_64" OR ${ARCHITECTURE} STREQUAL "amd64" )
-    LLVM_MAP_COMPONENTS_TO_LIBNAMES(llvm_libs Support Core IRReader ExecutionEngine OrcJit McJit X86CodeGen X86AsmParser X86Desc X86Info X86Disassembler runtimedyld bitreader bitwriter object objectyaml target DebugInfoDWARF Symbolize)
+  if( ${ARCHITECTURE} STREQUAL "x86_64" )
+    LLVM_MAP_COMPONENTS_TO_LIBNAMES(llvm_libs Support Core IRReader ExecutionEngine OrcJit McJit X86CodeGen X86AsmParser runtimedyld bitreader bitwriter object objectyaml target DebugInfoDWARF Symbolize)
   else()
-    LLVM_MAP_COMPONENTS_TO_LIBNAMES(llvm_libs Support Core IRReader ExecutionEngine OrcJit McJit AArch64CodeGen AArch64AsmParser AArch64Desc AArch64Info AArch64Disassembler runtimedyld bitreader bitwriter object objectyaml target DebugInfoDWARF Symbolize)
+    LLVM_MAP_COMPONENTS_TO_LIBNAMES(llvm_libs Support Core IRReader ExecutionEngine OrcJit McJit AArch64CodeGen AArch64AsmParser runtimedyld bitreader bitwriter object objectyaml target DebugInfoDWARF Symbolize)
   endif()
   set(CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
   include(${LLVM_CMAKE_DIR}/HandleLLVMOptions.cmake)

--- a/src/objit/CMakeLists.txt
+++ b/src/objit/CMakeLists.txt
@@ -57,10 +57,13 @@ endif()
 # Find the libraries that correspond to the LLVM components
 # that we wish to use
 if(NOT BUILD_EMBED_MODE)
+  # On Windows ${ARCHITECTURE} is taken from $env:PROCESSOR_ARCHITECTURE which
+  # is "amd64" on 64-bit Windows (see cmake/Env.cmake), so treat both
+  # "x86_64" and "amd64" as the X86_64 family.
   if( ${ARCHITECTURE} STREQUAL "x86_64" OR ${ARCHITECTURE} STREQUAL "amd64" )
-    LLVM_MAP_COMPONENTS_TO_LIBNAMES(llvm_libs Support Core IRReader ExecutionEngine OrcJit McJit X86CodeGen X86AsmParser runtimedyld bitreader bitwriter object objectyaml target DebugInfoDWARF Symbolize)
+    LLVM_MAP_COMPONENTS_TO_LIBNAMES(llvm_libs Support Core IRReader ExecutionEngine OrcJit McJit X86CodeGen X86AsmParser X86Desc X86Info X86Disassembler runtimedyld bitreader bitwriter object objectyaml target DebugInfoDWARF Symbolize)
   else()
-    LLVM_MAP_COMPONENTS_TO_LIBNAMES(llvm_libs Support Core IRReader ExecutionEngine OrcJit McJit AArch64CodeGen AArch64AsmParser runtimedyld bitreader bitwriter object objectyaml target DebugInfoDWARF Symbolize)
+    LLVM_MAP_COMPONENTS_TO_LIBNAMES(llvm_libs Support Core IRReader ExecutionEngine OrcJit McJit AArch64CodeGen AArch64AsmParser AArch64Desc AArch64Info AArch64Disassembler runtimedyld bitreader bitwriter object objectyaml target DebugInfoDWARF Symbolize)
   endif()
   set(CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
   include(${LLVM_CMAKE_DIR}/HandleLLVMOptions.cmake)


### PR DESCRIPTION
## Task Description
Windows debug vesion is unstable due to the backtrace difference between windows and linux.
## Solution Description
The backtrace in linux is based on RBP list,which in windows is just a normal register.So when trace down,seekdb will read a trash addr in rbp.
Solution:changed the backrace logic in windows,which use CaptureStackBackTrace api.
## Passed Regressions
core-test
## Upgrade Compatibility
## Other Info
## Related links
- DIMA-2026051800116159657