### PR TITLE
Fix invalid free of KV cache node

### DIFF
--- a/src/share/cache/ob_kvcache_hazard_version.cpp
+++ b/src/share/cache/ob_kvcache_hazard_version.cpp
@@ -96,7 +96,8 @@ void ObKVCacheHazardSlot::retire(const uint64_t version, const uint64_t tenant_i
       while (head != nullptr) {
         temp_node = head;
         head = head->get_next();
-        if (temp_node->get_version() < version || tenant_id == temp_node->tenant_id_) {
+        if (temp_node->get_version() < version ||
+            (tenant_id != OB_INVALID_TENANT_ID && tenant_id == temp_node->tenant_id_)) {
           temp_node->retire();
           temp_node = nullptr;
           ++retire_count;

--- a/src/share/cache/ob_kvcache_map.cpp
+++ b/src/share/cache/ob_kvcache_map.cpp
@@ -245,6 +245,7 @@ int ObKVCacheMap::put(
         } else {
           new_node = new (buf) Node();
           // set new node
+          new_node->tenant_id_ = OB_SYS_TENANT_ID;
           new_node->inst_ = &inst;
           new_node->hash_code_ = hash_code;
           new_node->mb_handle_ = hazptr_holder.get_mb_handle();


### PR DESCRIPTION
## Task Description
Fix a core dump issue caused by accessing illegal memory when using the kvcache for information collection.

## Solution Description
The issue was an invalid free of a kvcache node, which led to accessing an illegal `mb_handle` and triggered illegal memory access.

During node recycling (retire), the judgment condition included `tenant_id == temp_node->tenant_id_`. The `tenant_id` passed during retire was 0, but the node never had its `tenant_id` set correctly, so this condition was always true.

The fix modifies the node creation to set `tenant_id = sys tenant id`. Additionally, the retire judgment condition is updated to include `tenant_id != 0`.

> For more detailed information, please refer to: https://project.alipay.com/workItem?workItemId=2026060800116606444

## Passed Regressions

## Upgrade Compatibility

## Other Information
- Related link: DIMA-2026060800116606444

## Release Note