### PR TITLE
Add release_embedded build mode to support building on platform

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -245,6 +245,9 @@ function build
       xrelease_coverage)
         do_build "$@" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOB_USE_LLD=$LLD_OPTION -DWITH_COVERAGE=ON
         ;;
+      xrelease_embedded)
+        do_build "$@" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOB_USE_LLD=$LLD_OPTION -DBUILD_EMBED_MODE=ON
+        ;;
       xdebug)
         do_build "$@" -DCMAKE_BUILD_TYPE=Debug -DOB_USE_LLD=$LLD_OPTION
         ;;


### PR DESCRIPTION
## Task Description
Add a `release_embedded` build mode so that it can be compiled directly on the binary build platform.
By default, the Python build is disabled; the related code will be removed later.

## Solution Description

## Passed Regressions

## Upgrade Compatibility

## Other Information
- DIMA-2026042900115842761

## Release Note
