### PR TITLE
excute plan is negative

### DIFF
--- a/deps/oblib/src/lib/oblog/ob_log.cpp
+++ b/deps/oblib/src/lib/oblog/ob_log.cpp
@@ -170,8 +170,21 @@ int logdata_vprintf(char *buf, const int64_t buf_len, int64_t &pos, const char *
           while (*src == '-' || *src == '+' || *src == ' ' || *src == '#' || *src == '0' || *src == '\'') {
             if (*src == '\'') { src++; } else { *dst++ = *src++; }
           }
-          while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
-          if (*src == '.') { *dst++ = *src++; while (*src >= '0' && *src <= '9') { *dst++ = *src++; } }
+          // width: either '*' or digits
+          if (*src == '*') {
+            *dst++ = *src++;
+          } else {
+            while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
+          }
+          // precision: '.' followed by '*' or digits
+          if (*src == '.') {
+            *dst++ = *src++;
+            if (*src == '*') {
+              *dst++ = *src++;
+            } else {
+              while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
+            }
+          }
           if (*src == 'l' && *(src+1) == 'l') {
             *dst++ = *src++; *dst++ = *src++;
           } else if (*src == 'l' && (*(src+1) == 'd' || *(src+1) == 'i' || *(src+1) == 'o' ||

--- a/deps/oblib/src/lib/string/ob_sql_string.cpp
+++ b/deps/oblib/src/lib/string/ob_sql_string.cpp
@@ -213,8 +213,21 @@ int ObSqlString::vappend(const char *fmt, va_list ap)
           while (*src == '-' || *src == '+' || *src == ' ' || *src == '#' || *src == '0' || *src == '\'') {
             if (*src == '\'') { src++; } else { *dst++ = *src++; }
           }
-          while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
-          if (*src == '.') { *dst++ = *src++; while (*src >= '0' && *src <= '9') { *dst++ = *src++; } }
+          // width: either '*' or digits
+          if (*src == '*') {
+            *dst++ = *src++;
+          } else {
+            while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
+          }
+          // precision: '.' followed by '*' or digits
+          if (*src == '.') {
+            *dst++ = *src++;
+            if (*src == '*') {
+              *dst++ = *src++;
+            } else {
+              while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
+            }
+          }
           if (*src == 'l' && *(src+1) == 'l') {
             *dst++ = *src++; *dst++ = *src++;
           } else if (*src == 'l' && (*(src+1) == 'd' || *(src+1) == 'i' || *(src+1) == 'o' ||

--- a/deps/oblib/src/lib/utility/ob_print_utils.cpp
+++ b/deps/oblib/src/lib/utility/ob_print_utils.cpp
@@ -484,8 +484,21 @@ int databuff_vprintf(char *buf, const int64_t buf_len, int64_t &pos, const char 
           while (*src == '-' || *src == '+' || *src == ' ' || *src == '#' || *src == '0' || *src == '\'') {
             if (*src == '\'') { src++; } else { *dst++ = *src++; }
           }
-          while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
-          if (*src == '.') { *dst++ = *src++; while (*src >= '0' && *src <= '9') { *dst++ = *src++; } }
+          // width: either '*' or digits
+          if (*src == '*') {
+            *dst++ = *src++;
+          } else {
+            while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
+          }
+          // precision: '.' followed by '*' or digits
+          if (*src == '.') {
+            *dst++ = *src++;
+            if (*src == '*') {
+              *dst++ = *src++;
+            } else {
+              while (*src >= '0' && *src <= '9') { *dst++ = *src++; }
+            }
+          }
           if (*src == 'l' && *(src+1) == 'l') {
             *dst++ = *src++; *dst++ = *src++;
           } else if (*src == 'l' && (*(src+1) == 'd' || *(src+1) == 'i' || *(src+1) == 'o' ||


### PR DESCRIPTION
## Issue Description
the format string is %ld or %ld,which need translation in windows.but we ignored %*ld,resulting 32bit truncation.
## Fixed branches
master
## Fix Description
fixed format string translation.
## Passed Regressions
core-test
## Workaround
## Upgrade Compatibility
## Other Info
## Related links
- DIMA-2026041600115466994