### PR TITLE
Fix -Wincompatible-pointer-types-discards-qualifiers warning in speedtest1.c

### DIFF
--- a/sqlite-benchmark/speedtest1.c
+++ b/sqlite-benchmark/speedtest1.c
@@ -363,8 +363,8 @@ unsigned roundup_allones(unsigned limit){
 **     speedtest1_numbername(123)   ->  "one hundred twenty three"
 */
 int speedtest1_numbername(unsigned int n, char *zOut, int nOut){
-  static const char *ones[] = {  "zero", "one", "two", "three", "four", "five",
-                  "six", "seven", "eight", "nine", "ten", "eleven", "twelve",
+  static const char *ones[] = {  "zero", "one", "two", "three", "four", "five", 
+                  "six", "seven", "eight", "nine", "ten", "eleven", "twelve", 
                   "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
                   "eighteen", "nineteen" };
   static const char *tens[] = { "", "ten", "twenty", "thirty", "forty",
@@ -506,7 +506,7 @@ static void printSql(const char *zSql){
   if( g.bExplain ) printf("EXPLAIN ");
   printf("%.*s;\n", n, zSql);
   if( g.bExplain
-#if SQLITE_VERSION_NUMBER>=3007017
+#if SQLITE_VERSION_NUMBER>=3007017 
    && ( sqlite3_strglob("CREATE *", zSql)==0
      || sqlite3_strglob("DROP *", zSql)==0
      || sqlite3_strglob("ALTER *", zSql)==0
@@ -569,7 +569,7 @@ char *speedtest1_once(const char *zFormat, ...){
       fatal_error("SQL error: %s\n", sqlite3_errmsg(g.db));
     }
     if( g.pScript ){
-      const char *z = sqlite3_expanded_sql(pStmt);
+      char *z = sqlite3_expanded_sql(pStmt);
       fprintf(g.pScript,"%s\n",z);
       sqlite3_free(z);
     }
@@ -611,7 +611,7 @@ void speedtest1_run(void){
   assert( g.pStmt );
   g.nResult = 0;
   if( g.pScript ){
-    const char *z = sqlite3_expanded_sql(g.pStmt);
+    char *z = sqlite3_expanded_sql(g.pStmt);
     fprintf(g.pScript,"%s\n",z);
     sqlite3_free(z);
   }
@@ -1607,12 +1607,12 @@ int main(int argc, char **argv){
     printf("-- Page cache misses:           %d\n", iCur);
 #if SQLITE_VERSION_NUMBER>=3007012
     sqlite3_db_status(g.db, SQLITE_DBSTATUS_CACHE_WRITE, &iCur, &iHi, 1);
-    printf("-- Page cache writes:           %d\n", iCur);
+    printf("-- Page cache writes:           %d\n", iCur); 
 #endif
     sqlite3_db_status(g.db, SQLITE_DBSTATUS_SCHEMA_USED, &iCur, &iHi, 0);
-    printf("-- Schema Heap Usage:           %d bytes\n", iCur);
+    printf("-- Schema Heap Usage:           %d bytes\n", iCur); 
     sqlite3_db_status(g.db, SQLITE_DBSTATUS_STMT_USED, &iCur, &iHi, 0);
-    printf("-- Statement Heap Usage:        %d bytes\n", iCur);
+    printf("-- Statement Heap Usage:        %d bytes\n", iCur); 
   }
 #endif
 


### PR DESCRIPTION
## Description
During compilation of `sqlite-benchmark/speedtest1.c`, two instances of the `-Wincompatible-pointer-types-discards-qualifiers` warning are generated.

The function `sqlite3_expanded_sql` returns a `char *` (non-const, requiring the caller to free it using `sqlite3_free`). However, the code uses a `const char *` to receive this pointer. This leads to discarding the const qualifier when the pointer is later passed to `sqlite3_free(void*)`.

## Environment
- OS: Linux

## Related Links
- DIMA-2026052000116213423