### PR TITLE
Reduce seekdb stripped binary from 362M to 318M (-12.1%)

### DIFF
--- a/cmake/Env.cmake
+++ b/cmake/Env.cmake
@@ -53,7 +53,7 @@ ob_define(OB_ENABLE_UNITY ON)
 
 ob_define(OB_DISABLE_LSE OFF)
 
-ob_define(OB_DISABLE_PIE OFF)
+ob_define(OB_DISABLE_PIE ON)
 
 ob_define(OB_ENABLE_MCMODEL OFF)
 
@@ -378,7 +378,7 @@ if (OB_USE_CLANG)
     elseif(UNIX)
       set(LD_OPT "-fuse-ld=${DEVTOOLS_DIR}/bin/ld.lld -Wno-unused-command-line-argument")
       set(REORDER_COMP_OPT "-ffunction-sections -fdata-sections -fdebug-info-for-profiling")
-      set(REORDER_LINK_OPT "-Wl,--no-rosegment,--build-id=sha1,--gc-sections,--icf=safe ${HOTFUNC_OPT}")
+      set(REORDER_LINK_OPT "-Wl,--no-rosegment,--build-id=sha1,--gc-sections,--icf=all ${HOTFUNC_OPT}")
       set(OB_LD_BIN "${DEVTOOLS_DIR}/bin/ld.lld")
     endif()
   endif()


### PR DESCRIPTION
## Task Description
Reduce the size of the stripped seekdb binary.

## Solution Description
1. Disable PIE (Position Independent Executable).
2. Use linker flag `--icf=all` (Identical Code Folding).

Results:
```
┌─────────────────┬──────────────────┬────────────────┬─────────────┬────────┐
│ 指标            │ base (fa27dbefa) │ HEAD (4ee730e) │ 减少        │ 降幅   │
├─────────────────┼──────────────────┼────────────────┼─────────────┼────────┤
│ stripped 二进制 │ 362M             │ 318M           │ -44M        │ -12.1% │
├─────────────────┼──────────────────┼────────────────┼─────────────┼────────┤
│ .text (代码段)  │ 361,793,829      │ 316,132,730    │ -45,661,099 │ -12.6% │
├─────────────────┼──────────────────┼────────────────┼─────────────┼────────┤
│ .data           │ 16,824,984       │ 16,633,016     │ -191,968    │ -1.1%  │
├─────────────────┼──────────────────┼────────────────┼─────────────┼────────┤
│ .bss            │ 10,361,626       │ 10,361,626     │ 0           │ 0%     │
├─────────────────┼──────────────────┼────────────────┼─────────────┼────────┤
│ ELF type        │ DYN (PIE)        │ EXEC (fixed)   │ —           │ —      │
└─────────────────┴──────────────────┴────────────────┴─────────────┴────────┘
```

## Passed Regressions

## Upgrade Compatibility

## Other Information
- Related internal link: DIMA-2026060100116469409

## Release Note
Reduced the size of the stripped seekdb binary by 12.1% (44M) by disabling PIE and enabling Identical Code Folding (ICF).