### PR TITLE
Vector APPROXIMATE search fails with -4016 Internal error when the filter column has a prefix-length index

### DIFF
--- a/deps/oblib/src/lib/CMakeLists.txt
+++ b/deps/oblib/src/lib/CMakeLists.txt
@@ -387,6 +387,7 @@ ob_set_subtarget(oblib_lib utility
   utility/ob_backtrace.cpp
   utility/ob_proto_trans_util.cpp
   utility/ob_unify_serialize.cpp
+  utility/ob_rpc_authentication_utility.cpp
   utility/ob_hyperloglog.cpp
 )
 

--- a/deps/oblib/src/lib/ob_define.h
+++ b/deps/oblib/src/lib/ob_define.h
@@ -614,8 +614,6 @@ const int64_t OB_MAX_PACKET_DECODE_TS = 10 * 1000L;
  */
 const uint32_t OB_NET_HEADER_LENGTH = 16;            // 16 bytes packet header
 const uint32_t OB_MAX_RPC_PACKET_LENGTH = (1L << 24);
-// Default RPC timeout (was obcall::ObCallProxy::MAX_RPC_TIMEOUT).
-const int64_t OB_DEFAULT_RPC_TIMEOUT = 9000 * 1000;  // 9s
 
 const int OB_TBNET_PACKET_FLAG = 0x416e4574;
 const int OB_SERVER_ADDR_STR_LEN = 128; //used for buffer size of easy_int_addr_to_str

--- a/deps/oblib/src/lib/thread/thread.h
+++ b/deps/oblib/src/lib/thread/thread.h
@@ -22,8 +22,7 @@
 #include "lib/utility/ob_macro_utils.h"
 #include "lib/lock/ob_latch.h"
 #include "lib/net/ob_addr.h"
-#include "io/easy_io_struct.h"   // easy_addr_t (RpcGuard); formerly via ob_call_packet.h
-#include "rpc/frame/ob_req_packet_code.h"
+#include "rpc/obrpc/ob_rpc_packet.h"
 
 // Windows PThreads4W: pthread_t is a struct, not an integer
 #ifdef _WIN32

--- a/deps/oblib/src/rpc/obrpc/ob_rpc_proxy.ipp
+++ b/deps/oblib/src/rpc/obrpc/ob_rpc_proxy.ipp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_RPC_OBRPC_OB_RPC_PROXY_IPP_
+#define OCEANBASE_RPC_OBRPC_OB_RPC_PROXY_IPP_
+
+#include "lib/compress/ob_compressor.h"
+#include "lib/utility/ob_macro_utils.h"
+#include "lib/utility/serialization.h"
+#include "lib/utility/utility.h"
+#include "lib/oblog/ob_trace_log.h"
+#include "lib/stat/ob_diagnose_info.h"
+#include "lib/statistic_event/ob_stat_event.h"
+#include "lib/trace/ob_trace.h"
+#include "rpc/obrpc/ob_irpc_extra_payload.h"
+#include "lib/stat/ob_diagnostic_info_guard.h"
+#include "rpc/obrpc/ob_local_procedure_call.h"
+
+namespace oceanbase
+{
+namespace obrpc
+{
+
+template <class pcodeStruct>
+SSHandle<pcodeStruct>::~SSHandle()
+{
+  if (true == has_more_ && first_pkt_id_ != INVALID_RPC_PKT_ID) {
+    RPC_OBRPC_LOG_RET(WARN, OB_ERROR, "stream rpc is forgotten to abort", K_(pcode), K_(first_pkt_id));
+    this->abort();
+  }
+}
+
+template <class pcodeStruct>
+bool SSHandle<pcodeStruct>::has_more() const
+{
+  return has_more_;
+}
+
+template <class pcodeStruct>
+int SSHandle<pcodeStruct>::get_more(typename pcodeStruct::Response &result)
+{
+  int ret = OB_SUCCESS;
+  ret = OB_NOT_SUPPORTED;
+  RPC_OBRPC_LOG(ERROR, "it should not be reach here, observer-lite is not supported for stream rpc", K(has_more_), K(pcode_));
+  ob_abort();
+  return ret;
+}
+
+template <class pcodeStruct>
+int SSHandle<pcodeStruct>::abort()
+{
+  int ret = OB_SUCCESS;
+  ret = OB_NOT_SUPPORTED;
+  RPC_OBRPC_LOG(ERROR, "it should not be reach here, observer-lite is not supported for stream rpc", K(has_more_), K(pcode_));
+  ob_abort();
+  return ret;
+}
+
+template <class pcodeStruct>
+const ObRpcResultCode &SSHandle<pcodeStruct>::get_result_code() const
+{
+  return rcode_;
+}
+
+template <class pcodeStruct>
+int ObRpcProxy::AsyncCB<pcodeStruct>::decode(void *pkt)
+{
+  using namespace oceanbase::common;
+  using namespace rpc::frame;
+  int ret   = OB_SUCCESS;
+
+  if (OB_ISNULL(pkt)) {
+    ret = OB_INVALID_ARGUMENT;
+    RPC_OBRPC_LOG(WARN, "pkt should not be NULL", K(ret));
+  }
+
+  if (OB_SUCC(ret)) {
+    ObRpcPacket  *rpkt = reinterpret_cast<ObRpcPacket*>(pkt);
+    const char   *buf  = rpkt->get_cdata();
+    int64_t      len   = rpkt->get_clen();
+    int64_t      pos   = 0;
+    UNIS_VERSION_GUARD(rpkt->get_unis_version());
+    char *uncompressed_buf = NULL;
+
+    if (OB_FAIL(rpkt->verify_checksum())) {
+      RPC_OBRPC_LOG(ERROR, "verify checksum fail", K(*rpkt), K(ret));
+    }
+    if (OB_SUCC(ret)) {
+      const common::ObCompressorType &compressor_type = rpkt->get_compressor_type();
+      if (common::INVALID_COMPRESSOR != compressor_type) {
+        // uncompress
+        const int32_t original_len = rpkt->get_original_len();
+        common::ObCompressor *compressor = NULL;
+        int64_t dst_data_size = 0;
+        if (OB_FAIL(common::ObCompressorPool::get_instance().get_compressor(compressor_type, compressor))) {
+          RPC_OBRPC_LOG(WARN, "get_compressor failed", K(ret), K(compressor_type));
+        } else if (NULL == (uncompressed_buf =
+                                   static_cast<char *>(common::ob_malloc(original_len, common::ObModIds::OB_RPC)))) {
+          ret = common::OB_ALLOCATE_MEMORY_FAILED;
+          RPC_OBRPC_LOG(WARN, "Allocate memory failed", K(ret));
+        } else if (OB_FAIL(compressor->decompress(buf, len, uncompressed_buf, original_len, dst_data_size))) {
+          RPC_OBRPC_LOG(WARN, "decompress failed", K(ret));
+        } else if (dst_data_size != original_len) {
+          ret = common::OB_ERR_UNEXPECTED;
+          RPC_OBRPC_LOG(ERROR, "decompress len not match", K(ret), K(dst_data_size), K(original_len));
+        } else {
+          RPC_OBRPC_LOG(DEBUG, "uncompress result success", K(compressor_type), K(len), K(original_len));
+          // replace buf
+          buf = uncompressed_buf;
+          len = original_len;
+        }
+      }
+    }
+    if (OB_SUCC(ret)) {
+      ACTIVE_SESSION_FLAG_SETTER_GUARD(in_rpc_decode);
+      if (OB_FAIL(rcode_.deserialize(buf, len, pos))) {
+        RPC_OBRPC_LOG(WARN, "decode result code fail", K(*rpkt), K(ret));
+      } else if (rcode_.rcode_ != OB_SUCCESS) {
+        // RPC_OBRPC_LOG(WARN, "execute rpc fail", K_(rcode));
+      } else if (OB_FAIL(result_.deserialize(buf, len, pos))) {
+        RPC_OBRPC_LOG(WARN, "decode packet fail", K(ret));
+      } else {
+        // do nothing
+      }
+    }
+    // free the uncompress buffer
+    if (NULL != uncompressed_buf) {
+      common::ob_free(uncompressed_buf);
+      uncompressed_buf = NULL;
+    }
+  }
+  return ret;
+}
+template <class pcodeStruct>
+int ObRpcProxy::AsyncCB<pcodeStruct>::get_rcode()
+{
+  return rcode_.rcode_;
+}
+
+/*
+template <class pcodeStruct>
+void ObRpcProxy::AsyncCB<pcodeStruct>::check_request_rt(const bool force_print)
+{
+  if (force_print
+      || req_->client_send_time - req_->client_start_time > REQUEST_ITEM_COST_RT
+      || req_->client_connect_time - req_->client_send_time > REQUEST_ITEM_COST_RT
+      || req_->client_write_time - req_->client_connect_time > REQUEST_ITEM_COST_RT
+      || req_->request_arrival_time - req_->client_write_time > REQUEST_ITEM_COST_RT
+      || req_->arrival_push_diff > REQUEST_ITEM_COST_RT
+      || req_->push_pop_diff > REQUEST_ITEM_COST_RT
+      || req_->pop_process_start_diff > REQUEST_ITEM_COST_RT
+      || req_->process_start_end_diff > REQUEST_ITEM_COST_RT
+      || req_->process_end_response_diff > REQUEST_ITEM_COST_RT
+      || (req_->client_read_time - req_->request_arrival_time - req_->arrival_push_diff - req_->push_pop_diff
+        - req_->pop_process_start_diff - req_->process_start_end_diff - req_->process_end_response_diff) > REQUEST_ITEM_COST_RT
+      || req_->client_end_time - req_->client_read_time > REQUEST_ITEM_COST_RT) {
+
+    if (TC_REACH_TIME_INTERVAL(100 * 1000)) {
+      _RPC_OBRPC_LOG(INFO,
+          "rpc time, packet_id :%lu, client_start_time :%ld, start_send_diff :%ld, "
+          "send_connect_diff: %ld, connect_write_diff: %ld, request_fly_ts: %ld, "
+          "arrival_push_diff: %d, push_pop_diff: %d, pop_process_start_diff :%d, "
+          "process_start_end_diff: %d, process_end_response_diff: %d, response_fly_ts: %ld, "
+          "read_end_diff: %ld, client_end_time :%ld",
+          req_->packet_id,
+          req_->client_start_time,
+          req_->client_send_time - req_->client_start_time,
+          req_->client_connect_time - req_->client_send_time,
+          req_->client_write_time - req_->client_connect_time,
+          req_->request_arrival_time - req_->client_write_time,
+          req_->arrival_push_diff,
+          req_->push_pop_diff,
+          req_->pop_process_start_diff,
+          req_->process_start_end_diff,
+          req_->process_end_response_diff,
+          req_->client_read_time - req_->request_arrival_time - req_->arrival_push_diff - req_->push_pop_diff
+          - req_->pop_process_start_diff - req_->process_start_end_diff - req_->process_end_response_diff,
+          req_->client_end_time - req_->client_read_time,
+          req_->client_end_time);
+    }
+  }
+}
+*/
+
+template <typename Input, typename Out>
+int ObRpcProxy::rpc_call(ObRpcPacketCode pcode, const Input &args,
+                         Out &result, Handle *handle, const ObRpcOpts &opts)
+{
+  using namespace oceanbase::common;
+  using namespace rpc::frame;
+  int ret = OB_SUCCESS;
+  UNIS_VERSION_GUARD(opts.unis_version_);
+
+  const int64_t start_ts = ObTimeUtility::current_time();
+
+  if (!init_) {
+    ret = OB_NOT_INIT;
+    RPC_OBRPC_LOG(WARN, "Rpc proxy not inited", K(ret));
+  } else if (!active_) {
+    ret = OB_INACTIVE_RPC_PROXY;
+    RPC_OBRPC_LOG(WARN, "Rpc proxy inactive", K(ret));
+  } else {
+    //do nothing
+  }
+  if (dst_ == ObRpcProxy::myaddr_) {
+    ret = oceanbase::oblpc::send(*this, pcode, args, result, handle, opts);
+  } else {
+    ret = OB_NOT_SUPPORTED;
+    RPC_OBRPC_LOG(ERROR, "send rpc to other dst is not supported", K_(dst));
+  }
+
+  return ret;
+}
+
+template <class pcodeStruct>
+int ObRpcProxy::rpc_post(const typename pcodeStruct::Request &args,
+                         AsyncCB<pcodeStruct> *cb, const ObRpcOpts &opts)
+{
+  using namespace oceanbase::common;
+  using namespace rpc::frame;
+  int ret = OB_SUCCESS;
+  int tmp_ret = OB_SUCCESS;
+  UNIS_VERSION_GUARD(opts.unis_version_);
+
+  common::ObTimeGuard timeguard("rpc post", 10 * 1000);
+  const int64_t start_ts = ObTimeUtility::current_time();
+
+  if (!init_) {
+    ret = OB_NOT_INIT;
+    RPC_OBRPC_LOG(WARN, "rpc not inited", K(ret));
+  } else if (!active_) {
+    ret = OB_INACTIVE_RPC_PROXY;
+    RPC_OBRPC_LOG(WARN, "rpc is inactive", K(ret));
+  }
+  if (dst_ == ObRpcProxy::myaddr_) {
+    ret = oceanbase::oblpc::post(*this, pcodeStruct::PCODE, args, cb, opts);
+  } else {
+    ret = OB_NOT_SUPPORTED;
+    RPC_OBRPC_LOG(ERROR, "send rpc to other dst is not supported", K_(dst));
+  }
+  return ret;
+}
+
+
+
+
+} // end of namespace rpc
+} // end of namespace oceanbase
+
+
+#endif //OCEANBASE_RPC_OBRPC_OB_RPC_PROXY_IPP_

--- a/src/diagnose/lua/ob_lua_api.cpp
+++ b/src/diagnose/lua/ob_lua_api.cpp
@@ -48,7 +48,7 @@ using namespace common;
 using namespace diagnose;
 using namespace oceanbase::observer;
 using namespace oceanbase::rpc::frame;
-using namespace obcall;
+using namespace obrpc;
 using namespace rpc;
 using namespace sql;
 using namespace transaction;

--- a/src/libtable/src/ob_table_service_client.cpp
+++ b/src/libtable/src/ob_table_service_client.cpp
@@ -23,6 +23,7 @@
 #include "ob_table_service_config.h"
 
 #include "lib/encrypt/ob_encrypted_helper.h"
+#include "rpc/obrpc/ob_net_client.h"      // ObNetClient
 #include "sql/session/ob_sql_session_info.h"
 #include "ob_tablet_location_proxy.h"
 #include "observer/ob_signal_handle.h"
@@ -63,6 +64,7 @@ public:
   bool inited() const { return inited_; }
   share::schema::ObMultiVersionSchemaService &get_schema_service() { return schema_service_; }
   ObITabletLocationGetter &get_location_getter() { return *location_getter_; }
+  obrpc::ObTableRpcProxy &get_table_rpc_proxy() { return table_rpc_proxy_; }
   int get_timer_tg_id() const { return tg_id_; }
   const ObAddr &get_one_server() { return addr_; }
 
@@ -97,7 +99,8 @@ private:
   ObTabletLocationCache location_cache_;
   ObITabletLocationGetter *location_getter_;
   // for Table API proxy
-  obcall::ObNetClient net_client_;
+  obrpc::ObNetClient net_client_;
+  obrpc::ObTableRpcProxy table_rpc_proxy_;
 };
 
 ObTableServiceClientEnv::~ObTableServiceClientEnv()
@@ -160,7 +163,9 @@ int ObTableServiceClientEnv::init_net_client(int64_t net_io_thread_num, const Ob
     LOG_WARN("failed to set addr", K(host), K(port));
   } else if (OB_FAIL(net_client_.init(opt))) {
     LOG_ERROR("init net client fail", K(ret), K(net_io_thread_num));
-  } else { // Table-API RPC proxy removed (feature decommissioned)
+  } else if (OB_FAIL(net_client_.get_proxy(table_rpc_proxy_))) {
+    LOG_ERROR("net client get proxy fail", K(ret));
+  } else {
     LOG_INFO("init rpc succ", K(net_io_thread_num));
   }
   return ret;
@@ -343,6 +348,7 @@ public:
   int get_table_id(const ObString &table_name, uint64_t &table_id);
 
   common::ObMySQLProxy &get_user_sql_client() { return user_sql_client_; }
+  obrpc::ObTableRpcProxy &get_table_rpc_proxy() { return client_env_->get_table_rpc_proxy(); }
   uint64_t get_tenant_id() const { return tenant_id_; }
   uint64_t get_database_id() const { return database_id_; }
   const ObString &get_credential() const { return credential_; }
@@ -507,9 +513,11 @@ int ObTableServiceClientImpl::verify_user(const ObString &tenant, const ObString
   } else {
     login_request.pass_secret_.assign_ptr(pass_secret_buf, static_cast<int32_t>(pos));
     ObTableLoginResult login_result;
-    // Table-API RPC removed (feature decommissioned)
-    if (OB_FAIL((ret = OB_NOT_SUPPORTED))) {
-      LOG_WARN("login failed: Table-API RPC removed", K(ret), K(login_request));
+    if (OB_FAIL(client_env_->get_table_rpc_proxy()
+                .to(client_env_->get_one_server())
+                .as(OB_SYS_TENANT_ID)
+                .login(login_request, login_result))) {
+      LOG_WARN("login failed", K(ret), K(login_request));
     } else if (256 < login_result.credential_.length()) {
       ret = OB_ERR_UNEXPECTED;
       LOG_ERROR("credential is too long", K(ret), K(login_result));
@@ -1065,6 +1073,10 @@ oceanbase::common::ObMySQLProxy &ObTableServiceClient::get_user_sql_client()
   return impl_.get_user_sql_client();
 }
 
+oceanbase::obrpc::ObTableRpcProxy &ObTableServiceClient::get_table_rpc_proxy()
+{
+  return impl_.get_table_rpc_proxy();
+}
 
 
 

--- a/src/logservice/palf/palf_env_impl.cpp
+++ b/src/logservice/palf/palf_env_impl.cpp
@@ -187,6 +187,8 @@ int PalfEnvImpl::init(
     const char *base_dir, const ObAddr &self,
     const int64_t cluster_id,
     const int64_t tenant_id,
+    rpc::frame::ObReqTransport *transport,
+    obrpc::ObBatchRpc *batch_rpc,
     common::ObILogAllocator *log_alloc_mgr,
     ILogBlockPool *log_block_pool,
     PalfMonitorCb *monitor,
@@ -200,11 +202,11 @@ int PalfEnvImpl::init(
   if (is_inited_) {
     ret = OB_INIT_TWICE;
     PALF_LOG(ERROR, "PalfEnvImpl is inited twiced", K(ret));
-  } else if (OB_ISNULL(base_dir) || !self.is_valid()
+  } else if (OB_ISNULL(base_dir) || !self.is_valid() || NULL == transport || NULL == batch_rpc
              || OB_ISNULL(log_alloc_mgr) || OB_ISNULL(log_block_pool) || OB_ISNULL(monitor) 
              || OB_ISNULL(log_local_device) || OB_ISNULL(resource_manager) || OB_ISNULL(io_manager)) {
     ret = OB_INVALID_ARGUMENT;
-    PALF_LOG(ERROR, "invalid arguments", K(ret), K(base_dir), K(self),
+    PALF_LOG(ERROR, "invalid arguments", K(ret), KP(transport), KP(batch_rpc), K(base_dir), K(self), KP(transport),
              KP(log_alloc_mgr), KP(log_block_pool), KP(monitor), KP(log_local_device), KP(resource_manager), KP(io_manager));
   } else if (OB_FAIL(init_log_io_worker_config_(options.disk_options_.log_writer_parallelism_,
                                                 tenant_id,
@@ -212,7 +214,7 @@ int PalfEnvImpl::init(
     PALF_LOG(WARN, "init_log_io_worker_config_ failed", K(options));
   } else if (!lib::is_embed_mode() && OB_FAIL(fetch_log_engine_.init(this, log_alloc_mgr))) {
     PALF_LOG(ERROR, "FetchLogEngine init failed", K(ret));
-  } else if (OB_FAIL(log_rpc_.init(self, cluster_id, tenant_id))) {
+  } else if (OB_FAIL(log_rpc_.init(self, cluster_id, tenant_id, transport, batch_rpc))) {
     PALF_LOG(ERROR, "LogRpc init failed", K(ret));
   } else if (OB_FAIL(cb_thread_pool_.init(io_cb_num, this))) {
     PALF_LOG(ERROR, "LogIOTaskThreadPool init failed", K(ret));

--- a/src/logservice/palf/palf_env_impl.h
+++ b/src/logservice/palf/palf_env_impl.h
@@ -54,6 +54,10 @@ namespace frame
 class ObReqTransport;
 }
 }
+namespace obrpc
+{
+class ObBatchRpc;
+}
 namespace share
 {
 class ObLocalDevice;
@@ -214,6 +218,8 @@ public:
            const common::ObAddr &self,
            const int64_t cluster_id,
            const int64_t tenant_id,
+           rpc::frame::ObReqTransport *transport,
+           obrpc::ObBatchRpc *batch_rpc,
            common::ObILogAllocator *alloc_mgr,
            ILogBlockPool *log_block_pool,
            PalfMonitorCb *monitor,

--- a/src/logservice/restoreservice/ob_log_restore_service.cpp
+++ b/src/logservice/restoreservice/ob_log_restore_service.cpp
@@ -30,6 +30,7 @@ using namespace oceanbase::palf;
 ObLogRestoreService::ObLogRestoreService() :
   inited_(false),
   ls_svr_(NULL),
+  proxy_(),
   location_adaptor_(),
   archive_driver_(),
   net_driver_(),
@@ -48,7 +49,8 @@ ObLogRestoreService::~ObLogRestoreService()
   destroy();
 }
 
-int ObLogRestoreService::init(ObLSService *ls_svr,
+int ObLogRestoreService::init(rpc::frame::ObReqTransport *transport,
+    ObLSService *ls_svr,
     ObLogService *log_service)
 {
   int ret = OB_SUCCESS;
@@ -56,9 +58,11 @@ int ObLogRestoreService::init(ObLSService *ls_svr,
   if (OB_UNLIKELY(inited_)) {
     ret = OB_INIT_TWICE;
     LOG_WARN("ObLogRestoreService init twice", K(ret), K(inited_));
-  } else if (OB_ISNULL(ls_svr) || OB_ISNULL(log_service)) {
+  } else if (OB_ISNULL(transport) || OB_ISNULL(ls_svr) || OB_ISNULL(log_service)) {
     ret = OB_INVALID_ARGUMENT;
-    LOG_WARN("invalid argument", K(ret), K(ls_svr), K(log_service));
+    LOG_WARN("invalid argument", K(ret), K(transport), K(ls_svr), K(log_service));
+  } else if (OB_FAIL(proxy_.init(transport))) {
+    LOG_WARN("proxy_ init failed", K(ret));
   } else if (OB_FAIL(net_driver_.init(tenant_id, ls_svr, log_service))) {
     LOG_WARN("net_driver_ init failed");
   } else if (OB_FAIL(location_adaptor_.init(tenant_id, ls_svr, &net_driver_))) {
@@ -97,6 +101,7 @@ void ObLogRestoreService::destroy()
   net_driver_.destroy();
   fetch_log_impl_.destroy();
   error_reporter_.destroy();
+  proxy_.destroy();
   allocator_.destroy();
   scheduler_.destroy();
   ls_svr_ = NULL;

--- a/src/logservice/restoreservice/ob_log_restore_service.h
+++ b/src/logservice/restoreservice/ob_log_restore_service.h
@@ -20,6 +20,7 @@
 #include "rpc/frame/ob_req_transport.h"                     // ObReqTransport
 #include "share/ob_thread_pool.h"                           // ObThreadPool
 #include "ob_remote_fetch_log.h"                            // ObRemoteFetchLogImpl
+#include "ob_log_restore_rpc.h"                             // ObLogResSvrRpc
 #include "ob_remote_fetch_log_worker.h"                     // ObRemoteFetchWorker
 #include "ob_remote_location_adaptor.h"                     // ObRemoteLocationAdaptor
 #include "ob_remote_error_reporter.h"                       // ObRemoteErrorReporter
@@ -59,7 +60,11 @@ public:
   ~ObLogRestoreService();
 
 public:
-  int init(           ObLSService *ls_svr,
+  ObLogResSvrRpc *get_log_restore_proxy() { return &proxy_; }
+
+public:
+  int init(rpc::frame::ObReqTransport *transport,
+           ObLSService *ls_svr,
            ObLogService *log_service);
   void destroy();
   int start();
@@ -86,6 +91,7 @@ private:
 private:
   bool inited_;
   ObLSService *ls_svr_;
+  ObLogResSvrRpc proxy_;
   ObRemoteLocationAdaptor location_adaptor_;
   ObLogRestoreArchiveDriver archive_driver_;
   ObLogRestoreNetDriver net_driver_;

--- a/src/observer/dbms_scheduler/ob_dbms_sched_job_master.cpp
+++ b/src/observer/dbms_scheduler/ob_dbms_sched_job_master.cpp
@@ -17,8 +17,6 @@
 #define USING_LOG_PREFIX SERVER
 
 #include "ob_dbms_sched_job_master.h"
-#include "ob_dbms_sched_job_executor.h"
-#include "observer/ob_ex_rpc.h"
 #include "rootserver/ob_root_service.h"
 #include "storage/mview/ob_mview_sched_job_utils.h"
 #include "sql/session/ob_basic_session_info.h"
@@ -31,7 +29,7 @@ using namespace share;
 using namespace share::schema;
 using namespace rootserver;
 using namespace obutil;
-using namespace obcall;
+using namespace obrpc;
 using namespace storage;
 
 namespace dbms_scheduler
@@ -47,6 +45,7 @@ int ObDBMSSchedJobMaster::init(common::ObMySQLProxy *sql_proxy,
     LOG_WARN("dbms sched job master already inited", K(ret), K(inited_));
   } else if (OB_ISNULL(sql_proxy)
           || OB_ISNULL(schema_service)
+          || OB_ISNULL(GCTX.dbms_sched_job_rpc_proxy_)
           ) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("null ptr", K(ret), K(sql_proxy), K(schema_service));
@@ -62,6 +61,7 @@ int ObDBMSSchedJobMaster::init(common::ObMySQLProxy *sql_proxy,
   } else {
     self_addr_ = GCONF.self_addr_;
     schema_service_ = schema_service;
+    job_rpc_proxy_ = GCTX.dbms_sched_job_rpc_proxy_;
     tenant_id_ = tenant_id;
     inited_ = true;
   }
@@ -133,21 +133,20 @@ int64_t ObDBMSSchedJobMaster::run_job(ObDBMSSchedJobInfo &job_info, ObDBMSSchedJ
     LOG_INFO("job reach end date, not running", K(job_info));
   } else if (OB_FAIL(table_operator_.update_for_start(job_info.get_tenant_id(), job_info, next_date, execute_addr))) {
     LOG_WARN("failed to update for start", K(ret), K(job_info), KPC(job_key));
-  } else {
-    // RPC removed: dispatch run async (fire-and-forget), matching original async-RPC
-    // semantics (do not block the scheduler thread on the full job execution).
-    // job_name (ObString) is deep-copied via async_call's serialize-arg overload.
-    const uint64_t run_tenant_id = job_key->get_tenant_id();
-    const bool run_is_oracle = job_key->is_oracle_tenant();
-    const uint64_t run_job_id = job_key->get_job_id();
-    ex_rpc::async_call<void>(job_key->get_job_name(),
-      [run_tenant_id, run_is_oracle, run_job_id](const ObString &run_job_name) {
-        ObDBMSSchedJobExecutor executor;
-        if (OB_NOT_NULL(GCTX.sql_proxy_) && OB_NOT_NULL(GCTX.schema_service_)
-            && OB_SUCCESS == executor.init(GCTX.sql_proxy_, GCTX.schema_service_)) {
-          (void)executor.run_dbms_sched_job(run_tenant_id, run_is_oracle, run_job_id, run_job_name);
-        }
-      });
+  } else if (OB_FAIL(job_rpc_proxy_->run_dbms_sched_job(job_key->get_tenant_id(),
+      job_key->is_oracle_tenant(),
+      job_key->get_job_id(),
+      job_key->get_job_name(),
+      execute_addr,
+      self_addr_,
+      job_info.is_olap_async_job() ? share::OBCG_OLAP_ASYNC_JOB : share::OBCG_DBMS_SCHED_JOB))) {
+    LOG_WARN("failed to run dbms sched job", K(ret), K(job_info), KPC(job_key));
+    if (is_server_down_error(ret)) {
+      int tmp = OB_SUCCESS;
+      if (OB_SUCCESS != (tmp = table_operator_.update_for_rollback(job_info))) {
+        LOG_WARN("update for end failed for send rpc failed job", K(tmp), K(job_info), KPC(job_key));
+      }
+    }
   }
   return ret;
 }
@@ -517,37 +516,11 @@ int ObDBMSSchedJobMaster::purge_run_detail()
     ret = OB_NOT_INIT;
     LOG_WARN("dbms sched job not init yet", K(ret), K(inited_));
   } else {
-    // RPC removed: target is self on single replica; run purge in-process.
-    const uint64_t purge_tenant_id = tenant_id_;
-    ex_rpc::async_call([purge_tenant_id]() {
-          int ret = OB_SUCCESS;
-          const int64_t PURGE_RUN_DETAIL_TIMEOUT = 5 * 60 * 1000 * 1000L; // 5min
-          if (OB_ISNULL(GCTX.sql_proxy_)) {
-            ret = OB_ERR_UNEXPECTED;
-            LOG_WARN("sql proxy is null", K(ret), K(purge_tenant_id));
-          } else {
-            dbms_scheduler::ObDBMSSchedTableOperator table_operator;
-            if (OB_FAIL(table_operator.init(GCTX.sql_proxy_))) {
-              LOG_WARN("failed to init table_operator", K(ret), K(purge_tenant_id));
-            } else {
-              bool is_primary_cluster = true;
-              if (OB_FAIL(share::ObShareUtil::is_primary_cluster(is_primary_cluster))) {
-                LOG_WARN("fail to check whether is primary cluster", KR(ret), K(is_primary_cluster));
-              } else if (!is_primary_cluster) {
-                LOG_INFO("tenant is standby, not GC", K(purge_tenant_id), K(is_primary_cluster));
-              } else {
-                const int64_t save_timeout_ts = THIS_WORKER.get_timeout_ts();
-                THIS_WORKER.set_timeout_ts(ObTimeUtility::current_time() + PURGE_RUN_DETAIL_TIMEOUT);
-                if (OB_FAIL(table_operator.purge_run_detail(purge_tenant_id))) {
-                  LOG_WARN("failed to purge run detail", K(ret), K(purge_tenant_id));
-                }
-                THIS_WORKER.set_timeout_ts(save_timeout_ts);
-              }
-            }
-            LOG_INFO("[DBMS_SCHED_GC] finish once", K(ret), K(purge_tenant_id));
-          }
-        });
-    LOG_INFO("dispatch purge run detail async (fire-and-forget)", K(ret), K(tenant_id_));
+    if (OB_FAIL(job_rpc_proxy_->purge_run_detail(tenant_id_, self_addr_))) {
+      LOG_WARN("failed to run dbms sched job", K(ret), K(tenant_id_), K(self_addr_));
+    } else {
+      LOG_INFO("send purge run detail rpc finish", K(ret), K(tenant_id_));
+    }
   }
   return ret;
 }

--- a/src/observer/dbms_scheduler/ob_dbms_sched_job_master.h
+++ b/src/observer/dbms_scheduler/ob_dbms_sched_job_master.h
@@ -17,6 +17,7 @@
 #ifndef SRC_OBSERVER_OB_DBMS_SCHED_JOB_MASTER_H_
 #define SRC_OBSERVER_OB_DBMS_SCHED_JOB_MASTER_H_
 
+#include "ob_dbms_sched_job_rpc_proxy.h"
 #include "ob_dbms_sched_job_utils.h"
 #include "ob_dbms_sched_table_operator.h"
 
@@ -106,6 +107,7 @@ public:
       tenant_id_(OB_INVALID_TENANT_ID),
       rand_(),
       schema_service_(NULL),
+      job_rpc_proxy_(NULL),
       self_addr_(),
       allocator_(ObMemAttr(MTL_ID(), "DbmsScheduler"), OB_MALLOC_NORMAL_BLOCK_SIZE, block_alloc_),
       alive_jobs_(),
@@ -169,6 +171,7 @@ private:
 
   common::ObRandom rand_; // for random pick server
   share::schema::ObMultiVersionSchemaService *schema_service_; // for got all tenant info
+  obrpc::ObDBMSSchedJobRpcProxy *job_rpc_proxy_;
 
   common::ObAddr self_addr_;
   ObDBMSSchedTableOperator table_operator_;

--- a/src/observer/dbms_scheduler/ob_dbms_sched_job_utils.cpp
+++ b/src/observer/dbms_scheduler/ob_dbms_sched_job_utils.cpp
@@ -22,8 +22,7 @@
 #include "share/stat/ob_dbms_stats_maintenance_window.h"
 #include "observer/dbms_scheduler/ob_dbms_sched_table_operator.h"
 #include "storage/ob_common_id_utils.h"
-#include "sql/session/ob_sql_session_mgr.h"
-#include "observer/ob_ex_rpc.h"
+#include "observer/dbms_scheduler/ob_dbms_sched_job_rpc_proxy.h"
 #include "storage/mview/ob_mview_sched_job_utils.h"
 
 namespace oceanbase
@@ -365,9 +364,11 @@ int ObDBMSSchedJobUtils::stop_dbms_sched_job(
     const bool is_delete_after_stop)
 {
   int ret = OB_SUCCESS;
+  obrpc::ObDBMSSchedJobRpcProxy *rpc_proxy = GCTX.dbms_sched_job_rpc_proxy_;
   uint64_t tenant_id = job_info.tenant_id_;
   bool is_oracle_tenant =  lib::is_oracle_mode();
   ObSqlString sql;
+  CK (OB_NOT_NULL(rpc_proxy));
 
   if (OB_SUCC(ret)) {
     if (is_delete_after_stop) {
@@ -406,49 +407,10 @@ int ObDBMSSchedJobUtils::stop_dbms_sched_job(
                 if (OB_SUCC(ret)) {
                   LOG_INFO("send rpc", K(tenant_id), K(job_info.job_name_), K(svr), K(session_id));
                   ObString stop_job_name = ObString(job_info.job_name_);
-                  const int64_t stop_rpc_send_time = ObTimeUtility::current_time();
-                  // RPC removed: target is self on single replica; run stop in-process.
-                  // Mirrors ObCallStopDBMSSchedJobP::process (preserves session reuse guard).
-                  OZ (ex_rpc::sync_call([&stop_job_name, session_id, stop_rpc_send_time]() -> int {
-                    int ret = OB_SUCCESS;
-                    ObSQLSessionInfo *kill_session = NULL;
-                    if (OB_ISNULL(GCTX.session_mgr_)) {
-                      ret = OB_ERR_UNEXPECTED;
-                      LOG_WARN("session_mgr_ is null", K(ret));
-                    } else {
-                      sql::ObSessionGetterGuard sess_guard(*GCTX.session_mgr_, session_id);
-                      if (OB_FAIL(sess_guard.get_session(kill_session))) {
-                        LOG_WARN("failed to get session", K(session_id), K(stop_job_name));
-                      } else if (OB_ISNULL(kill_session)) {
-                        ret = OB_ERR_UNEXPECTED;
-                        LOG_WARN("session is null", K(ret));
-                      } else {
-                        {
-                          ObSQLSessionInfo::LockGuard lock_guard(kill_session->get_thread_data_lock());
-                          ObDBMSSchedJobInfo *cur_job_info = kill_session->get_job_info();
-                          if (OB_ISNULL(cur_job_info)) {
-                            ret = OB_ENTRY_NOT_EXIST;
-                            LOG_WARN("job_info is null, maybe job end", K(ret), K(stop_job_name));
-                          } else if (0 != cur_job_info->get_job_name().case_compare(stop_job_name)) {
-                            ret = OB_ERR_UNEXPECTED;
-                            LOG_WARN("job_info is not expected", K(ret), KPC(cur_job_info), K(stop_job_name));
-                          }
-                        }
-                        if (OB_SUCC(ret)) {
-                          if (stop_rpc_send_time <= kill_session->get_sess_create_time()) {
-                            ret = OB_ERR_UNEXPECTED;
-                            LOG_WARN("session maybe reused by later round", K(ret), K(stop_job_name),
-                                K(session_id), K(kill_session->get_sess_create_time()), KPC(kill_session));
-                          } else if (OB_FAIL(GCTX.session_mgr_->kill_session(*kill_session))) {
-                            LOG_WARN("failed to kill session", K(ret), K(stop_job_name), KPC(kill_session));
-                          } else {
-                            LOG_INFO("stop job finish", K(stop_job_name), K(session_id));
-                          }
-                        }
-                      }
-                    }
-                    return ret;
-                  }));
+                  OZ (rpc_proxy->stop_dbms_sched_job(tenant_id,
+                    stop_job_name,
+                    svr,
+                    session_id));
                 }
               }
             } while (OB_SUCC(ret));

--- a/src/observer/ob_server.cpp
+++ b/src/observer/ob_server.cpp
@@ -25,13 +25,13 @@
 #endif
 #include <thread>
 #include "observer/ob_server.h"
-#include "rootserver/ob_rs_serial_call.h"
 #include "lib/alloc/memory_dump.h"
 #include "lib/oblog/ob_log_compressor.h"
 #include "lib/resource/ob_affinity_ctrl.h"
 #include "lib/task/ob_timer_monitor.h"
 #include "lib/task/ob_timer_service.h" // ObTimerService
 #include "observer/ob_server_utils.h"
+#include "observer/ob_rpc_extra_payload.h"
 #include "observer/ob_server_options.h"
 #include "observer/omt/ob_tenant_timezone_mgr.h"
 #ifndef OB_BUILD_EMBED_MODE
@@ -78,8 +78,7 @@
 #include "common/ob_target_specific.h"
 #include "storage/fts/dict/ob_gen_dic_loader.h"
 #include "plugin/sys/ob_plugin_mgr.h"
-#include "rpc/frame/ob_net_consts.h"
-#include "rpc/ob_req_operator.h"   // rpc::g_rpc_self_addr
+#include "rpc/obrpc/ob_rpc_net_handler.h"
 #include "storage/blocksstable/ob_block_sstable_struct.h"
 #include "rootserver/standby/ob_standby_service.h" // ObStandbyService
 
@@ -106,6 +105,15 @@ uint64_t __attribute__((used)) lib_get_cpu_khz()
 }
 } // namespace common
 
+namespace obrpc
+{
+
+void keepalive_make_data(ObNetKeepAliveData &ka_data)
+{
+  ka_data.rs_server_status_ = GCTX.rs_server_status_;
+  ka_data.start_service_time_ = GCTX.start_service_time_;
+}
+}
 }
 
 namespace oceanbase
@@ -149,9 +157,9 @@ ObServer::ObServer()
     gctx_(GCTX),
     prepare_stop_(true), stop_(true), has_stopped_(true), has_destroy_(false),
     net_frame_(gctx_), sql_conn_pool_(), ddl_conn_pool_(),
-    res_inner_conn_pool_(), restore_ctx_(),
-    storage_rpc_proxy_(), sql_proxy_(),
-    executor_rpc_(),
+    res_inner_conn_pool_(), restore_ctx_(), srv_rpc_proxy_(),
+    storage_rpc_proxy_(), rs_rpc_proxy_(), sql_proxy_(),
+    executor_proxy_(), executor_rpc_(), dbms_job_rpc_proxy_(), dbms_sched_job_rpc_proxy_(), interrupt_proxy_(),
     config_(ObServerConfig::get_instance()),
     reload_config_(config_, gctx_), config_mgr_(config_, reload_config_),
     tenant_timezone_mgr_(omt::ObTenantTimezoneMgr::get_instance()),
@@ -398,7 +406,8 @@ int ObServer::init(const ObServerOptions &opts, const ObPLogWriterCfg &log_cfg)
       LOG_ERROR("tablet table operator init failed", KR(ret));
     } else if (OB_FAIL(location_service_.init(
                                               schema_service_,
-                                              sql_proxy_))) {
+                                              sql_proxy_,
+                                              srv_rpc_proxy_))) {
       LOG_ERROR("init location service failed", KR(ret));
     }
     if (OB_SUCC(ret) && OB_FAIL(init_autoincrement_service())) {
@@ -433,7 +442,7 @@ int ObServer::init(const ObServerOptions &opts, const ObPLogWriterCfg &log_cfg)
       LOG_ERROR("init log kv cache failed", KR(ret));
     } else if (OB_FAIL(init_ts_mgr())) {
       LOG_ERROR("init ts mgr failed", KR(ret));
-    } else if (OB_FAIL(weak_read_service_.init())) {
+    } else if (OB_FAIL(weak_read_service_.init(net_frame_.get_req_transport()))) {
       LOG_ERROR("init weak_read_service failed", KR(ret));
     } else if (OB_FAIL(bl_service_.init())) {
       LOG_ERROR("init bl_service_ failed", KR(ret));
@@ -493,7 +502,8 @@ int ObServer::init(const ObServerOptions &opts, const ObPLogWriterCfg &log_cfg)
     } else if (OB_FAIL(ObActiveSessHistList::get_instance().init())) {
       LOG_ERROR("init ASH failed", KR(ret));
 #ifndef OB_BUILD_LITE
-    } else if (OB_FAIL(ObServerBlacklist::get_instance().init(self_addr_))) {
+    } else if (OB_FAIL(ObServerBlacklist::get_instance().init(self_addr_,
+                                                              net_frame_.get_req_transport()))) {
       LOG_ERROR("init server blacklist failed", KR(ret));
 #endif
     } else if (OB_FAIL(ObLongopsMgr::get_instance().init())) {
@@ -511,7 +521,7 @@ int ObServer::init(const ObServerOptions &opts, const ObPLogWriterCfg &log_cfg)
     } else if (OB_FAIL(wr_service_.init())) {
       LOG_WARN("failed to init wr service", K(ret));
     } else {
-      // GDS direct dispatch through GCTX.root_service_
+      GDS.set_rpc_proxy(&rs_rpc_proxy_);
     }
   }
     }
@@ -529,7 +539,7 @@ int ObServer::init(const ObServerOptions &opts, const ObPLogWriterCfg &log_cfg)
     set_stop();
     destroy();
   } else {
-    FLOG_INFO("[OBSERVER_NOTICE] success to init observer", "cluster_id", rpc::frame::ObNetConsts::CLUSTER_ID,
+    FLOG_INFO("[OBSERVER_NOTICE] success to init observer", "cluster_id", obrpc::ObRpcNetHandler::CLUSTER_ID,
         "lib::g_runtime_enabled", lib::g_runtime_enabled);
     LOG_DBA_INFO_V2(OB_SERVER_INIT_SUCCESS,
                     DBA_STEP_INC_INFO(server_start),
@@ -1760,7 +1770,7 @@ int ObServer::init_self_addr()
     LOG_INFO("Build basic information for each syslog file", "info", syslog_file_info);
 
     // initialize self address
-    rpc::g_rpc_self_addr = self_addr_;
+    obrpc::ObRpcProxy::myaddr_ = self_addr_;
     LOG_INFO("my addr", K_(self_addr));
     config_.self_addr_ = self_addr_;
   }
@@ -2011,6 +2021,7 @@ int ObServer::init_restore_ctx()
   restore_ctx_.ob_sql_ = &sql_engine_;
   restore_ctx_.vt_iter_creator_ = &vt_data_service_.get_vt_iter_factory().get_vt_iter_creator();
   restore_ctx_.server_config_ = &config_;
+  restore_ctx_.rs_rpc_proxy_ = &rs_rpc_proxy_;
   return ret;
 }
 
@@ -2021,7 +2032,7 @@ int ObServer::init_interrupt()
   if (OB_ISNULL(mgr)) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_ERROR("fail get interrupt mgr instance", KR(ret));
-  } else if (OB_FAIL(mgr->init(get_self()))) {
+  } else if (OB_FAIL(mgr->init(get_self(), &interrupt_proxy_))) {
     LOG_ERROR("fail init interrupt mgr", KR(ret));
   }
   return ret;
@@ -2088,10 +2099,34 @@ int ObServer::init_network()
 {
   int ret = OB_SUCCESS;
 
+  obrpc::ObIRpcExtraPayload::set_extra_payload(ObRpcExtraPayload::extra_payload_instance());
+
   if (OB_FAIL(net_frame_.init())) {
     LOG_ERROR("init server network fail");
-  } else if (OB_FAIL(storage_rpc_proxy_.init(GCTX.self_addr()))) {
-    LOG_ERROR("init storage rpc proxy fail");
+  } else if (OB_FAIL(net_frame_.get_proxy(srv_rpc_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else if (OB_FAIL(net_frame_.get_proxy(storage_rpc_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else if (OB_FAIL(net_frame_.get_proxy(rs_rpc_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else if (OB_FAIL(net_frame_.get_proxy(executor_proxy_))) {
+    LOG_ERROR("get rpc proxy fail");
+  } else if (OB_FAIL(net_frame_.get_proxy(load_data_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else if (OB_FAIL(net_frame_.get_proxy(external_table_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else if (OB_FAIL(net_frame_.get_proxy(interrupt_proxy_))) {
+    LOG_ERROR("get rpc proxy fail");
+  } else if (OB_FAIL(net_frame_.get_proxy(dbms_job_rpc_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else if (OB_FAIL(net_frame_.get_proxy(inner_sql_rpc_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else if (OB_FAIL(net_frame_.get_proxy(dbms_sched_job_rpc_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else if (OB_FAIL(net_frame_.get_proxy(table_rpc_proxy_))) {
+    LOG_ERROR("get rpc proxy fail", KR(ret));
+  } else {
+    srv_rpc_proxy_.set_server(get_self());
   }
 
   return ret;
@@ -2135,7 +2170,9 @@ int ObServer::init_autoincrement_service()
   int ret = OB_SUCCESS;
   if (OB_FAIL(ObAutoincrementService::get_instance().init(self_addr_,
                                                          &sql_proxy_,
-                                                         &schema_service_))) {
+                                                         &srv_rpc_proxy_,
+                                                         &schema_service_,
+                                                         net_frame_.get_req_transport()))) {
     LOG_ERROR("init autoincrement_service_ fail", KR(ret));
   }
   return ret;
@@ -2194,8 +2231,8 @@ int ObServer::init_root_service()
   int ret = OB_SUCCESS;
 
   if (OB_FAIL(root_service_.init(
-                 config_, config_mgr_,
-                 self_addr_, sql_proxy_,
+                 config_, config_mgr_, srv_rpc_proxy_,
+                 rs_rpc_proxy_, self_addr_, sql_proxy_,
                  restore_ctx_, &schema_service_))) {
     LOG_ERROR("init root service failed", K(ret));
   }
@@ -2223,6 +2260,7 @@ int ObServer::init_sql()
   if (OB_SUCC(ret)) {
     if (OB_FAIL(sql_engine_.init(
                     &ObOptStatManager::get_instance(),
+                    net_frame_.get_req_transport(),
                     &vt_data_service_,
                     self_addr_))) {
       LOG_ERROR("init sql engine failed", KR(ret));
@@ -2235,6 +2273,8 @@ int ObServer::init_sql()
     if (nullptr == dtl::ObDtl::instance()) {
       ret = OB_INIT_FAIL;
       LOG_ERROR("allocate DTL service fail", KR(ret));
+    } else if (OB_FAIL(net_frame_.get_proxy(DTL.get_rpc_proxy()))) {
+      LOG_ERROR("initialize DTL RPC proxy fail", KR(ret));
     } else if (OB_FAIL(DTL.init())) {
       LOG_ERROR("fail initialize DTL instance", KR(ret));
     }
@@ -2268,7 +2308,7 @@ int ObServer::init_sql_runner()
 {
   int ret = OB_SUCCESS;
 
-  if (OB_FAIL(executor_rpc_.init())) {
+  if (OB_FAIL(executor_rpc_.init(&executor_proxy_))) {
     LOG_ERROR("init executor rpc fail", K(ret));
   } else if (OB_FAIL(ObDASTaskResultGCRunner::schedule_timer_task())) {
     LOG_WARN("schedule das result gc runner failed", KR(ret));
@@ -2315,7 +2355,14 @@ int ObServer::init_global_context()
   gctx_.tablet_operator_ = &tablet_operator_;
   gctx_.meta_db_pool_ = &meta_db_pool_;
   gctx_.kv_storage_ = &kv_storage_;
+  gctx_.srv_rpc_proxy_ = &srv_rpc_proxy_;
   gctx_.storage_rpc_proxy_ = &storage_rpc_proxy_;
+  gctx_.dbms_job_rpc_proxy_ = &dbms_job_rpc_proxy_;
+  gctx_.inner_sql_rpc_proxy_ = &inner_sql_rpc_proxy_;
+  gctx_.dbms_sched_job_rpc_proxy_ = &dbms_sched_job_rpc_proxy_;
+  gctx_.rs_rpc_proxy_ = &rs_rpc_proxy_;
+  gctx_.load_data_proxy_ = &load_data_proxy_;
+  gctx_.external_table_proxy_ = &external_table_proxy_;
   gctx_.sql_proxy_ = &sql_proxy_;
   gctx_.ddl_sql_proxy_ = &ddl_sql_proxy_;
   gctx_.ddl_oracle_sql_proxy_ = &ddl_oracle_sql_proxy_;
@@ -2347,9 +2394,10 @@ int ObServer::init_global_context()
   gctx_.schema_status_proxy_ = &schema_status_proxy_;
   gctx_.net_frame_ = &net_frame_;
 
+  gctx_.batch_rpc_ = &batch_rpc_;
   gctx_.disk_reporter_ = &disk_usage_report_task_;
   gctx_.log_block_mgr_ = &log_block_mgr_;
-  (void)gctx_.set_upgrade_stage(obcall::OB_UPGRADE_STAGE_INVALID);
+  (void)gctx_.set_upgrade_stage(obrpc::OB_UPGRADE_STAGE_INVALID);
   gctx_.wr_service_ = &wr_service_;
   gctx_.startup_accel_handler_ = &startup_accel_handler_;
 
@@ -2403,7 +2451,8 @@ int ObServer::init_ts_mgr()
   int ret = OB_SUCCESS;
   if (OB_FAIL(OB_TS_MGR.init(self_addr_,
                              schema_service_,
-                             location_service_))) {
+                             location_service_,
+                             net_frame_.get_req_transport()))) {
     LOG_ERROR("gts cache mgr init failed", K_(self_addr), KR(ret));
   } else {
     LOG_INFO("gts cache mgr init success");
@@ -3086,8 +3135,9 @@ int ObServer::clean_up_invalid_tables_by_tenant(
   ObSchemaGetterGuard schema_guard;
   const ObDatabaseSchema *database_schema = NULL;
   ObArray<uint64_t> table_ids;
-  obcall::ObDropTableArg drop_table_arg;
-  obcall::ObTableItem table_item;
+  obrpc::ObDropTableArg drop_table_arg;
+  obrpc::ObTableItem table_item;
+  obrpc::ObCommonRpcProxy *common_rpc_proxy = NULL;
   if (OB_FAIL(schema_service_.get_tenant_schema_guard(tenant_id, schema_guard))) {
     LOG_WARN("fail to get schema guard", K(ret));
   } else if (OB_FAIL(schema_guard.get_table_ids_in_tenant(tenant_id, table_ids))) {
@@ -3096,6 +3146,7 @@ int ObServer::clean_up_invalid_tables_by_tenant(
     ObCTASCleanUp ctas_cleanup(this, true);
     drop_table_arg.if_exist_ = true;
     drop_table_arg.to_recyclebin_ = false;
+    common_rpc_proxy = GCTX.rs_rpc_proxy_;
     // only OB_ISNULL(GCTX.session_mgr_) will exit the loop
     for (int64_t i = 0; i < table_ids.count() && OB_SUCC(tmp_ret); i++) {
       bool is_oracle_mode = false;
@@ -3135,7 +3186,7 @@ int ObServer::clean_up_invalid_tables_by_tenant(
         }
         if (ctas_cleanup.get_drop_flag()) {
           LOG_INFO("a table will be dropped!", K(*table_schema));
-          obcall::ObDDLRes res;
+          obrpc::ObDDLRes res;
           database_schema = NULL;
           drop_table_arg.tables_.reset();
           drop_table_arg.if_exist_ = true;
@@ -3158,7 +3209,7 @@ int ObServer::clean_up_invalid_tables_by_tenant(
             //impossible
           } else if (OB_FAIL(drop_table_arg.tables_.push_back(table_item))) {
             LOG_WARN("failed to add table item!", K(table_item), K(ret));
-          } else if (OB_FAIL(rootserver::serial_call([&]{ return GCTX.root_service_->drop_table(drop_table_arg, res); }))) {
+          } else if (OB_FAIL(common_rpc_proxy->drop_table(drop_table_arg, res))) {
             LOG_WARN("failed to drop table", K(drop_table_arg), K(table_item), KR(ret));
           } else {
             LOG_INFO("a table is dropped due to previous error or is a temporary one", K(i), "table_name", table_item.table_name_);

--- a/src/observer/ob_server_reload_config.cpp
+++ b/src/observer/ob_server_reload_config.cpp
@@ -31,8 +31,7 @@
 #include "share/compaction/ob_shared_storage_compaction_util.h"
 #endif
 #include "lib/stat/ob_diagnostic_info_container.h"
-#include "rpc/frame/ob_net_consts.h"
-#include "rpc/frame/ob_req_packet_code.h"  // rpc::frame::ObReqCheckSumCheckLevel (relocated)
+#include "rpc/obrpc/ob_rpc_net_handler.h"
 
 using namespace oceanbase::lib;
 using namespace oceanbase::common;
@@ -48,12 +47,12 @@ namespace observer
 int set_cluster_name_hash(const ObString &cluster_name)
 {
   int ret = OB_SUCCESS;
-  uint64_t cluster_name_hash = 0/*INVALID_CLUSTER_NAME_HASH*/;
+  uint64_t cluster_name_hash = obrpc::ObRpcPacket::INVALID_CLUSTER_NAME_HASH;
 
   if (OB_FAIL(calc_cluster_name_hash(cluster_name, cluster_name_hash))) {
     LOG_WARN("failed to calc_cluster_name_hash", KR(ret), K(cluster_name));
   } else {
-    rpc::frame::ObNetConsts::CLUSTER_NAME_HASH = cluster_name_hash;
+    obrpc::ObRpcNetHandler::CLUSTER_NAME_HASH = cluster_name_hash;
     LOG_INFO("set cluster_name_hash", KR(ret), K(cluster_name), K(cluster_name_hash));
   }
   return ret;
@@ -62,10 +61,10 @@ int set_cluster_name_hash(const ObString &cluster_name)
 int calc_cluster_name_hash(const ObString &cluster_name, uint64_t &cluster_name_hash)
 {
   int ret = OB_SUCCESS;
-  cluster_name_hash = 0/*INVALID_CLUSTER_NAME_HASH*/;
+  cluster_name_hash = obrpc::ObRpcPacket::INVALID_CLUSTER_NAME_HASH;
 
   if (0 == cluster_name.length()) {
-    cluster_name_hash = 0/*INVALID_CLUSTER_NAME_HASH*/;
+    cluster_name_hash = obrpc::ObRpcPacket::INVALID_CLUSTER_NAME_HASH;
     LOG_INFO("set cluster_name_hash to invalid", K(cluster_name));
   } else {
     cluster_name_hash = common::murmurhash(cluster_name.ptr(), cluster_name.length(), 0);
@@ -243,17 +242,17 @@ int ObServerReloadConfig::operator()()
   }
 
   {
-    auto new_level = rpc::frame::get_rpc_checksum_check_level_from_string(GCONF._rpc_checksum.str());
-    auto orig_level = rpc::frame::get_rpc_checksum_check_level();
+    auto new_level = obrpc::get_rpc_checksum_check_level_from_string(GCONF._rpc_checksum.str());
+    auto orig_level = obrpc::get_rpc_checksum_check_level();
     if (new_level != orig_level) {
       LOG_INFO("rpc_checksum_check_level changed",
                "orig", orig_level,
                "new", new_level);
     }
-    rpc::frame::set_rpc_checksum_check_level(new_level);
+    obrpc::set_rpc_checksum_check_level(new_level);
   }
 
-    auto new_upgrade_stage = obcall::get_upgrade_stage(GCONF._upgrade_stage.str());
+    auto new_upgrade_stage = obrpc::get_upgrade_stage(GCONF._upgrade_stage.str());
     auto orig_upgrade_stage = GCTX.get_upgrade_stage();
     if (new_upgrade_stage != orig_upgrade_stage) {
       LOG_INFO("_upgrade_stage changed", K(new_upgrade_stage), K(orig_upgrade_stage));

--- a/src/observer/omt/ob_multi_tenant.h
+++ b/src/observer/omt/ob_multi_tenant.h
@@ -81,9 +81,7 @@ typedef common::ObVector<uint64_t> TenantIdList;
 class ObMultiTenant : public common::ObTimerTask
 {
 public:
-  // 100ms: bounds packet-retry requeue latency (retry_queue_ is only drained
-  // by timeup); heavy work in timeup is gated to 1s internally.
-  const     static int64_t TIME_SLICE_PERIOD        = 100000;
+  const     static int64_t TIME_SLICE_PERIOD        = 1000000;
 
 public:
   explicit ObMultiTenant();

--- a/src/observer/omt/ob_tenant.cpp
+++ b/src/observer/omt/ob_tenant.cpp
@@ -44,7 +44,7 @@ using namespace oceanbase::share;
 using namespace oceanbase::share::schema;
 using namespace oceanbase::storage;
 using namespace oceanbase::sql::dtl;
-using namespace oceanbase::obcall;
+using namespace oceanbase::obrpc;
 
 #define GET_OTHER_TSI_ADDR(var_name, addr) \
 const int64_t var_name##_offset = ((int64_t)addr - (int64_t)pthread_self()); \
@@ -773,14 +773,47 @@ int ObTenant::get_new_request(
       if (req->large_retry_flag()) {
         w.set_large_query();
       }
+      if (req->get_type() == ObRequest::OB_RPC) {
+        using obrpc::ObRpcPacket;
+        const ObRpcPacket &pkt
+          = static_cast<const ObRpcPacket&>(req->get_packet());
+        w.set_curr_request_level(pkt.get_request_level());
+      }
     }
   }
   return ret;
 }
 
+using oceanbase::obrpc::ObRpcPacket;
+inline bool is_high_prio(const ObRpcPacket &pkt)
+{
+  return pkt.get_priority() < 5;
+}
+
+inline bool is_normal_prio(const ObRpcPacket &pkt)
+{
+  return pkt.get_priority() == 5;
+}
+
+inline bool is_low_prio(const ObRpcPacket &pkt)
+{
+  return pkt.get_priority() > 5 && pkt.get_priority() < 10;
+}
+
+inline bool is_ddl(const ObRpcPacket &pkt)
+{
+  return pkt.get_priority() == 10;
+}
+
+inline bool is_warmup(const ObRpcPacket &pkt)
+{
+  return pkt.get_priority() == 11;
+}
+
 int ObTenant::recv_request(ObRequest &req)
 {
   int ret = OB_SUCCESS;
+  int req_level = 0;
   if (has_stopped()) {
     ret = OB_TENANT_NOT_IN_SERVER;
     LOG_WARN("receive request but tenant has already stopped", K(ret), K(id_));
@@ -796,10 +829,53 @@ int ObTenant::recv_request(ObRequest &req)
     req.set_trace_point(ObRequest::OB_EASY_REQUEST_TENANT_RECEIVED);
     switch (req.get_type()) {
       case ObRequest::OB_RPC: {
-        // obcall RPC transport removed (single-replica): no OB_RPC request is
-        // ever delivered to a tenant. Treat any arrival as unexpected.
-        ret = OB_ERR_UNEXPECTED;
-        LOG_ERROR("unexpected OB_RPC request after rpc removal", K(ret), K(id_));
+        using obrpc::ObRpcPacket;
+        const ObRpcPacket& pkt = static_cast<const ObRpcPacket&>(req.get_packet());
+        req_level = pkt.get_request_level();
+        if (req_level < 0) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_ERROR("unexpected level", K(req_level), K(id_));
+        } else {
+          // (0,5) High priority
+          //  [5,10) Normal priority
+          //  10 is the low priority used by ddl and should not appear here
+          //  11 Ultra-low priority for preheating
+          if (is_high_prio(pkt)) {  // the less number the higher priority
+            ATOMIC_INC(&recv_hp_rpc_cnt_);
+            if (OB_FAIL(req_queue_.push(&req, QQ_HIGH, true))) {
+              if (REACH_TIME_INTERVAL(5 * 1000 * 1000)) {
+                LOG_WARN("push request to queue fail", K(ret), K(*this));
+              }
+            }
+          } else if (req.is_retry_on_lock())  {
+            ATOMIC_INC(&recv_retry_on_lock_rpc_cnt_);
+            if (OB_FAIL(req_queue_.push(&req, QQ_NORMAL, true))) {
+              LOG_WARN("push request to QQ_NORMAL queue fail", K(ret), K(this));
+            }
+          } else if (pkt.is_kv_request()) {
+            // the same as sql request, kv request use q4
+            ATOMIC_INC(&recv_np_rpc_cnt_);
+            if (OB_FAIL(req_queue_.push(&req, RQ_NORMAL, true))) {
+              LOG_WARN("push kv request to queue fail", K(ret), K(this));
+            }
+          } else if (is_normal_prio(pkt) || is_low_prio(pkt)) {
+            ATOMIC_INC(&recv_np_rpc_cnt_);
+            if (OB_FAIL(req_queue_.push(&req, QQ_LOW, true))) {
+              LOG_WARN("push request to queue fail", K(ret), K(this));
+            }
+          } else if (is_ddl(pkt)) {
+            ret = OB_ERR_UNEXPECTED;
+            LOG_WARN("priority 10 should not come here", K(ret));
+          } else if (is_warmup(pkt)) {
+            ATOMIC_INC(&recv_lp_rpc_cnt_);
+            if (OB_FAIL(req_queue_.push(&req, RQ_LOW, true))) {
+              LOG_WARN("push request to queue fail", K(ret), K(this));
+            }
+          } else {
+            ret = OB_ERR_UNEXPECTED;
+            LOG_ERROR("unexpected priority", K(ret), K(pkt.get_priority()));
+          }
+        }
         break;
       }
       case ObRequest::OB_MYSQL: {
@@ -875,12 +951,7 @@ int ObTenant::timeup()
   if (!has_stopped() && OB_SUCC(try_rdlock())) {
     // it may fail during drop tenant, try next time.
     if (!has_stopped()) {
-      // timeup ticks at 100ms so retry_queue_ is drained promptly
-      // (packet-retry latency is bounded by this period); the costly
-      // worker-count maintenance keeps its relaxed 1s cadence.
-      if (REACH_TIME_INTERVAL(1 * 1000 * 1000L)) {
-        check_worker_count();
-      }
+      check_worker_count();
       // Rescue expansion: if request completion stalls for 3s while
       // queue is non-empty and workers are at min_worker_cnt, workers
       // may be deadlocked — expand up to max_worker_cnt.

--- a/src/rootserver/ddl_task/ob_ddl_scheduler.h
+++ b/src/rootserver/ddl_task/ob_ddl_scheduler.h
@@ -339,13 +339,13 @@ public:
                             const bool is_copy_foreign_keys,
                             const bool is_ignore_errors);
   int finish_redef_table(const ObDDLTaskID &task_id);
-  int start_redef_table(const obcall::ObStartRedefTableArg &arg, obcall::ObStartRedefTableRes &res);
+  int start_redef_table(const obrpc::ObStartRedefTableArg &arg, obrpc::ObStartRedefTableRes &res);
   int update_ddl_task_active_time(const ObDDLTaskID &task_id);
   int prepare_alter_table_arg(const ObPrepareAlterTableArgParam &param,
                               const ObTableSchema *target_table_schema,
-                              obcall::ObAlterTableArg &alter_table_arg);
-  int cache_auto_split_task(const obcall::ObAutoSplitTabletBatchArg &arg,  
-                            obcall::ObAutoSplitTabletBatchRes &res);
+                              obrpc::ObAlterTableArg &alter_table_arg);
+  int cache_auto_split_task(const obrpc::ObAutoSplitTabletBatchArg &arg,  
+                            obrpc::ObAutoSplitTabletBatchRes &res);
   int schedule_auto_split_task();
   inline share::ObDDLReplicaBuilder &get_ddl_builder() { return ddl_builder_; }
 private:
@@ -417,7 +417,7 @@ private:
       const int64_t parent_task_id,
       const int64_t consumer_group_id,
       const int32_t sub_task_trace_id,
-      const obcall::ObCreateIndexArg *create_index_arg,
+      const obrpc::ObCreateIndexArg *create_index_arg,
       const share::ObDDLType task_type,
       const uint64_t tenant_data_version,
       ObIAllocator &allocator,
@@ -432,7 +432,7 @@ private:
       const int64_t parent_task_id,
       const int64_t consumer_group_id,
       const uint64_t tenant_data_version,
-      const obcall::ObCreateIndexArg *create_index_arg,
+      const obrpc::ObCreateIndexArg *create_index_arg,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record,
       int64_t snapshot_version = 0,
@@ -445,7 +445,7 @@ private:
       const int64_t parent_task_id,
       const int64_t consumer_group_id,
       const share::ObDDLType task_type,
-      const obcall::ObCreateIndexArg *create_index_arg,
+      const obrpc::ObCreateIndexArg *create_index_arg,
       const uint64_t tenant_data_version,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
@@ -456,7 +456,7 @@ private:
       const int64_t parallelism,
       const int64_t parent_task_id,
       const int64_t consumer_group_id,
-      const obcall::ObCreateIndexArg *create_index_arg,
+      const obrpc::ObCreateIndexArg *create_index_arg,
       const uint64_t tenant_data_version,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record,
@@ -468,7 +468,7 @@ private:
       const int64_t constraint_id,
       const share::ObDDLType ddl_type,
       const int64_t schema_version,
-      const obcall::ObAlterTableArg *arg,
+      const obrpc::ObAlterTableArg *arg,
       const int64_t parent_task_id,
       const int64_t consumer_group_id,
       const int32_t sub_task_trace_id,
@@ -480,7 +480,7 @@ private:
       const int64_t parallelism,
       const int64_t parent_task_id,
       const int64_t consumer_group_id,
-      const obcall::ObMViewCompleteRefreshArg *mview_complete_refresh_arg,
+      const obrpc::ObMViewCompleteRefreshArg *mview_complete_refresh_arg,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
   int create_table_redefinition_task(
@@ -493,7 +493,7 @@ private:
       const int64_t parent_task_id,
       const int64_t task_id,
       const int32_t sub_task_trace_id,
-      const obcall::ObAlterTableArg *alter_table_arg,
+      const obrpc::ObAlterTableArg *alter_table_arg,
       const uint64_t tenant_data_version,
       const bool ddl_need_retry_at_executor,
       ObIAllocator &allocator,
@@ -508,7 +508,7 @@ private:
       const int64_t consumer_group_id,
       const int64_t task_id,
       const int32_t sub_task_trace_id,
-      const obcall::ObAlterTableArg *alter_table_arg,
+      const obrpc::ObAlterTableArg *alter_table_arg,
       const uint64_t tenant_data_version,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
@@ -522,7 +522,7 @@ private:
       const int64_t consumer_group_id,
       const int64_t task_id,
       const int32_t sub_task_trace_id,
-      const obcall::ObAlterTableArg *alter_table_arg,
+      const obrpc::ObAlterTableArg *alter_table_arg,
       const uint64_t tenant_data_version,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
@@ -535,7 +535,7 @@ private:
       const int64_t consumer_group_id,
       const int64_t task_id,
       const int32_t sub_task_trace_id,
-      const obcall::ObAlterTableArg *alter_table_arg,
+      const obrpc::ObAlterTableArg *alter_table_arg,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
   
@@ -547,7 +547,7 @@ private:
       const int64_t parent_task_id,
       const int64_t consumer_group_id,
       const int32_t sub_task_trace_id,
-      const obcall::ObRebuildIndexArg *rebuild_index_arg,
+      const obrpc::ObRebuildIndexArg *rebuild_index_arg,
       const uint64_t tenant_data_version,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
@@ -559,7 +559,7 @@ private:
       const int64_t parent_task_id,
       const int64_t consumer_group_id,
       const int32_t sub_task_trace_id,
-      const obcall::ObDropIndexArg *drop_index_arg,
+      const obrpc::ObDropIndexArg *drop_index_arg,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
 
@@ -572,7 +572,7 @@ private:
       const share::schema::ObTableSchema *doc_rowkey_schema,
       const share::schema::ObTableSchema *domain_index_schema,
       const share::schema::ObTableSchema *doc_word_schema,
-      const obcall::ObDropIndexArg *drop_index_arg,
+      const obrpc::ObDropIndexArg *drop_index_arg,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
   
@@ -589,7 +589,7 @@ private:
       const share::schema::ObTableSchema *pq_centroid_schema_,
       const share::schema::ObTableSchema *pq_code_schema_,
       const uint64_t tenant_data_version,
-      const obcall::ObDropIndexArg *drop_index_arg,
+      const obrpc::ObDropIndexArg *drop_index_arg,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
 
@@ -605,7 +605,7 @@ private:
       const share::schema::ObTableSchema *index_snapshot_data_schema_,
       const share::schema::ObTableSchema *embedded_vec_schema_,
       const uint64_t tenant_data_version,
-      const obcall::ObDropIndexArg *drop_index_arg,
+      const obrpc::ObDropIndexArg *drop_index_arg,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
 
@@ -622,7 +622,7 @@ int create_partition_split_task(
     const int64_t parallelism,
     const int64_t parent_task_id,
     const int64_t task_id,
-    const obcall::ObPartitionSplitArg *partition_split_arg,
+    const obrpc::ObPartitionSplitArg *partition_split_arg,
     const uint64_t tenant_data_version,
     ObIAllocator &allocator,
     ObDDLTaskRecord &task_record);
@@ -636,7 +636,7 @@ int create_partition_split_task(
       const int64_t consumer_group_id,
       const int64_t task_id,
       const int32_t sub_task_trace_id,
-      const obcall::ObAlterTableArg *alter_table_arg,
+      const obrpc::ObAlterTableArg *alter_table_arg,
       const uint64_t tenant_data_version,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
@@ -647,7 +647,7 @@ int create_partition_split_task(
       const int64_t schema_version,
       const int64_t snapshot_version,
       const int64_t parent_task_id,
-      const obcall::ObForkTableArg *fork_table_arg,
+      const obrpc::ObForkTableArg *fork_table_arg,
       ObIAllocator &allocator,
       ObDDLTaskRecord &task_record);
 

--- a/src/rootserver/ddl_task/ob_ddl_task.h
+++ b/src/rootserver/ddl_task/ob_ddl_task.h
@@ -261,7 +261,7 @@ public:
                        const int64_t parallelism,
                        const int64_t consumer_group_id,
                        ObIAllocator *allocator,
-                       const obcall::ObDDLArg *ddl_arg = nullptr,
+                       const obrpc::ObDDLArg *ddl_arg = nullptr,
                        const int64_t parent_task_id = 0,
                        const int64_t task_id = 0,
                        const bool ddl_need_retry_at_executor = false);
@@ -286,7 +286,7 @@ public:
   share::ObDDLType type_;
   const ObTableSchema *src_table_schema_;
   const ObTableSchema *dest_table_schema_;
-  const obcall::ObDDLArg *ddl_arg_;
+  const obrpc::ObDDLArg *ddl_arg_;
   common::ObIAllocator *allocator_;
   const ObTableSchema *aux_rowkey_doc_schema_;
   const ObTableSchema *aux_doc_rowkey_schema_;
@@ -604,6 +604,7 @@ private:
       common::ObIArray<int> &ret_array,
       common::ObIArray<int64_t> &snapshot_array,
       const uint64_t tenant_id,
+      obrpc::ObSrvRpcProxy *rpc_proxy,
       share::ObLocationService *location_service,
       const bool need_wait_trans_end,
       const bool need_write_defensive);
@@ -613,6 +614,7 @@ private:
       const uint64_t tenant_id,
       const int64_t sstable_exist_ts,
       const common::ObIArray<common::ObTabletID> &tablet_ids,
+      obrpc::ObSrvRpcProxy *rpc_proxy,
       share::ObLocationService *location_service,
       common::ObIArray<int> &ret_array,
       common::ObIArray<int64_t> &snapshot_array);
@@ -757,8 +759,8 @@ public:
   uint64_t get_gmt_create() const { return gmt_create_; }
   void set_gmt_create(uint64_t gmt_create) { gmt_create_ = gmt_create; }
   static int deep_copy_table_arg(common::ObIAllocator &allocator, 
-                                 const obcall::ObDDLArg &source_arg, 
-                                 obcall::ObDDLArg &dest_arg);
+                                 const obrpc::ObDDLArg &source_arg, 
+                                 obrpc::ObDDLArg &dest_arg);
   void set_longops_stat(share::ObDDLLongopsStat *longops_stat) { longops_stat_ = longops_stat; }
   share::ObDDLLongopsStat *get_longops_stat() const { return longops_stat_; }
   uint64_t get_data_format_version() const { return data_format_version_; }

--- a/src/share/CMakeLists.txt
+++ b/src/share/CMakeLists.txt
@@ -77,6 +77,8 @@ ob_set_subtarget(ob_share ALONE
   ob_tenant_mgr.cpp
   parameter/ob_parameter_attr.cpp
   schema/ob_schema_service_sql_impl.cpp
+  ob_srv_rpc_proxy.cpp
+  ob_common_rpc_proxy.cpp
   ob_ddl_args.cpp
   ob_mview_args.cpp
   ob_lonely_table_clean_rpc_struct.cpp
@@ -208,6 +210,7 @@ ob_set_subtarget(ob_share common
   ob_proposal_id.cpp
   ob_plugin_helper.cpp
   ob_resource_limit.cpp
+  ob_rpc_share.cpp
   ob_scanner.cpp
   ob_schema_status_proxy.cpp
   ob_server_blacklist.cpp
@@ -278,7 +281,7 @@ ob_set_subtarget(ob_share common_mixed
   diagnosis/ob_sql_monitor_statname.cpp
   diagnosis/ob_sql_plan_monitor_node_list.cpp
   interrupt/ob_global_interrupt_call.cpp
-  interrupt/ob_interrupt_message.cpp
+  interrupt/ob_interrupt_rpc_proxy.cpp
   location_cache/ob_location_service.cpp
   location_cache/ob_location_struct.cpp
   inner_table/ob_inner_table_schema.vt.cpp
@@ -425,7 +428,12 @@ ob_set_subtarget(ob_share redolog
 )
 
 ob_set_subtarget(ob_share rpc
+  rpc/ob_batch_processor.cpp
+  rpc/ob_batch_proxy.cpp
+  rpc/ob_batch_rpc.cpp
   rpc/ob_blacklist_proxy.cpp
+  rpc/ob_blacklist_req_processor.cpp
+  rpc/ob_blacklist_resp_processor.cpp
 )
 
 ob_set_subtarget(ob_share resource_manager
@@ -466,6 +474,7 @@ ob_set_subtarget(ob_share schema
   schema/ob_schema_printer_external_table.cpp
   schema/ob_schema_retrieve_utils.ipp
   schema/ob_schema_service.cpp
+  schema/ob_schema_service_rpc_proxy.cpp
   schema/ob_schema_store.cpp
   schema/ob_schema_utils.cpp
   schema/ob_sequence_mgr.cpp
@@ -562,6 +571,7 @@ ob_set_subtarget(ob_share stat
 
 ob_set_subtarget(ob_share external_table
   external_table/ob_external_table_file_mgr.cpp
+  external_table/ob_external_table_file_rpc_processor.cpp
   external_table/ob_external_table_file_task.cpp
   external_table/ob_external_table_utils.cpp
   external_table/ob_external_table_part_info.cpp

--- a/src/share/cache/ob_kvcache_map.cpp
+++ b/src/share/cache/ob_kvcache_map.cpp
@@ -30,7 +30,6 @@ namespace common
 ObKVCacheMap::ObKVCacheMap()
     : is_inited_(false),
       bucket_allocator_(ObMemAttr(OB_SERVER_TENANT_ID, "CACHE_MAP_BKT", ObCtxIds::DEFAULT_CTX_ID)),
-      node_allocator_(),
       bucket_start_pos_(0),
       bucket_num_(0),
       bucket_size_(0),
@@ -59,10 +58,6 @@ int ObKVCacheMap::init(const int64_t bucket_num, ObKVCacheStore *store)
     COMMON_LOG(WARN, "Fail to init bucket lock, ", K(bucket_num), K(ret));
   } else if (OB_FAIL(global_hazard_station_.init(HAZARD_STATION_WAITING_THRESHOLD, HAZARD_STATION_SLOT_NUM))) {
     COMMON_LOG(WARN, "Fail to init hazard version, ", K(ret));
-  } else if (OB_FAIL(node_allocator_.init(OB_MALLOC_MIDDLE_BLOCK_SIZE,
-                                          ObMemAttr(OB_SYS_TENANT_ID, "CACHE_MAP_NODE"),
-                                          1))) {
-    COMMON_LOG(WARN, "Fail to init shared node allocator", K(ret));
   } else {
     bucket_size_ = DEFAULT_BUCKET_SIZE;
     if (is_mini_mode()) {
@@ -75,15 +70,15 @@ int ObKVCacheMap::init(const int64_t bucket_num, ObKVCacheStore *store)
       ret = OB_ALLOCATE_MEMORY_FAILED;
       COMMON_LOG(WARN, "failed to allocate bucket array", K(ret), K(bucket_cnt));
     } else {
+      Node **nodes = NULL;
       MEMSET(buckets_, 0, sizeof(Bucket) * bucket_cnt);
-      Node **all_nodes = static_cast<Node **>(bucket_allocator_.alloc(sizeof(Node *) * bucket_num));
-      if (OB_ISNULL(all_nodes)) {
-        ret = OB_ALLOCATE_MEMORY_FAILED;
-        COMMON_LOG(WARN, "failed to allocate all nodes", K(ret), K(bucket_num));
-      } else {
-        memset(all_nodes, 0, sizeof(Node *) * bucket_num);
-        for (int64_t i = 0; i < bucket_cnt; ++i) {
-          buckets_[i].nodes_ = all_nodes + i * bucket_size_;
+      for (int64_t i = 0; OB_SUCC(ret) && i < bucket_cnt; ++i) {
+        if (OB_ISNULL(nodes = static_cast<Node **>(bucket_allocator_.alloc(sizeof(Node *) * bucket_size_)))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          COMMON_LOG(WARN, "failed to allocate bucket", K(ret), K(i), K(bucket_cnt));
+        } else {
+          memset(nodes, 0, sizeof(Node *) * bucket_size_);
+          buckets_[i].nodes_ = nodes;
         }
       }
     }
@@ -102,7 +97,6 @@ int ObKVCacheMap::init(const int64_t bucket_num, ObKVCacheStore *store)
 
 void ObKVCacheMap::destroy()
 {
-  int ret = OB_SUCCESS;
   if (NULL != buckets_) {
     if (is_inited_) {
       ObKVCacheHazardGuard hazard_guard(global_hazard_station_);
@@ -120,22 +114,19 @@ void ObKVCacheMap::destroy()
           iter = NULL;
         }
       }  // hazard version guard
-      int tmp_ret = global_hazard_station_.retire();
-      if (OB_SUCCESS != tmp_ret) {
-        _OB_LOG(WARN, "Fail to retire hazard nodes before destroy, ret=%d", tmp_ret);
-      }
     }
-    const int64_t bucket_cnt = bucket_size_ == 0 ? 0 : (bucket_num_ % bucket_size_ == 0 ?
-      bucket_num_ / bucket_size_ : bucket_num_ / bucket_size_ + 1);
-    if (bucket_cnt > 0 && NULL != buckets_[0].nodes_) {
-      bucket_allocator_.free(buckets_[0].nodes_);
-      buckets_[0].nodes_ = NULL;
+    const int64_t bucket_cnt = bucket_num_ % bucket_size_ == 0 ?
+      bucket_num_ / bucket_size_ : bucket_num_ / bucket_size_ + 1;
+    for (int64_t i = 0; i < bucket_cnt; ++i) {
+      if (NULL != buckets_[i].nodes_) {
+        bucket_allocator_.free(buckets_[i].nodes_);
+        buckets_[i].nodes_ = NULL;
+      }
     }
     bucket_allocator_.free(buckets_);
     buckets_ = NULL;
   }
   global_hazard_station_.destroy();
-  node_allocator_.destroy();
   bucket_lock_.destroy();
   bucket_num_ = 0;
   bucket_size_ = 0;
@@ -226,7 +217,7 @@ int ObKVCacheMap::put(
           (void) ATOMIC_SAF(&iter->inst_->status_.kv_cnt_, 1);
           internal_map_erase(hazard_guard, prev, iter, bucket_ptr);
         } else {
-          if (OB_NOT_NULL(iter->inst_->node_allocator_) && iter->inst_->node_allocator_->is_fragment(iter)) {
+          if (iter->inst_->node_allocator_.is_fragment(iter)) {
             internal_map_replace(hazard_guard, prev, iter, bucket_ptr);
           }
           if (hash_code == iter->hash_code_) {
@@ -248,10 +239,7 @@ int ObKVCacheMap::put(
       if (OB_SUCC(ret)) {
         Node *new_node = NULL;
         void *buf = NULL;
-        if (OB_ISNULL(inst.node_allocator_)) {
-          ret = OB_ERR_UNEXPECTED;
-          COMMON_LOG(ERROR, "Unexpected null node allocator", K(ret), K(inst.cache_id_));
-        } else if (NULL == (buf = inst.node_allocator_->alloc(sizeof(Node)))) {
+        if (NULL == (buf = inst.node_allocator_.alloc(sizeof(Node)))) {
           ret = OB_ALLOCATE_MEMORY_FAILED;
           COMMON_LOG(ERROR, "Fail to allocate memory, ", K(ret), "size", sizeof(Node));
         } else {
@@ -423,7 +411,7 @@ int ObKVCacheMap::erase(const int64_t cache_id, const ObIKVCacheKey &key)
         if (OB_FAIL(hazptr_holder.protect(protect_success, iter->mb_handle_, iter->seq_num_))) {
           COMMON_LOG(WARN, "protect failed", KP(iter->mb_handle_));
         } else if (protect_success) {
-          if (OB_NOT_NULL(iter->inst_->node_allocator_) && iter->inst_->node_allocator_->is_fragment(iter)) {
+          if (iter->inst_->node_allocator_.is_fragment(iter)) {
             internal_map_replace(hazard_guard, prev, iter, bucket_ptr);
           }
           if (hash_code == iter->hash_code_ && OB_SUCC(key.equal(*iter->key_, is_equal)) && is_equal) {
@@ -775,7 +763,7 @@ int ObKVCacheMap::replace_fragment_node(int64_t &start_pos, int64_t &replace_nod
           iter = bucket_ptr;
           int64_t node_count = 0;
           while (NULL != iter) {
-            if (OB_NOT_NULL(iter->inst_->node_allocator_) && iter->inst_->node_allocator_->is_fragment(iter)) {
+            if (iter->inst_->node_allocator_.is_fragment(iter)) {
               internal_map_replace(hazard_guard, prev, iter, bucket_ptr);
               ++node_count;
             }
@@ -876,8 +864,7 @@ void ObKVCacheMap::internal_map_replace(const ObKVCacheHazardGuard &guard,
   if (NULL != iter) {
     Node *new_node = NULL;
     void *buf = NULL;
-    if (OB_NOT_NULL(iter->inst_->node_allocator_)
-        && NULL != (buf = iter->inst_->node_allocator_->alloc(sizeof(Node)))) {
+     if (NULL != (buf = iter->inst_->node_allocator_.alloc(sizeof(Node)))) {
       new_node = new (buf) Node();
       *new_node = *iter;
 
@@ -907,14 +894,11 @@ int ObKVCacheMap::internal_data_move(const ObKVCacheHazardGuard &guard,
   ObKVCachePair *new_kvpair = NULL;
   ObKVMemBlockHandle *new_mb_handle = NULL;
   HazptrHolder hazptr_holder;
-  if (OB_ISNULL(old_iter->inst_->node_allocator_)) {
-    ret = OB_ERR_UNEXPECTED;
-    COMMON_LOG(WARN, "Unexpected null node allocator", K(ret), KPC(old_iter));
-  } else if (NULL == (buf = old_iter->inst_->node_allocator_->alloc(sizeof(Node)))) {
+  if (NULL == (buf = old_iter->inst_->node_allocator_.alloc(sizeof(Node)))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     COMMON_LOG(WARN, "Fail to allocate memory for Node, ", K(ret), "size:", sizeof(Node));
   } else if (OB_FAIL(store_->store(*old_iter->key_, *old_iter->value_, new_kvpair, hazptr_holder, LFU))) {
-    old_iter->inst_->node_allocator_->free(buf);
+    old_iter->inst_->node_allocator_.free(buf);
     COMMON_LOG(WARN, "Fail to move kvpair ", K(ret));
   } else {
     new_mb_handle = hazptr_holder.get_mb_handle();
@@ -957,12 +941,7 @@ int ObKVCacheMap::internal_data_move(const ObKVCacheHazardGuard &guard,
 
 void ObKVCacheMap::Node::retire()
 {
-  int ret = OB_SUCCESS;
-  if (OB_NOT_NULL(inst_) && OB_NOT_NULL(inst_->node_allocator_)) {
-    inst_->node_allocator_->free(this);
-  } else {
-    _OB_LOG(ERROR, "Invalid node allocator when retire, inst=%p, node=%p", inst_, this);
-  }
+  inst_->node_allocator_.free(this);
 }
 
 }//end namespace common

--- a/src/share/cache/ob_kvcache_store.cpp
+++ b/src/share/cache/ob_kvcache_store.cpp
@@ -98,6 +98,7 @@ ObKVCacheStore::ObKVCacheStore()
       active_mb_handles_{NULL},
       global_status_(),
       wash_out_lock_(common::ObLatchIds::WASH_OUT_LOCK),
+      mb_ptr_pool_(),
       washable_size_allocator_(),
       washbale_size_info_(),
       tmp_washbale_size_info_(),
@@ -167,10 +168,6 @@ void ObKVCacheStore::destroy()
 {
   int ret = OB_SUCCESS;
 
-  if (!inited_) {
-    return;
-  }
-
   if (NULL != mb_handles_) {
     for (int64_t i = 0; i < max_mb_num_; ++i) {
       if (FREE != mb_handles_[i].status_) {
@@ -190,7 +187,6 @@ void ObKVCacheStore::destroy()
   block_payload_size_ = 0;
 
   destroy_wash_structs();
-  cur_mb_num_ = 0;
   inited_ = false;
 }
 
@@ -373,6 +369,7 @@ bool ObKVCacheStore::wash()
     wash_itid_ = get_itid();
   }
   lib::ObMutexGuard guard(wash_out_lock_);
+  reuse_wash_structs();
 
   //compute the wash size of each tenant
   start_time = ObTimeUtility::current_time();
@@ -394,9 +391,13 @@ bool ObKVCacheStore::wash()
 
   tmp_washbale_size_info_.reuse();
 
-  wash_heap_.mb_cnt_ = 0;
+  WashHeap global_wash_heap;
   int64_t heap_size = global_wash_size / block_size_;
-  wash_heap_.heap_size_ = std::min(heap_size, WASH_HEAP_SIZE);
+  if (heap_size > 0) {
+    if (OB_FAIL(init_wash_heap(global_wash_heap, heap_size))) {
+      COMMON_LOG(WARN, "init_wash_heap failed", K(ret), K(heap_size));
+    }
+  }
 
   // refresh score and sort mb_handles to wash in a single pass
   HazptrHolder hazptr_holder;
@@ -420,8 +421,8 @@ bool ObKVCacheStore::wash()
         if (score <= WASH_OUT_SCORE_THRESHOLD) {
           wash_mb(&mb_handles_[i]);
           washed = true;
-          if (wash_heap_.heap_size_ > 0) {
-            wash_heap_.heap_size_--;
+          if (global_wash_heap.heap_size_ > 0) {
+            global_wash_heap.heap_size_--;
           }
         }
         if (!washed) {
@@ -433,7 +434,7 @@ bool ObKVCacheStore::wash()
                       K(tmp_ret),
                       K(OB_SERVER_TENANT_ID));
           }
-          wash_heap_.add(&mb_handles_[i]);
+          global_wash_heap.add(&mb_handles_[i]);
         }
       }
       //any error should not break washing, so reset ret to OB_SUCCESS
@@ -446,11 +447,11 @@ bool ObKVCacheStore::wash()
   }
 
   //wash memory in tenant wash heap
-  if (wash_heap_.mb_cnt_ > 0) {
-    wash_mbs(wash_heap_);
+  if (global_wash_heap.mb_cnt_ > 0) {
+    wash_mbs(global_wash_heap);
     COMMON_LOG(INFO, "Wash memory globally, ",
         K(global_wash_size),
-        "wash_heap_cnt", wash_heap_.mb_cnt_);
+        "wash_heap_cnt", global_wash_heap.mb_cnt_);
   }
   wash_time = ObTimeUtility::current_time() - start_time;
   WashCallBack callback(*this, reclaimed_size);
@@ -1231,10 +1232,8 @@ int ObKVCacheStore::init_wash_heap(WashHeap &heap, const int64_t heap_size)
   heap.mb_cnt_ = 0;
   if (heap_size > 0) {
     heap.heap_size_ = heap_size;
-    heap.heap_ = static_cast<ObKVMemBlockHandle **>(ob_malloc(heap_size * sizeof(ObKVMemBlockHandle *), ObModIds::OB_KVSTORE_CACHE_WASH_STRUCT));
-    if (NULL == heap.heap_) {
-      ret = OB_ALLOCATE_MEMORY_FAILED;
-      COMMON_LOG(WARN, "init_wash_heap ob_malloc failed", K(ret), K(heap_size));
+    if (OB_FAIL(mb_ptr_pool_.alloc(heap_size, heap.heap_))) {
+      COMMON_LOG(WARN, "mb_ptr_free_heap_ sbrk failed", K(ret), K(heap_size));
     }
   } else {
     heap.heap_size_ = 0;
@@ -1256,16 +1255,23 @@ int ObKVCacheStore::prepare_wash_structs()
     COMMON_LOG(WARN, "Fail to init washable size info", K(ret));
   } else if (OB_FAIL(tmp_washbale_size_info_.init(1/*tenant_node_size*/, bucket_num, washable_size_allocator_))) {
     COMMON_LOG(WARN, "Fail to init tmp washable size info", K(ret));
-  } else if (OB_FAIL(init_wash_heap(wash_heap_, WASH_HEAP_SIZE))) {
-    COMMON_LOG(WARN, "Fail to pre-allocate wash heap", K(ret));
+  } else if (OB_FAIL(mb_ptr_pool_.init(2 * max_mb_num_, label))) {
+    COMMON_LOG(WARN, "mb_ptr_pool_ init failed", K(ret), K_(max_mb_num));
   }
 
   return ret;
 }
 
+void ObKVCacheStore::reuse_wash_structs()
+{
+  int ret = OB_SUCCESS;
+  mb_ptr_pool_.reuse();
+}
+
 void ObKVCacheStore::destroy_wash_structs()
 {
-  wash_heap_.reset();
+  int ret = OB_SUCCESS;
+  mb_ptr_pool_.destroy();
   washbale_size_info_.destroy();
   tmp_washbale_size_info_.destroy();
   washable_size_allocator_.reset();
@@ -1419,7 +1425,6 @@ ObKVCacheStore::WashHeap::WashHeap()
 
 ObKVCacheStore::WashHeap::~WashHeap()
 {
-  reset();
 }
 
 ObKVMemBlockHandle *ObKVCacheStore::WashHeap::add(ObKVMemBlockHandle *mb_handle)
@@ -1441,12 +1446,82 @@ ObKVMemBlockHandle *ObKVCacheStore::WashHeap::add(ObKVMemBlockHandle *mb_handle)
 
 void ObKVCacheStore::WashHeap::reset()
 {
-  if (NULL != heap_) {
-    ob_free(heap_);
-    heap_ = NULL;
-  }
+  heap_ = NULL;
   heap_size_ = 0;
   mb_cnt_ = 0;
+}
+
+ObKVCacheStore::MBHandlePointerWashPool::MBHandlePointerWashPool()
+  : inited_(false), 
+    total_count_(0),
+    free_count_(0),
+    buf_(nullptr),
+    allocator_(ObModIds::OB_KVSTORE_CACHE_WASH_STRUCT)
+{
+}
+
+int ObKVCacheStore::MBHandlePointerWashPool::init(const int64_t count, const char *label)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(inited_)) {
+    ret = OB_INIT_TWICE;
+    COMMON_LOG(WARN, "init twice!", K(ret));
+  } else if (count <= 0 || nullptr == label) {
+    ret = OB_INVALID_ARGUMENT;
+    COMMON_LOG(WARN, "invalid argument", K(ret));
+  } else {
+    allocator_.set_label(label);
+    buf_ = static_cast<ObKVMemBlockHandle **>(allocator_.alloc(sizeof(ObKVMemBlockHandle *) * count));
+    if (nullptr == buf_) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      COMMON_LOG(WARN, "alloc memory failed", K(ret));
+    } else {
+      MEMSET(buf_, 0, sizeof(ObKVMemBlockHandle *) * count);
+      total_count_ = count;
+      free_count_ = count;
+      inited_ = true;
+    }
+  }
+
+  return ret;
+}
+
+int ObKVCacheStore::MBHandlePointerWashPool::alloc(const int64_t count, ObKVMemBlockHandle **&heap)
+{
+  int ret = OB_SUCCESS;
+  if(OB_UNLIKELY(!inited_)) {
+    ret = OB_NOT_INIT;
+    COMMON_LOG(WARN, "not init", K(ret));
+  } else if (count <= 0) {
+    ret = OB_INVALID_ARGUMENT;
+    COMMON_LOG(WARN, "invalid argument", K(ret));
+  } else if (count > free_count_) {
+    ret = OB_BUF_NOT_ENOUGH;
+  } else {
+    free_count_ -= count;
+    heap = buf_ + free_count_;
+  }
+
+  return ret;
+}
+
+void ObKVCacheStore::MBHandlePointerWashPool::reuse()
+{
+  free_count_ = total_count_;
+}
+
+int ObKVCacheStore::MBHandlePointerWashPool::destroy()
+{
+  int ret = OB_SUCCESS;
+  if (OB_LIKELY(inited_)) {
+    free_count_ = 0;
+    total_count_ = 0;
+    allocator_.free(buf_);
+    buf_ = nullptr;
+    inited_ = false;
+  }
+
+  return ret;
 }
 
 }//end namespace common

--- a/src/share/io/ob_io_manager.cpp
+++ b/src/share/io/ob_io_manager.cpp
@@ -17,7 +17,6 @@
 #define USING_LOG_PREFIX COMMON
 
 #include "ob_io_manager.h"
-#include "observer/net/ob_shared_storage_net_throt_rpc_struct.h"
 #include "share/errsim_module/ob_errsim_module_interface_imp.h"
 #include "observer/ob_server.h"
 #include "src/share/io/io_schedule/ob_io_schedule_v2.h"
@@ -115,14 +114,14 @@ int ObTrafficControl::ObSharedDeviceIORecord::calc_usage(ObIORequest &req)
 // when use this interface input array default size shoulde be ResourceTypeCnt
 void ObTrafficControl::ObSharedDeviceIORecord::reset_total_size(ResourceUsage usages[])
 {
-  usages[obcall::ResourceType::ibw].type_   = obcall::ResourceType::ibw;
-  usages[obcall::ResourceType::ibw].total_  = ibw_.clear();
-  usages[obcall::ResourceType::obw].type_   = obcall::ResourceType::obw;
-  usages[obcall::ResourceType::obw].total_  = obw_.clear();
-  usages[obcall::ResourceType::ips].type_   = obcall::ResourceType::ips;
-  usages[obcall::ResourceType::ips].total_  = ips_.clear();
-  usages[obcall::ResourceType::ops].type_   = obcall::ResourceType::ops;
-  usages[obcall::ResourceType::ops].total_  = ops_.clear();
+  usages[obrpc::ResourceType::ibw].type_   = obrpc::ResourceType::ibw;
+  usages[obrpc::ResourceType::ibw].total_  = ibw_.clear();
+  usages[obrpc::ResourceType::obw].type_   = obrpc::ResourceType::obw;
+  usages[obrpc::ResourceType::obw].total_  = obw_.clear();
+  usages[obrpc::ResourceType::ips].type_   = obrpc::ResourceType::ips;
+  usages[obrpc::ResourceType::ips].total_  = ips_.clear();
+  usages[obrpc::ResourceType::ops].type_   = obrpc::ResourceType::ops;
+  usages[obrpc::ResourceType::ops].total_  = ops_.clear();
 }
 
 ObTrafficControl::ObSharedDeviceControlV2::ObSharedDeviceControlV2()
@@ -138,13 +137,13 @@ ObTrafficControl::ObSharedDeviceControlV2::~ObSharedDeviceControlV2()
 int ObTrafficControl::ObSharedDeviceControlV2::init()
 {
   int ret = OB_SUCCESS;
-  limits_[obcall::ResourceType::ops] = INT64_MAX / 2;
-  limits_[obcall::ResourceType::ips] = INT64_MAX / 2;
-  limits_[obcall::ResourceType::iops] = INT64_MAX;
-  limits_[obcall::ResourceType::obw] = INT64_MAX / (16 * (1<<11));
-  limits_[obcall::ResourceType::ibw] = INT64_MAX / (16 * (1<<11));
-  limits_[obcall::ResourceType::iobw] = INT64_MAX / (16 * (1<<10));
-  limits_[obcall::ResourceType::tag] = INT64_MAX;
+  limits_[obrpc::ResourceType::ops] = INT64_MAX / 2;
+  limits_[obrpc::ResourceType::ips] = INT64_MAX / 2;
+  limits_[obrpc::ResourceType::iops] = INT64_MAX;
+  limits_[obrpc::ResourceType::obw] = INT64_MAX / (16 * (1<<11));
+  limits_[obrpc::ResourceType::ibw] = INT64_MAX / (16 * (1<<11));
+  limits_[obrpc::ResourceType::iobw] = INT64_MAX / (16 * (1<<10));
+  limits_[obrpc::ResourceType::tag] = INT64_MAX;
   storage_key_  = ObStorageKey();
   return ret;
 }
@@ -182,12 +181,12 @@ int ObTrafficControl::ObSharedDeviceControlV2::is_group_key_exist(const ObIOSSGr
   return group_list_.is_group_key_exist(grp_key);
 }
 
-int64_t ObTrafficControl::ObSharedDeviceControlV2::get_limit(const obcall::ResourceType type) const
+int64_t ObTrafficControl::ObSharedDeviceControlV2::get_limit(const obrpc::ResourceType type) const
 {
   return limits_[static_cast<int>(type)];
 }
 
-int ObTrafficControl::ObSharedDeviceControlV2::update_limit(const obcall::ObSharedDeviceResource &limit)
+int ObTrafficControl::ObSharedDeviceControlV2::update_limit(const obrpc::ObSharedDeviceResource &limit)
 {
   int ret = OB_SUCCESS;
   limits_[static_cast<int>(limit.type_)] = limit.value_;
@@ -352,7 +351,7 @@ void ObTrafficControl::print_bucket_status_V2()
   shared_device_map_v2_.foreach_refactored(fn);
 }
 
-int ObTrafficControl::set_limit_v2(const obcall::ObSharedDeviceResourceArray &limit)
+int ObTrafficControl::set_limit_v2(const obrpc::ObSharedDeviceResourceArray &limit)
 {
   int ret = OB_SUCCESS;
   inner_calc_();

--- a/src/share/io/ob_io_manager.h
+++ b/src/share/io/ob_io_manager.h
@@ -26,7 +26,7 @@
 
 namespace oceanbase
 {
-namespace obcall
+namespace obrpc
 {
 struct ObSharedDeviceResource;
 struct ObSharedDeviceResourceArray;
@@ -62,7 +62,7 @@ inline const char *get_resource_type_str(const ResourceType type)
   }
   return str;
 }
-}  // namespace obcall
+}  // namespace obrpc
 namespace common
 {
 int64_t get_norm_iops(const int64_t size, const double iops, const ObIOMode mode);
@@ -74,11 +74,11 @@ class ObSSIORequest;
 
 struct ResourceUsage
 {
-  ResourceUsage() : type_(obcall::ResourceType::ResourceTypeCnt), total_(0)
+  ResourceUsage() : type_(obrpc::ResourceType::ResourceTypeCnt), total_(0)
   {}
   ~ResourceUsage()
   {}
-  obcall::ResourceType type_;
+  obrpc::ResourceType type_;
   int64_t total_;
 };
 
@@ -223,11 +223,11 @@ public:
     int set_storage_key(const ObTrafficControl::ObStorageKey &key);
     int add_group(const ObIOSSGrpKey &grp_key);
     int is_group_key_exist(const ObIOSSGrpKey &grp_key);
-    int64_t get_limit(const obcall::ResourceType type) const;
-    int update_limit(const obcall::ObSharedDeviceResource &limit);
+    int64_t get_limit(const obrpc::ResourceType type) const;
+    int update_limit(const obrpc::ObSharedDeviceResource &limit);
     ObStorageKey storage_key_;
     // limit: ops = 0, ips = 1, iops = 2, obw = 3, ibw = 4, iobw = 5, tag = 6
-    int64_t limits_[static_cast<int>(obcall::ResourceType::ResourceTypeCnt)];
+    int64_t limits_[static_cast<int>(obrpc::ResourceType::ResourceTypeCnt)];
     ObSDGroupList group_list_;
   };
 
@@ -236,7 +236,7 @@ public:
   int calc_usage(ObIORequest &req);
   void print_server_status();
   void print_bucket_status_V2();
-  int set_limit_v2(const obcall::ObSharedDeviceResourceArray &limit);
+  int set_limit_v2(const obrpc::ObSharedDeviceResourceArray &limit);
   template <class _cb>
   int foreach_limit_v2(_cb &cb) const { return shared_device_map_v2_.foreach_refactored(cb); }
   template<class _cb>

--- a/src/share/ob_timezone_importer.cpp
+++ b/src/share/ob_timezone_importer.cpp
@@ -30,7 +30,7 @@ namespace oceanbase
 using namespace share;
 using namespace sql;
 using namespace common;
-using namespace obcall;
+using namespace obrpc;
 namespace table
 {
 

--- a/src/share/schema/ob_ddl_trans_controller.cpp
+++ b/src/share/schema/ob_ddl_trans_controller.cpp
@@ -126,7 +126,8 @@ int ObDDLTransController::broadcast_consensus_version(const int64_t tenant_id,
                                                       const ObArray<ObAddr> &server_list)
 {
   int ret = OB_SUCCESS;
-  obcall::ObBroadcastConsensusVersionArg arg;
+  obrpc::ObBroadcastConsensusVersionArg arg;
+  rootserver::ObBroadcstConsensusVersionProxy proxy(*GCTX.srv_rpc_proxy_, &obrpc::ObSrvRpcProxy::broadcast_consensus_version);
   if (!inited_) {
     ret = OB_NOT_INIT;
     LOG_WARN("ObDDLTransController", KR(ret));
@@ -147,20 +148,28 @@ int ObDDLTransController::broadcast_consensus_version(const int64_t tenant_id,
   } else {
     arg.set_tenant_id(tenant_id);
     arg.set_consensus_version(schema_version);
-    obcall::ObBroadcastConsensusVersionRes result;
+    const int64_t rpc_timeout = GCONF.rpc_timeout;
     FOREACH_X(s, server_list, OB_SUCC(ret)) {
       if (OB_ISNULL(s)) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("s is null", KR(ret));
       } else {
-        // Direct call — seekdb has no remote servers.
-        UNUSED(*s);
-        int tmp_ret = GCTX.ob_service_->broadcast_consensus_version(arg, result);
-        if (OB_SUCCESS != tmp_ret) {
-          LOG_WARN("broadcast consensus version failed", KR(tmp_ret),
-              K(schema_version), K(arg));
+        // overwrite ret
+        if (OB_FAIL(proxy.call(*s, rpc_timeout, arg))) {
+          LOG_WARN("send broadcast consensus version rpc failed", KR(ret),
+              K(rpc_timeout), K(schema_version), K(arg), "server", *s);
+          ret = OB_SUCCESS;
         }
       }
+    }
+    int tmp_ret = OB_SUCCESS;
+    ObArray<int> return_code_array;
+    if (OB_TMP_FAIL(proxy.wait_all(return_code_array))) {
+      LOG_WARN("wait result failed", KR(tmp_ret), K(ret));
+      ret = OB_SUCC(ret) ? tmp_ret : ret;
+    } else if (OB_FAIL(ret)) {
+    } else {
+      // don't use arg/dest here beacause call() may has failure.
     }
   }
   LOG_INFO("broadcast consensus version finished", KR(ret), K(schema_version), K(arg), K(server_list));

--- a/src/share/schema/ob_multi_version_schema_service.cpp
+++ b/src/share/schema/ob_multi_version_schema_service.cpp
@@ -4199,7 +4199,7 @@ int ObMultiVersionSchemaService::get_tablet_to_table_history(
 
 // cal purge recyclebin need timeout
 int ObMultiVersionSchemaService::cal_purge_need_timeout(
-    const obcall::ObPurgeRecycleBinArg &purge_recyclebin_arg,
+    const obrpc::ObPurgeRecycleBinArg &purge_recyclebin_arg,
     int64_t &cal_timeout)
 {
   int ret = OB_SUCCESS;

--- a/src/sql/code_generator/ob_tsc_cg_service.cpp
+++ b/src/sql/code_generator/ob_tsc_cg_service.cpp
@@ -654,6 +654,8 @@ int ObTscCgService::generate_tsc_filter(const ObLogTableScan &op, ObTableScanSpe
   ObArray<ObRawExpr *> lookup_pushdown_filters;
   ObDASScanCtDef &scan_ctdef = spec.tsc_ctdef_.scan_ctdef_;
   ObDASScanCtDef *lookup_ctdef = spec.tsc_ctdef_.get_lookup_ctdef();
+  ObSqlSchemaGuard *schema_guard = nullptr;
+  const ObTableSchema *scan_table_schema = nullptr;
   if (OB_NOT_NULL(op.get_auto_split_filter())) {
     ObRawExpr *auto_split_expr = const_cast<ObRawExpr *>(op.get_auto_split_filter());
     if (OB_FAIL(scan_pushdown_filters.push_back(auto_split_expr))) {
@@ -718,6 +720,22 @@ int ObTscCgService::generate_tsc_filter(const ObLogTableScan &op, ObTableScanSpe
                                        lookup_ctdef->pd_expr_spec_))) {
     LOG_WARN("generate pd storage flag for lookup ctdef failed", K(ret));
   }
+  if (OB_FAIL(ret)) {
+  } else if (scan_pushdown_filters.empty() || !op.is_vec_adaptive_scan()) {
+    // do nothing
+  } else if (OB_ISNULL(cg_.opt_ctx_) ||
+             OB_ISNULL(schema_guard = cg_.opt_ctx_->get_sql_schema_guard())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null schema guard", K(ret), KP(cg_.opt_ctx_), KP(schema_guard));
+  } else if (OB_FAIL(schema_guard->get_table_schema(scan_ctdef.ref_table_id_, scan_table_schema))) {
+    LOG_WARN("get table schema failed", K(ret), K(scan_ctdef.ref_table_id_));
+  } else if (OB_ISNULL(scan_table_schema)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null table schema", K(ret), K(scan_ctdef.ref_table_id_));
+  } else if (OB_FAIL(prune_scan_pushdown_filters_by_table_columns(*scan_table_schema,
+                                                                  scan_pushdown_filters))) {
+    LOG_WARN("failed to prune scan pushdown filters", K(ret), K(scan_ctdef.ref_table_id_));
+  }
   if (OB_SUCC(ret) && !scan_pushdown_filters.empty()) {
     bool pd_filter = scan_ctdef.pd_expr_spec_.pd_storage_flag_.is_filter_pushdown();
     if (OB_FAIL(cg_.generate_rt_exprs(scan_pushdown_filters, scan_ctdef.pd_expr_spec_.pushdown_filters_))) {
@@ -764,6 +782,38 @@ int ObTscCgService::generate_tsc_filter(const ObLogTableScan &op, ObTableScanSpe
   return ret;
 }
 
+int ObTscCgService::prune_scan_pushdown_filters_by_table_columns(
+    const ObTableSchema &scan_table_schema,
+    ObIArray<ObRawExpr*> &scan_pushdown_filters) const
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<ObRawExpr*, 8> valid_filters;
+  ObSEArray<uint64_t, 8> column_ids;
+  for (int64_t i = 0; OB_SUCC(ret) && i < scan_pushdown_filters.count(); ++i) {
+    ObRawExpr *filter = scan_pushdown_filters.at(i);
+    bool can_push_to_scan = true;
+    column_ids.reuse();
+    if (OB_ISNULL(filter)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected null filter", K(ret), K(i));
+    } else if (OB_FAIL(ObRawExprUtils::extract_column_ids(filter, column_ids))) {
+      LOG_WARN("failed to extract column ids", K(ret), KPC(filter));
+    }
+    for (int64_t j = 0; OB_SUCC(ret) && can_push_to_scan && j < column_ids.count(); ++j) {
+      if (OB_ISNULL(scan_table_schema.get_column_schema(column_ids.at(j)))) {
+        can_push_to_scan = false;
+      }
+    }
+    if (OB_FAIL(ret)) {
+    } else if (can_push_to_scan && OB_FAIL(valid_filters.push_back(filter))) {
+      LOG_WARN("failed to push back valid filter", K(ret), KPC(filter));
+    }
+  }
+  if (OB_SUCC(ret) && OB_FAIL(scan_pushdown_filters.assign(valid_filters))) {
+    LOG_WARN("failed to assign scan pushdown filters", K(ret));
+  }
+  return ret;
+}
 
 int ObTscCgService::generate_pd_storage_flag(const ObLogPlan *log_plan,
                                              const uint64_t ref_table_id,
@@ -956,7 +1006,18 @@ int ObTscCgService::extract_das_access_exprs(const ObLogTableScan &op,
                                            scan_ctdef.ir_scan_type_ == OB_IR_FWD_IDX_AGG ||
                                            scan_ctdef.ir_scan_type_ == OB_IR_BLOCK_MAX_SCAN);
   const bool is_doc_id_index_back = (!op.is_vec_idx_scan() || !op.get_vector_index_info().is_vec_aux_table_id(scan_table_id)) && op.need_doc_id_index_back() && scan_table_id == op.get_doc_id_index_table_id();
-  if (op.need_skip_rowkey_doc() && (scan_table_id == op.get_doc_id_index_table_id() || scan_table_id == op.get_rowkey_doc_table_id())) {
+  ObSqlSchemaGuard *schema_guard = nullptr;
+  const ObTableSchema *scan_table_schema = nullptr;
+  if (OB_ISNULL(cg_.opt_ctx_) ||
+      OB_ISNULL(schema_guard = cg_.opt_ctx_->get_sql_schema_guard())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null schema guard", K(ret), KP(cg_.opt_ctx_), KP(schema_guard));
+  } else if (OB_FAIL(schema_guard->get_table_schema(scan_table_id, scan_table_schema))) {
+    LOG_WARN("get table schema failed", K(ret), K(scan_table_id));
+  } else if (OB_ISNULL(scan_table_schema)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null table schema", K(ret), K(scan_table_id));
+  } else if (op.need_skip_rowkey_doc() && (scan_table_id == op.get_doc_id_index_table_id() || scan_table_id == op.get_rowkey_doc_table_id())) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("skip rowkey doc is not supported", K(ret));
   } else if (is_func_lookup ||
@@ -1001,6 +1062,10 @@ int ObTscCgService::extract_das_access_exprs(const ObLogTableScan &op,
                                                                             scan_pushdown_filters,
                                                                             lookup_pushdown_filters))) {
         LOG_WARN("extract pushdown filters failed", K(ret));
+      } else if (op.is_vec_adaptive_scan() &&
+                 OB_FAIL(prune_scan_pushdown_filters_by_table_columns(*scan_table_schema,
+                                                                      scan_pushdown_filters))) {
+        LOG_WARN("failed to prune scan pushdown filters", K(ret), K(scan_table_id));
       } else if (OB_FAIL(ObRawExprUtils::extract_column_exprs(scan_pushdown_filters,
                                                               filter_columns))) {
         LOG_WARN("extract column exprs failed", K(ret));

--- a/src/sql/code_generator/ob_tsc_cg_service.h
+++ b/src/sql/code_generator/ob_tsc_cg_service.h
@@ -155,6 +155,9 @@ private:
                                const DASScanCGCtx &cg_ctx,
                                ObDASScanCtDef &scan_ctdef,
                                common::ObIArray<ObRawExpr*> &access_exprs);
+  int prune_scan_pushdown_filters_by_table_columns(
+      const share::schema::ObTableSchema &scan_table_schema,
+      common::ObIArray<ObRawExpr*> &scan_pushdown_filters) const;
   //extract these column exprs need by TSC operator, these column will output by DAS scan
   int extract_tsc_access_columns(const ObLogTableScan &op, common::ObIArray<ObRawExpr*> &access_exprs);
   int extract_das_column_ids(const common::ObIArray<ObRawExpr*> &column_exprs, common::ObIArray<uint64_t> &column_ids);

--- a/src/sql/das/ob_data_access_service.cpp
+++ b/src/sql/das/ob_data_access_service.cpp
@@ -46,9 +46,11 @@ int ObDataAccessService::mtl_init(ObDataAccessService *&das)
 {
   int ret = OB_SUCCESS;
   const ObAddr &self = GCTX.self_addr();
-  if (OB_FAIL(das->id_cache_.init(self))) {
+  observer::ObSrvNetworkFrame *net_frame = GCTX.net_frame_;
+  auto req_transport = net_frame->get_req_transport();
+  if (OB_FAIL(das->id_cache_.init(self, req_transport))) {
     LOG_ERROR("init das id service failed", K(ret));
-  } else if (OB_FAIL(das->init(self))) {
+  } else if (OB_FAIL(das->init(net_frame->get_req_transport(), self))) {
     LOG_ERROR("init data access service failed", K(ret));
   }
   return ret;
@@ -63,7 +65,7 @@ void ObDataAccessService::mtl_destroy(ObDataAccessService *&das)
   }
 }
 
-int ObDataAccessService::init(const ObAddr &self_addr)
+int ObDataAccessService::init(rpc::frame::ObReqTransport *transport, const ObAddr &self_addr)
 {
   int ret = OB_SUCCESS;
   if (OB_FAIL(task_result_mgr_.init())) {
@@ -472,19 +474,10 @@ int ObDataAccessService::push_parallel_task(ObDASRef &das_ref, ObDasAggregatedTa
     LOG_WARN("alloc memory failed", K(ret));
   } else if (OB_FAIL(task->init(&agg_task, timeout_ts, group_id))) {
     LOG_WARN("init parallel task failed", K(ret), K(agg_task));
+  } else if (OB_FAIL(omt->recv_request(MTL_ID(), *task))) {
+    LOG_WARN("fail to push parallel_das_task", K(ret), KPC(task));
   } else {
-    const uint64_t tenant_id = MTL_ID();
-    omt::ObTenant *tenant = nullptr;
-    if (OB_FAIL(omt->get_tenant(tenant_id, tenant))) {
-      LOG_WARN("get tenant failed", K(ret), K(tenant_id));
-    } else if (OB_ISNULL(tenant)) {
-      ret = OB_ERR_UNEXPECTED;
-      LOG_WARN("tenant is null", K(ret), K(tenant_id));
-    } else if (OB_FAIL(tenant->recv_request(*task))) {
-      LOG_WARN("fail to push parallel_das_task", K(ret), KPC(task));
-    } else {
-      LOG_TRACE("push parallel task succeed", K(agg_task));
-    }
+    LOG_TRACE("push parallel task succeed", K(agg_task));
   }
   if (OB_FAIL(ret)) {
     ObDASParallelTaskFactory::free(task);
@@ -607,6 +600,7 @@ int ObDataAccessService::setup_extra_result(ObDASRef &das_ref,
   } else if (OB_FAIL(extra_result->init(task_op->get_task_id(),
                                         timeout_ts,
                                         task_resp.get_runner_svr(),
+                                        GCTX.net_frame_->get_req_transport(),
                                         das_ref.enable_rich_format_))) {
     LOG_WARN("init extra data failed", KR(ret));
   } else {

--- a/src/sql/engine/cmd/ob_alter_system_executor.cpp
+++ b/src/sql/engine/cmd/ob_alter_system_executor.cpp
@@ -17,11 +17,6 @@
 #define USING_LOG_PREFIX SQL_ENG
 
 #include "sql/engine/cmd/ob_alter_system_executor.h"
-#include "rootserver/ob_rs_serial_call.h"
-#include "observer/ob_ex_rpc.h"
-#include "share/io/ob_io_manager.h"
-#include "storage/meta_store/ob_server_storage_meta_service.h"
-#include "storage/meta_store/ob_tenant_storage_meta_service.h"
 #include "observer/ob_server.h"
 #include "rootserver/standby/ob_standby_service.h" // ObStandbyService
 #include "sql/resolver/cmd/ob_switch_role_stmt.h" // ObSwitchRoleStmt
@@ -41,7 +36,7 @@
 namespace oceanbase
 {
 using namespace common;
-using namespace obcall;
+using namespace obrpc;
 using namespace share;
 using namespace omt;
 using namespace obmysql;
@@ -52,9 +47,16 @@ int ObFreezeExecutor::execute(ObExecContext &ctx, ObFreezeStmt &stmt)
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc_proxy = NULL;
+
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_FAIL(task_exec_ctx->get_common_rpc(common_rpc_proxy))) {
+    LOG_WARN("get common rpc proxy failed", K(ret));
+  } else if (OB_ISNULL(common_rpc_proxy)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("common_rpc_proxy is null", K(ret));
   } else {
     if (!stmt.is_major_freeze()) {
       const uint64_t local_tenant_id = MTL_ID();
@@ -133,8 +135,9 @@ int ObFreezeExecutor::execute(ObExecContext &ctx, ObFreezeStmt &stmt)
         }
       }
       if (OB_SUCC(ret)) {
-        if (OB_FAIL(GCTX.root_service_->root_minor_freeze(arg))) {
-          LOG_WARN("minor freeze failed", K(arg), K(ret), "dst", GCTX.self_addr());
+        int64_t timeout = THIS_WORKER.get_timeout_remain();
+        if (OB_FAIL(common_rpc_proxy->timeout(timeout).root_minor_freeze(arg))) {
+          LOG_WARN("minor freeze rpc failed", K(arg), K(ret), K(timeout), "dst", common_rpc_proxy->get_server());
         }
       }
     } else if (stmt.get_tablet_id().is_valid()) {
@@ -155,6 +158,7 @@ int ObFreezeExecutor::execute(ObExecContext &ctx, ObFreezeStmt &stmt)
       param.freeze_all_ = stmt.is_freeze_all();
       param.freeze_all_user_ = stmt.is_freeze_all_user();
       param.freeze_all_meta_ = stmt.is_freeze_all_meta();
+      param.transport_ = GCTX.net_frame_->get_req_transport();
       param.freeze_reason_ = rootserver::MF_USER_REQUEST;
       for (int64_t i = 0; i < stmt.get_tenant_ids().count() && OB_SUCC(ret); ++i) {
         uint64_t tenant_id = stmt.get_tenant_ids().at(i);
@@ -441,7 +445,7 @@ int ObFlushCacheExecutor::execute(ObExecContext &ctx, ObFlushCacheStmt &stmt)
       }
       //case CACHE_TYPE_BALANCE: {
       //  ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
-      //  ObCommonRpcProxy *common_rpc_proxy = NULL;
+      //  obrpc::ObCommonRpcProxy *common_rpc_proxy = NULL;
 
       //  if (OB_ISNULL(task_exec_ctx)) {
       //    ret = OB_NOT_INIT;
@@ -482,12 +486,16 @@ int ObFlushCacheExecutor::execute(ObExecContext &ctx, ObFlushCacheStmt &stmt)
     }
   } else { // flush global
     ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+    obrpc::ObCommonRpcProxy *common_rpc = NULL;
     if (OB_ISNULL(task_exec_ctx)) {
       ret = OB_NOT_INIT;
       LOG_WARN("get task executor context failed");
-    } else if (OB_FAIL(GCTX.root_service_->admin_flush_cache(
+    } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+      ret = OB_NOT_INIT;
+      LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+    } else if (OB_FAIL(common_rpc->admin_flush_cache(
                            stmt.flush_cache_arg_))) {
-      LOG_WARN("flush cache failed", K(ret), "rpc_arg", stmt.flush_cache_arg_);
+      LOG_WARN("flush cache rpc failed", K(ret), "rpc_arg", stmt.flush_cache_arg_);
     }
   }
   return ret;
@@ -498,9 +506,13 @@ int ObFlushKVCacheExecutor::execute(ObExecContext &ctx, ObFlushKVCacheStmt &stmt
   UNUSED(stmt);
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
   } else {
     share::schema::ObSchemaGetterGuard schema_guard;
     if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(
@@ -560,7 +572,7 @@ int ObFlushIlogCacheExecutor::execute(ObExecContext &ctx, ObFlushIlogCacheStmt &
   UNUSEDx(ctx, stmt);
   int ret = OB_NOT_SUPPORTED;
   // ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
-  // ObCommonRpcProxy *common_rpc = NULL;
+  // obrpc::ObCommonRpcProxy *common_rpc = NULL;
   // if (OB_ISNULL(task_exec_ctx)) {
   //   ret = OB_NOT_INIT;
   //   LOG_WARN("get task executor context failed");
@@ -596,9 +608,13 @@ int ObFlushDagWarningsExecutor::execute(ObExecContext &ctx, ObFlushDagWarningsSt
   UNUSED(stmt);
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get task exec ctx error", K(ret), KP(task_exec_ctx));
   } else {
     MTL(ObDagWarningHistoryManager *)->clear();
   }
@@ -609,12 +625,16 @@ int ObAdminMergeExecutor::execute(ObExecContext &ctx, ObAdminMergeStmt &stmt)
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
-  const ObAdminMergeArg &arg = stmt.get_rpc_arg();
+  const obrpc::ObAdminMergeArg &arg = stmt.get_rpc_arg();
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(GCTX.root_service_->admin_merge(arg))) {
-    LOG_WARN("admin merge failed", K(ret), "rpc_arg", arg);
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->admin_merge(arg))) {
+    LOG_WARN("admin merge rpc failed", K(ret), "rpc_arg", arg);
   }
   return ret;
 }
@@ -623,12 +643,16 @@ int ObAdminRecoveryExecutor::execute(ObExecContext &ctx, ObAdminRecoveryStmt &st
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(GCTX.root_service_->admin_recovery(
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->admin_recovery(
                          stmt.get_rpc_arg()))) {
-    LOG_WARN("admin recovery failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+    LOG_WARN("admin merge rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
   }
   return ret;
 }
@@ -637,12 +661,16 @@ int ObClearRoottableExecutor::execute(ObExecContext &ctx, ObClearRoottableStmt &
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(GCTX.root_service_->admin_clear_roottable(
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->admin_clear_roottable(
                          stmt.get_rpc_arg()))) {
-    LOG_WARN("clear roottable failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+    LOG_WARN("clear roottable rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
   }
   return ret;
 }
@@ -651,12 +679,16 @@ int ObRefreshSchemaExecutor::execute(ObExecContext &ctx, ObRefreshSchemaStmt &st
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(GCTX.root_service_->admin_refresh_schema(
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->admin_refresh_schema(
                          stmt.get_rpc_arg()))) {
-    LOG_WARN("refresh schema failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+    LOG_WARN("refresh schema rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
   }
   return ret;
 }
@@ -665,12 +697,16 @@ int ObRefreshMemStatExecutor::execute(ObExecContext &ctx, ObRefreshMemStatStmt &
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(GCTX.root_service_->admin_refresh_memory_stat(
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->admin_refresh_memory_stat(
                          stmt.get_rpc_arg()))) {
-    LOG_WARN("refresh memory stat failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+    LOG_WARN("refresh memory stat rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
   }
   return ret;
 }
@@ -679,12 +715,16 @@ int ObWashMemFragmentationExecutor::execute(ObExecContext &ctx, ObWashMemFragmen
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(GCTX.root_service_->admin_wash_memory_fragmentation(
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->admin_wash_memory_fragmentation(
                          stmt.get_rpc_arg()))) {
-    LOG_WARN("wash memory fragmentation failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+    LOG_WARN("sync wash fragment rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
   }
   return ret;
 }
@@ -693,11 +733,15 @@ int ObRefreshIOCalibraitonExecutor::execute(ObExecContext &ctx, ObRefreshIOCalib
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(GCTX.root_service_->admin_refresh_io_calibration(stmt.get_rpc_arg()))) {
-    LOG_WARN("refresh io calibration failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->admin_refresh_io_calibration(stmt.get_rpc_arg()))) {
+    LOG_WARN("refresh io calibration rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
   }
   return ret;
 }
@@ -724,10 +768,18 @@ int ObSetConfigExecutor::execute(ObExecContext &ctx, ObSetConfigStmt &stmt)
 int ObChangeExternalStorageDestExecutor::execute(ObExecContext &ctx, ObChangeExternalStorageDestStmt &stmt)
 {
   int ret = OB_SUCCESS;
-  if (OB_FAIL(ex_rpc::sync_call([&]{
-    return GCTX.ob_service_->change_external_storage_dest(stmt.get_rpc_arg());
-  }))) {
-    LOG_WARN("change external storage dest failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+  ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObSrvRpcProxy *svr_rpc = NULL;
+  if (OB_ISNULL(task_exec_ctx)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(svr_rpc = task_exec_ctx->get_srv_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get svr rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(svr_rpc->change_external_storage_dest(stmt.get_rpc_arg()))) {
+    LOG_WARN("set config rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+  } else {
+    LOG_INFO("change external storage dest rpc", K(stmt.get_rpc_arg()));
   }
   return ret;
 }
@@ -753,12 +805,16 @@ int ObClearMergeErrorExecutor::execute(ObExecContext &ctx, ObClearMergeErrorStmt
 	int ret = OB_SUCCESS;
 	UNUSED(stmt);
 	ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
-  const ObAdminMergeArg &arg = stmt.get_rpc_arg();
+  const obrpc::ObAdminMergeArg &arg = stmt.get_rpc_arg();
+	obrpc::ObCommonRpcProxy *common_rpc = NULL;
 	if (OB_ISNULL(task_exec_ctx)) {
 		ret = OB_NOT_INIT;
 		LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(GCTX.root_service_->admin_clear_merge_error(arg))) {
-		LOG_WARN("clear merge error failed", K(ret), "rpc_arg", arg);
+	} else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+		ret = OB_NOT_INIT;
+		LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->admin_clear_merge_error(arg))) {
+		LOG_WARN("clear merge error rpc failed", K(ret), "rpc_arg", arg);
 	}
   return ret;
 }
@@ -769,11 +825,16 @@ int ObUpgradeVirtualSchemaExecutor ::execute(
   int ret = OB_SUCCESS;
   UNUSED(stmt);
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
+  int64_t timeout = THIS_WORKER.get_timeout_remain();
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(rootserver::serial_call([&]{ return GCTX.root_service_->admin_upgrade_virtual_schema(); }))) {
-    LOG_WARN("upgrade virtual schema failed", K(ret));
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->timeout(timeout).admin_upgrade_virtual_schema())) {
+    LOG_WARN("upgrade virtual schema rpc failed", K(ret));
   }
   return ret;
 }
@@ -781,21 +842,26 @@ int ObUpgradeVirtualSchemaExecutor ::execute(
 int ObAdminUpgradeCmdExecutor::execute(ObExecContext &ctx, ObAdminUpgradeCmdStmt &stmt)
 {
   int ret = OB_SUCCESS;
-  Bool upgrade = true;
+  obrpc::Bool upgrade = true;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
+  int64_t timeout = THIS_WORKER.get_timeout_remain();
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
   } else {
     if (ObAdminUpgradeCmdStmt::BEGIN == stmt.get_op()) {
       upgrade = true;
-      if (OB_FAIL(GCTX.root_service_->admin_upgrade_cmd(upgrade))) {
-        LOG_WARN("begin upgrade failed", K(ret));
+      if (OB_FAIL(common_rpc->timeout(timeout).admin_upgrade_cmd(upgrade))) {
+        LOG_WARN("begin upgrade rpc failed", K(ret));
       }
     } else if (ObAdminUpgradeCmdStmt::END == stmt.get_op()) {
       upgrade = false;
-      if (OB_FAIL(GCTX.root_service_->admin_upgrade_cmd(upgrade))) {
-        LOG_WARN("end upgrade failed", K(ret));
+      if (OB_FAIL(common_rpc->timeout(timeout).admin_upgrade_cmd(upgrade))) {
+        LOG_WARN("end upgrade rpc failed", K(ret));
       }
     }
   }
@@ -806,20 +872,25 @@ int ObAdminRollingUpgradeCmdExecutor::execute(ObExecContext &ctx, ObAdminRolling
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
+  int64_t timeout = THIS_WORKER.get_timeout_remain();
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
   } else {
     ObAdminRollingUpgradeArg arg;
     if (ObAdminRollingUpgradeCmdStmt::BEGIN == stmt.get_op()) {
-      arg.stage_ = OB_UPGRADE_STAGE_DBUPGRADE;
-      if (OB_FAIL(GCTX.root_service_->admin_rolling_upgrade_cmd(arg))) {
-        LOG_WARN("begin upgrade failed", K(ret));
+      arg.stage_ = obrpc::OB_UPGRADE_STAGE_DBUPGRADE;
+      if (OB_FAIL(common_rpc->timeout(timeout).admin_rolling_upgrade_cmd(arg))) {
+        LOG_WARN("begin upgrade rpc failed", K(ret));
       }
     } else if (ObAdminRollingUpgradeCmdStmt::END == stmt.get_op()) {
-      arg.stage_ = OB_UPGRADE_STAGE_POSTUPGRADE;
-      if (OB_FAIL(GCTX.root_service_->admin_rolling_upgrade_cmd(arg))) {
-        LOG_WARN("end upgrade failed", K(ret));
+      arg.stage_ = obrpc::OB_UPGRADE_STAGE_POSTUPGRADE;
+      if (OB_FAIL(common_rpc->timeout(timeout).admin_rolling_upgrade_cmd(arg))) {
+        LOG_WARN("end upgrade rpc failed", K(ret));
       }
     }
   }
@@ -831,12 +902,17 @@ int ObRunUpgradeJobExecutor::execute(
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  int64_t timeout = THIS_WORKER.get_timeout_remain();
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(rootserver::serial_call([&]{ return GCTX.root_service_->run_upgrade_job(
-                         stmt.get_rpc_arg()); }))) {
-    LOG_WARN("run upgrade job failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->timeout(timeout).run_upgrade_job(
+                         stmt.get_rpc_arg()))) {
+    LOG_WARN("run job rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
   }
   return ret;
 }
@@ -846,12 +922,17 @@ int ObStopUpgradeJobExecutor::execute(
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  int64_t timeout = THIS_WORKER.get_timeout_remain();
+  obrpc::ObCommonRpcProxy *common_rpc = NULL;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(rootserver::serial_call([&]{ return GCTX.root_service_->run_upgrade_job(
-                         stmt.get_rpc_arg()); }))) {
-    LOG_WARN("run upgrade job failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+  } else if (OB_ISNULL(common_rpc = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(common_rpc->timeout(timeout).run_upgrade_job(
+                         stmt.get_rpc_arg()))) {
+    LOG_WARN("run job rpc failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
   }
   return ret;
 }
@@ -929,22 +1010,41 @@ int ObDisableSqlThrottleExecutor::execute(ObExecContext &ctx, ObDisableSqlThrott
 int ObCancelTaskExecutor::execute(ObExecContext &ctx, ObCancelTaskStmt &stmt)
 {
   int ret = OB_SUCCESS;
+  ObAddr task_server;
   share::ObTaskId task_id;
+  bool is_local_task = false;
 
-  LOG_INFO("cancel sys task log",
-           K(stmt.get_task_id()), K(stmt.get_task_type()), K(stmt.get_cmd_type()));
+	LOG_INFO("cancel sys task log",
+		       K(stmt.get_task_id()), K(stmt.get_task_type()), K(stmt.get_cmd_type()));
 
-  if (NULL == GCTX.ob_service_) {
-    ret = OB_ERR_SYS;
-    LOG_ERROR("GCTX must not inited", K(ret), KP(GCTX.ob_service_));
-  } else if (OB_FAIL(parse_task_id(stmt.get_task_id(), task_id))) {
-    LOG_WARN("failed to parse task id", K(ret), K(stmt.get_task_id()));
-  } else if (OB_FAIL(ex_rpc::sync_call([&]{
-    return GCTX.ob_service_->cancel_sys_task(task_id);
-  }))) {
-    LOG_WARN("failed to cancel sys task", K(ret), K(task_id));
-  }
-  return ret;
+	if (NULL == GCTX.ob_service_ || NULL == GCTX.srv_rpc_proxy_) {
+		ret = OB_ERR_SYS;
+		LOG_ERROR("GCTX must not inited", K(ret), KP(GCTX.srv_rpc_proxy_), KP(GCTX.ob_service_));
+	} else if (OB_FAIL(parse_task_id(stmt.get_task_id(), task_id))) {
+		LOG_WARN("failed to parse task id", K(ret), K(stmt.get_task_id()));
+	} else if (OB_FAIL(SYS_TASK_STATUS_MGR.task_exist(task_id, is_local_task))) {
+		LOG_WARN("failed to check is local task", K(ret), K(task_id));
+	} else if (is_local_task) {
+		if (OB_FAIL(GCTX.ob_service_->cancel_sys_task(task_id))) {
+		  LOG_WARN("failed to cancel sys task at local", K(ret), K(task_id));
+      }
+	} else {
+		if (OB_FAIL(fetch_sys_task_info(ctx, stmt.get_task_id(), task_server))) {
+		  LOG_WARN("failed to fetch sys task info", K(ret));
+    } else if (!task_server.is_valid() || task_id.is_invalid()) {
+		  ret = OB_INVALID_ARGUMENT;
+		  LOG_WARN("invalid task info", K(ret), K(task_server), K(task_id));
+		} else {
+		  obrpc::ObCancelTaskArg rpc_arg;
+		  rpc_arg.task_id_ = task_id;
+		  if (OB_FAIL(GCTX.srv_rpc_proxy_->to(task_server).cancel_sys_task(rpc_arg))) {
+			LOG_WARN("failed to cancel remote sys task", K(ret), K(task_server), K(rpc_arg));
+		  } else {
+			LOG_INFO("succeed to cancel sys task at remote", K(task_server), K(rpc_arg));
+		  }
+		}
+	}
+	return ret;
 }
 
 int ObCancelTaskExecutor::fetch_sys_task_info(
@@ -1037,10 +1137,24 @@ int ObCancelTaskExecutor::parse_task_id(
 int ObSetDiskValidExecutor::execute(ObExecContext &ctx, ObSetDiskValidStmt &stmt)
 {
   int ret = OB_SUCCESS;
-  LOG_INFO("set_disk_valid", "server", stmt.server_);
-  if (OB_FAIL(ex_rpc::sync_call([]{ return ObIOManager::get_instance().reset_device_health(); }))) {
-    LOG_WARN("set_disk_valid failed", K(ret));
+  ObTaskExecutorCtx *task_exec_ctx = NULL;
+  obrpc::ObSrvRpcProxy *srv_rpc_proxy = NULL;
+  ObAddr server = stmt.server_;
+  ObSetDiskValidArg arg;
+
+  LOG_INFO("set_disk_valid", K(server));
+  if (OB_ISNULL(task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx))) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get task executor failed");
+  } else if (OB_ISNULL(srv_rpc_proxy = task_exec_ctx->get_srv_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get srv rpc proxy failed");
+  } else if (OB_FAIL(srv_rpc_proxy->to(GCTX.self_addr()).set_disk_valid(arg))) {
+    LOG_WARN("rpc proxy set_disk_valid failed", K(ret));
+  } else {
+    LOG_INFO("set_disk_valid success", K(server));
   }
+
   return ret;
 }
 
@@ -1048,11 +1162,18 @@ int ObAddDiskExecutor::execute(ObExecContext &ctx, ObAddDiskStmt &stmt)
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObSrvRpcProxy *srv_rpc_proxy = NULL;
+
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(ex_rpc::sync_call([]{ return OB_NOT_SUPPORTED; }))) {
-    LOG_WARN("add_disk failed", K(ret), "arg", stmt.arg_);
+  } else if (OB_ISNULL(srv_rpc_proxy = task_exec_ctx->get_srv_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get server rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(srv_rpc_proxy->to(stmt.arg_.server_).add_disk(stmt.arg_))) {
+    LOG_WARN("failed to send add disk rpc", K(ret), "arg", stmt.arg_);
+  } else {
+    FLOG_INFO("succeed to send add disk rpc", "arg", stmt.arg_);
   }
   return ret;
 }
@@ -1061,11 +1182,18 @@ int ObDropDiskExecutor::execute(ObExecContext &ctx, ObDropDiskStmt &stmt)
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObSrvRpcProxy *srv_rpc_proxy = NULL;
+
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
-  } else if (OB_FAIL(ex_rpc::sync_call([]{ return OB_NOT_SUPPORTED; }))) {
-    LOG_WARN("drop_disk failed", K(ret), "arg", stmt.arg_);
+  } else if (OB_ISNULL(srv_rpc_proxy = task_exec_ctx->get_srv_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get server rpc proxy failed", K(task_exec_ctx));
+  } else if (OB_FAIL(srv_rpc_proxy->to(stmt.arg_.server_).drop_disk(stmt.arg_))) {
+    LOG_WARN("failed to send drop disk rpc", K(ret), "arg", stmt.arg_);
+  } else {
+    FLOG_INFO("succeed to send drop disk rpc", "arg", stmt.arg_);
   }
   return ret;
 }
@@ -1074,19 +1202,25 @@ int ObArchiveLogExecutor::execute(ObExecContext &ctx, ObArchiveLogStmt &stmt)
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc_proxy = NULL;
   common::ObCurTraceId::mark_user_request();
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_FAIL(task_exec_ctx->get_common_rpc(common_rpc_proxy))) {
+    LOG_WARN("get common rpc proxy failed", K(ret));
+  } else if (OB_ISNULL(common_rpc_proxy)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("common_rpc_proxy is null", K(ret));
   } else {
     FLOG_INFO("ObArchiveLogExecutor::execute", K(stmt), K(ctx));
-    ObArchiveLogArg arg;
+    obrpc::ObArchiveLogArg arg;
     arg.enable_ = stmt.is_enable();
     arg.tenant_id_ = stmt.get_tenant_id();
     if (OB_FAIL(arg.archive_tenant_ids_.assign(stmt.get_archive_tenant_ids()))) {
       LOG_WARN("failed to assign archive tenant ids", K(ret), K(stmt));
-    } else if (OB_FAIL(GCTX.root_service_->handle_archive_log(arg))) {
-      LOG_WARN("archive_tenant failed", K(ret), K(arg), "dst", GCTX.self_addr());
+    } else if (OB_FAIL(common_rpc_proxy->archive_log(arg))) {
+      LOG_WARN("archive_tenant rpc failed", K(ret), K(arg), "dst", common_rpc_proxy->get_server());
     }
   }
   return ret;
@@ -1097,16 +1231,20 @@ int ObBackupDatabaseExecutor::execute(ObExecContext &ctx, ObBackupDatabaseStmt &
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
   ObSQLSessionInfo *session_info = ctx.get_my_session();
+  ObCommonRpcProxy *common_proxy = NULL;
   common::ObCurTraceId::mark_user_request();
   ObString passwd;
   ObObj value;
-  ObBackupDatabaseArg arg;
+  obrpc::ObBackupDatabaseArg arg;
   // rs will attempt to update the schema_version of the freeze point every 5s
   const int64_t SECOND = 1* 1000 * 1000; //1s
   const int64_t MAX_RETRY_NUM = UPDATE_SCHEMA_ADDITIONAL_INTERVAL / SECOND + 1;
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(common_proxy = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(ret));
   } else if (OB_ISNULL(session_info)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("session_info must not null", K(ret));
@@ -1151,13 +1289,13 @@ int ObBackupDatabaseExecutor::execute(ObExecContext &ctx, ObBackupDatabaseStmt &
       int32_t retry_cnt = 0;
       while (retry_cnt < MAX_RETRY_NUM) {
         ret = OB_SUCCESS;
-        if (OB_FAIL(GCTX.root_service_->handle_backup_database(arg))) {
+        if (OB_FAIL(common_proxy->backup_database(arg))) {
           if (OB_EAGAIN == ret) {
             LOG_WARN("backup_database rpc failed, need retry", K(ret), K(arg),
-                "dst", GCTX.self_addr(), "retry_cnt", retry_cnt);
+                "dst", common_proxy->get_server(), "retry_cnt", retry_cnt);
             ob_usleep(SECOND); //1s
           } else {
-            LOG_WARN("backup_database rpc failed", K(ret), K(arg), "dst", GCTX.self_addr());
+            LOG_WARN("backup_database rpc failed", K(ret), K(arg), "dst", common_proxy->get_server());
             break;
           }
         } else {
@@ -1174,22 +1312,26 @@ int ObBackupManageExecutor::execute(ObExecContext &ctx, ObBackupManageStmt &stmt
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  ObCommonRpcProxy *common_proxy = NULL;
   common::ObCurTraceId::mark_user_request();
 
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(common_proxy = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(ret));
   } else {
     LOG_INFO("ObBackupManageExecutor::execute", K(stmt), K(ctx));
-    ObBackupManageArg arg;
+    obrpc::ObBackupManageArg arg;
     arg.tenant_id_ = stmt.get_tenant_id();
     arg.type_ = stmt.get_type();
     arg.value_ = stmt.get_value();
     arg.copy_id_ = stmt.get_copy_id();
     if (OB_FAIL(append(arg.managed_tenant_ids_, stmt.get_managed_tenant_ids()))) {
       LOG_WARN("failed to append managed tenants", K(ret), K(stmt));
-    } else if (OB_FAIL(GCTX.root_service_->handle_backup_manage(arg))) {
-      LOG_WARN("backup_manage failed", K(ret), K(arg), "dst", GCTX.self_addr());
+    } else if (OB_FAIL(common_proxy->backup_manage(arg))) {
+      LOG_WARN("backup_manage rpc failed", K(ret), K(arg), "dst", common_proxy->get_server());
     }
   }
   return ret;
@@ -1199,14 +1341,18 @@ int ObBackupCleanExecutor::execute(ObExecContext &ctx, ObBackupCleanStmt &stmt)
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  ObCommonRpcProxy *common_proxy = NULL;
   common::ObCurTraceId::mark_user_request();
 
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(common_proxy = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(ret));
   } else {
     LOG_INFO("ObBackupCleanExecutor::execute", K(stmt), K(ctx));
-    ObBackupCleanArg arg;
+    obrpc::ObBackupCleanArg arg;
     arg.initiator_tenant_id_ = stmt.get_tenant_id();
     arg.type_ = stmt.get_type();
     arg.value_ = stmt.get_value();
@@ -1215,8 +1361,8 @@ int ObBackupCleanExecutor::execute(ObExecContext &ctx, ObBackupCleanStmt &stmt)
       LOG_WARN("set clean description failed", K(ret));
     } else if (OB_FAIL(arg.clean_tenant_ids_.assign(stmt.get_clean_tenant_ids()))) {
       LOG_WARN("set clean tenant ids failed", K(ret));
-    } else if (OB_FAIL(GCTX.root_service_->handle_backup_delete(arg))) {
-      LOG_WARN("backup clean failed", K(ret), K(arg), "dst", GCTX.self_addr());
+    } else if (OB_FAIL(common_proxy->backup_delete(arg))) {
+      LOG_WARN("backup clean rpc failed", K(ret), K(arg), "dst", common_proxy->get_server());
     }
   }
   FLOG_INFO("ObBackupCleanExecutor::execute");
@@ -1227,14 +1373,18 @@ int ObDeletePolicyExecutor::execute(ObExecContext &ctx, ObDeletePolicyStmt &stmt
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  ObCommonRpcProxy *common_proxy = NULL;
   common::ObCurTraceId::mark_user_request();
 
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_ISNULL(common_proxy = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(ret));
   } else {
     LOG_INFO("ObDeletePolicyExecutor::execute", K(stmt), K(ctx));
-    ObDeletePolicyArg arg;
+    obrpc::ObDeletePolicyArg arg;
     arg.initiator_tenant_id_ = stmt.get_tenant_id();
     arg.type_ = stmt.get_type();
     arg.redundancy_ = stmt.get_redundancy();
@@ -1245,8 +1395,8 @@ int ObDeletePolicyExecutor::execute(ObExecContext &ctx, ObDeletePolicyStmt &stmt
       LOG_WARN("failed to set recovery window", K(ret), K(stmt));
     } else if (OB_FAIL(arg.clean_tenant_ids_.assign(stmt.get_clean_tenant_ids()))) {
       LOG_WARN("set clean tenant ids failed", K(ret));
-    } else if (OB_FAIL(GCTX.root_service_->handle_delete_policy(arg))) {
-      LOG_WARN("delete policy failed", K(ret), K(arg), "dst", GCTX.self_addr());
+    } else if (OB_FAIL(common_proxy->delete_policy(arg))) {
+      LOG_WARN("delete policy rpc failed", K(ret), K(arg), "dst", common_proxy->get_server());
     }
   }
   FLOG_INFO("ObDeletePolicyExecutor::execute");
@@ -1258,12 +1408,16 @@ int ObBackupClusterParamExecutor::execute(ObExecContext &ctx, ObBackupClusterPar
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
   ObSQLSessionInfo *session_info = ctx.get_my_session();
+  ObCommonRpcProxy *common_proxy = NULL;
   uint64_t login_tenant_id = OB_INVALID_TENANT_ID;
   const share::ObBackupPathString &backup_dest = stmt.get_backup_dest();
 
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("task exec ctx is null", KR(ret));
+  } else if (OB_ISNULL(common_proxy = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(ret));
   } else if (FALSE_IT(login_tenant_id = session_info->get_login_tenant_id())) {
   } else if (OB_SYS_TENANT_ID != login_tenant_id) {
     ret = OB_OP_NOT_ALLOW;
@@ -1281,12 +1435,16 @@ int ObBackupBackupsetExecutor::execute(ObExecContext &ctx, ObBackupBackupsetStmt
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  ObCommonRpcProxy *common_proxy = NULL;
   common::ObCurTraceId::reset();
   common::ObCurTraceId::mark_user_request();
 
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("task exec ctx is null", KR(ret));
+  } else if (OB_ISNULL(common_proxy = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(ret));
   } else {
     ret = OB_NOT_SUPPORTED;
     LOG_ERROR("not support now", K(ret));
@@ -1298,13 +1456,19 @@ int ObBackupArchiveLogExecutor::execute(ObExecContext &ctx, ObBackupArchiveLogSt
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy *common_rpc_proxy = NULL;
   common::ObCurTraceId::mark_user_request();
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_FAIL(task_exec_ctx->get_common_rpc(common_rpc_proxy))) {
+    LOG_WARN("get common rpc proxy failed", K(ret));
+  } else if (OB_ISNULL(common_rpc_proxy)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("common_rpc_proxy is null", K(ret));
   } else {
     FLOG_INFO("ObBackupArchiveLogExecutor::execute", K(stmt), K(ctx));
-//    ObBackupArchiveLogArg arg;
+//    obrpc::ObBackupArchiveLogArg arg;
 //    arg.enable_ = stmt.is_enable();
 
     ret = OB_NOT_SUPPORTED;
@@ -1320,15 +1484,19 @@ int ObBackupBackupPieceExecutor::execute(ObExecContext &ctx, ObBackupBackupPiece
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  ObCommonRpcProxy *common_proxy = NULL;
   common::ObCurTraceId::reset();
   common::ObCurTraceId::mark_user_request();
 
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("task exec ctx is null", KR(ret));
+  } else if (OB_ISNULL(common_proxy = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed", K(ret));
   } else {
     LOG_INFO("ObBackupBackupPieceExecutor::execute", K(stmt), K(ctx));
-//    ObBackupBackupPieceArg arg;
+//    obrpc::ObBackupBackupPieceArg arg;
 //    arg.tenant_id_ = stmt.get_tenant_id();
 //    arg.piece_id_ = stmt.get_piece_id();
 //    arg.max_backup_times_ = stmt.get_max_backup_times();
@@ -1459,18 +1627,24 @@ int ObClearRestoreSourceExecutor::execute(ObExecContext &ctx, ObClearRestoreSour
 int ObCheckpointSlogExecutor::execute(ObExecContext &ctx, ObCheckpointSlogStmt &stmt)
 {
   int ret = OB_SUCCESS;
-  uint64_t tenant_id = stmt.tenant_id_;
-  if (OB_FAIL(ex_rpc::sync_call([&]() -> int {
-    if (OB_SERVER_TENANT_ID == tenant_id) {
-      return SERVER_STORAGE_META_SERVICE.write_checkpoint(true);
-    } else {
-      int r = OB_SUCCESS;
-      MTL_SWITCH(tenant_id) { r = MTL(ObTenantStorageMetaService*)->write_checkpoint(true); }
-      return r;
-    }
-  }))) {
-    LOG_WARN("checkpoint slog failed", K(ret), K(tenant_id));
+  ObTaskExecutorCtx *task_exec_ctx = NULL;
+  obrpc::ObSrvRpcProxy *srv_rpc_proxy = NULL;
+  const ObAddr server = stmt.server_;
+  ObCheckpointSlogArg arg;
+  arg.tenant_id_ = stmt.tenant_id_;
+
+  if (OB_ISNULL(task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx))) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get task executor failed");
+  } else if (OB_ISNULL(srv_rpc_proxy = task_exec_ctx->get_srv_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get srv rpc proxy failed");
+  } else if (OB_FAIL(srv_rpc_proxy->to(GCTX.self_addr()).timeout(THIS_WORKER.get_timeout_remain()).checkpoint_slog(arg))) {
+    LOG_WARN("rpc proxy checkpoint slog failed", K(ret));
   }
+
+  LOG_INFO("checkpoint slog execute finish", K(ret), K(arg.tenant_id_), K(server));
+
   return ret;
 }
 
@@ -1478,14 +1652,19 @@ int ObRecoverTableExecutor::execute(ObExecContext &ctx, ObRecoverTableStmt &stmt
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx *task_exec_ctx = nullptr;
+  ObCommonRpcProxy *common_proxy = nullptr;
+  ObAddr server;
   if (OB_ISNULL(task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx))) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor failed");
-  } else if (OB_FAIL(GCTX.root_service_->handle_recover_table(stmt.get_rpc_arg()))) {
-    LOG_WARN("failed to recover table", K(ret));
+  } else if (OB_ISNULL(common_proxy = task_exec_ctx->get_common_rpc())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("get common rpc proxy failed");
+  } else if (OB_FAIL(common_proxy->recover_table(stmt.get_rpc_arg()))) {
+    LOG_WARN("failed to send recover table rpc", K(ret));
   } else {
-    const ObRecoverTableArg &recover_table_rpc_arg = stmt.get_rpc_arg();
-    LOG_INFO("recover table finish", K(recover_table_rpc_arg));
+    const obrpc::ObRecoverTableArg &recover_table_rpc_arg = stmt.get_rpc_arg();
+    LOG_INFO("send recover table rpc finish", K(recover_table_rpc_arg));
   }
   return ret;
 }
@@ -1497,7 +1676,7 @@ int ObSwitchRoleExecutor::execute(ObExecContext &ctx, ObSwitchRoleStmt &stmt)
   if (OB_FAIL(stmt.get_first_stmt(first_stmt))) {
     LOG_WARN("fail to get first stmt", KR(ret), K(stmt));
   } else {
-    ObSwitchRoleArg &arg = stmt.get_arg();
+    obrpc::ObSwitchRoleArg &arg = stmt.get_arg();
     // Always use sys tenant, arg already initialized in resolver with OB_SYS_TENANT_ID
     arg.set_stmt_str(first_stmt);
     if (OB_FAIL(OB_STANDBY_SERVICE.switch_role(arg))) {
@@ -1517,14 +1696,22 @@ int ObTableTTLExecutor::execute(ObExecContext& ctx, ObTableTTLStmt& stmt)
 {
   int ret = OB_SUCCESS;
   ObTaskExecutorCtx* task_exec_ctx = GET_TASK_EXECUTOR_CTX(ctx);
+  obrpc::ObCommonRpcProxy* common_rpc_proxy = NULL;
+
   if (OB_ISNULL(task_exec_ctx)) {
     ret = OB_NOT_INIT;
     LOG_WARN("get task executor context failed");
+  } else if (OB_FAIL(task_exec_ctx->get_common_rpc(common_rpc_proxy))) {
+    LOG_WARN("get common rpc proxy failed", K(ret));
+  } else if (OB_ISNULL(common_rpc_proxy)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("common_rpc_proxy is null", K(ret));
   } else {
     FLOG_INFO("ObTableTTLExecutor::execute", K(stmt), K(ctx));
     common::ObTTLParam param;
     ObSEArray<common::ObSimpleTTLInfo, 32> ttl_info_array;
     param.ttl_all_ = stmt.is_ttl_all();
+    param.transport_ = GCTX.net_frame_->get_req_transport();
     param.type_ = stmt.get_type();
     for (int64_t i = 0; (i < stmt.get_tenant_ids().count()) && OB_SUCC(ret); i++) {
       uint64_t tenant_id = stmt.get_tenant_ids().at(i);

--- a/src/sql/engine/px/ob_px_sqc_async_proxy.cpp
+++ b/src/sql/engine/px/ob_px_sqc_async_proxy.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+
+#include "sql/engine/px/ob_px_sqc_async_proxy.h"
+#include "sql/engine/px/ob_px_util.h"
+
+namespace oceanbase {
+using namespace common;
+namespace sql {
+/* ObSqcAsyncCB */
+int ObSqcAsyncCB::process() {
+  ObThreadCondGuard guard(cond_);
+  int ret = OB_SUCCESS;
+  is_processed_ = true;
+  ret = cond_.broadcast();
+  return ret;
+}
+
+void ObSqcAsyncCB::on_invalid() {
+  ObThreadCondGuard guard(cond_);
+  int ret = OB_SUCCESS;
+  is_invalid_ = true;
+  ret = cond_.broadcast();
+  LOG_WARN("ObSqcAsyncCB invalid, check object serialization impl or oom",
+           K(trace_id_), K(ret));
+}
+
+void ObSqcAsyncCB::on_timeout() {
+  ObThreadCondGuard guard(cond_);
+  int ret = OB_SUCCESS;
+  is_timeout_ = true;
+  ret = cond_.broadcast();
+  LOG_WARN("ObSqcAsyncCB timeout, check timeout value, peer cpu load, network "
+           "packet drop rate",
+           K(trace_id_), K(ret));
+}
+
+rpc::frame::ObReqTransport::AsyncCB *
+ObSqcAsyncCB::clone(const rpc::frame::SPAlloc &alloc) const {
+  UNUSED(alloc);
+  return const_cast<rpc::frame::ObReqTransport::AsyncCB *>(
+      static_cast<const rpc::frame::ObReqTransport::AsyncCB *const>(this));
+}
+
+/* ObPxSqcAsyncProxy */
+int ObPxSqcAsyncProxy::launch_all_rpc_request() {
+  int ret = OB_SUCCESS;
+  // prepare allocate the results_ array
+  if (OB_FAIL(results_.prepare_allocate(sqcs_.count()))) {
+    LOG_WARN("fail to prepare allocate result array");
+  }
+
+  if (OB_SUCC(ret)) {
+    int64_t cluster_id = GCONF.cluster_id;
+    SMART_VAR(ObPxRpcInitSqcArgs, args) {
+      if (sqcs_.count() > 1) {
+        args.enable_serialize_cache();
+      }
+      ARRAY_FOREACH_X(sqcs_, idx, count, OB_SUCC(ret)) {
+        if (OB_UNLIKELY(ObPxCheckAlive::is_in_blacklist(sqcs_.at(idx).get_exec_addr(),
+                        session_->get_process_query_time()))) {
+          ret = OB_RPC_CONNECT_ERROR;
+          LOG_WARN("peer no in communication, maybe crashed", K(ret),
+                  K(sqcs_.at(idx)), K(cluster_id), K(session_->get_process_query_time()));
+        } else {
+          ret = launch_one_rpc_request(args, idx, NULL);
+        }
+      }
+    }
+  }
+  if (OB_FAIL(ret)) {
+    LOG_WARN("fail to launch all sqc rpc request", K(ret));
+    fail_process();
+  }
+  return ret;
+}
+
+int ObPxSqcAsyncProxy::launch_one_rpc_request(ObPxRpcInitSqcArgs &args, int64_t idx, ObSqcAsyncCB *cb) {
+  int ret = OB_SUCCESS;
+  ObCurTraceId::TraceId *trace_id = NULL;
+  ObPxSqcMeta &sqc = sqcs_.at(idx);
+  const ObAddr &addr = sqc.get_exec_addr();
+  int64_t timeout_us =
+      phy_plan_ctx_->get_timeout_timestamp() - ObTimeUtility::current_time();
+  args.set_serialize_param(exec_ctx_, const_cast<ObOpSpec &>(*dfo_.get_root_op_spec()), *phy_plan_);
+  if (OB_FAIL(ret)) {
+  } else if (timeout_us < 0) {
+    ret = OB_TIMEOUT;
+  } else if (OB_FAIL(args.sqc_.assign(sqc))) {
+    LOG_WARN("fail assign sqc", K(ret));
+  } else if (OB_ISNULL(trace_id = ObCurTraceId::get_trace_id())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("fail to get trace id");
+  } else {
+    // allocate SqcAsync callback
+    if (cb == NULL) {
+      void *mem = NULL;
+      if (NULL == (mem = allocator_.alloc(sizeof(ObSqcAsyncCB)))) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("alloc memory failed", "size", sizeof(ObSqcAsyncCB), K(ret));
+      } else {
+        cb = new (mem) ObSqcAsyncCB(cond_, *trace_id);
+        if (OB_FAIL(callbacks_.push_back(cb))) {
+          // free the callback
+          LOG_WARN("callback obarray push back failed.");
+          cb->~ObSqcAsyncCB();
+          allocator_.free(cb);
+          cb = NULL;
+        }
+      }
+    }
+    if (cb != NULL) {
+      if (OB_SUCC(ret)) {
+        if (OB_FAIL(proxy_.to(addr)
+                        .by(THIS_WORKER.get_rpc_tenant()?: session_->get_effective_tenant_id())
+                        .timeout(timeout_us)
+                        .async_init_sqc(args, cb))) {
+          LOG_WARN("fail to call asynchronous sqc rpc", K(sqc), K(timeout_us),
+                   K(ret));
+          // error_index_ = idx;
+        } else {
+          LOG_DEBUG("send the sqc request successfully.", K(idx), K(sqc),
+                    K(args), K(cb));
+        }
+      }
+      // ret is TIME_OUT, or when the asynchronous rpc is resent and fails, the corresponding callback needs to be recycled
+      // If removing the corresponding callback fails, the callback cannot be destructed
+      if (OB_FAIL(ret) && cb != NULL) {
+        // The reason for using temp_ret is to retain the original ret error code
+        int temp_ret = callbacks_.remove(idx);
+        if (temp_ret != OB_SUCCESS) {
+          // Here we need to mark callback as invalid, waiting for `fail_process` to handle
+          cb->set_invalid(true);
+          LOG_WARN("callback obarray remove element failed", K(ret));
+        } else {
+          cb->~ObSqcAsyncCB();
+          allocator_.free(cb);
+          cb = NULL;
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObPxSqcAsyncProxy::wait_all() {
+  int ret = OB_SUCCESS;
+  LOG_TRACE("wail all async sqc rpc to end", K(dfo_));
+  // Exit the while loop condition: exit the while loop if any of the 3 conditions are met
+  // 1. Obtain enough and correct callback results within the valid time frame
+  // 2. Timeout, ret = OB_TIMEOUT
+  // 3. retry an rpc failure
+  while (return_cb_count_ < sqcs_.count() && OB_SUCC(ret)) {
+
+    ObThreadCondGuard guard(cond_);
+    // wait for timeout or until notified.
+    cond_.wait_us(500);
+
+    if (OB_FAIL(exec_ctx_.fast_check_status())) {
+      LOG_WARN("check status failed", K(ret));
+    }
+
+    ARRAY_FOREACH_X(callbacks_, idx, count, OB_SUCC(ret)) {
+      ObSqcAsyncCB &callback = *callbacks_.at(idx);
+      if (!callback.is_visited() && callback.is_timeout()) {
+        // callback timeout, no need to retry
+        // It might just be an RPC timeout, but not a QUERY timeout, implementation-wise they need to be distinguished
+        // This situation needs to be marked as RPC CONNECT ERROR for retry
+        return_cb_count_++;
+        if (phy_plan_ctx_->get_timeout_timestamp() -
+          ObTimeUtility::current_time() > 0) {
+          error_index_ = idx;
+          ret = OB_RPC_CONNECT_ERROR;
+        } else {
+          ret = OB_TIMEOUT;
+        }
+        callback.set_visited(true);
+      } else if (!callback.is_visited() && callback.is_invalid()) {
+        // rpc parsing pack failed, callback calls on_invalid method, no need to retry
+        return_cb_count_++;
+        ret = callback.get_error() == OB_ALLOCATE_MEMORY_FAILED ?
+              OB_ALLOCATE_MEMORY_FAILED : OB_RPC_PACKET_INVALID;
+        LOG_WARN("callback invalid", K(ret), K(callback.get_error()));
+        callback.set_visited(true);
+      } else if (!callback.is_visited() && callback.is_processed()) {
+        return_cb_count_++;
+        callback.set_visited(true);
+        if (OB_SUCC(callback.get_ret_code().rcode_)) {
+          const ObPxRpcInitSqcResponse &cb_result = callback.get_result();
+          if (cb_result.rc_ == OB_ERR_INSUFFICIENT_PX_WORKER) {
+            // No sufficient px worker obtained, no need to retry internal SQC to prevent deadlock
+            // SQC if it does not obtain enough workers, the outer layer directly performs query-level retry
+            // 
+            LOG_INFO("can't get enough worker resource, and not retry",
+                K(cb_result.rc_), K(sqcs_.at(idx)));
+          }
+          if (OB_FAIL(cb_result.rc_)) {
+            // Error may contain is_data_not_readable_err or other types of errors
+            if (is_data_not_readable_err(ret)) {
+              error_index_ = idx;
+            }
+          } else {
+            // Obtain the correct return result
+            results_.at(idx) = &cb_result;
+          }
+        } else {
+          // RPC framework error, directly return the corresponding error code, current SQC does not need to retry again
+          ret = callback.get_ret_code().rcode_;
+          LOG_WARN("call rpc failed", K(ret), K(callback.get_ret_code()));
+        }
+      }
+    }
+  }
+  // wait_all result:
+  // 1. sqc corresponds to all callbacks returning the correct result, return_cb_count_=sqcs_.count(), directly return OB_SUCCESS;
+  // 2. Due to timeout or retry sqc rpc failure, in this case, we need to wait for all callback responses to end before returning ret.
+  if (return_cb_count_ < callbacks_.count()) {
+    // There are still unprocessed callbacks, need to wait for all callbacks to respond before exiting the `wait_all` method
+    fail_process();
+  }
+  return ret;
+}
+
+void ObPxSqcAsyncProxy::destroy() {
+  int ret = OB_SUCCESS;
+  LOG_DEBUG("async sqc proxy deconstruct, the callbacklist is ", K(callbacks_));
+  ARRAY_FOREACH(callbacks_, idx) {
+    ObSqcAsyncCB *callback = callbacks_.at(idx);
+    LOG_DEBUG("async sqc proxy deconstruct, the callback status is ", K(idx), K(*callback));
+    callback->~ObSqcAsyncCB();
+  }
+  allocator_.reuse();
+  callbacks_.reuse();
+  results_.reuse();
+}
+
+void ObPxSqcAsyncProxy::fail_process() {
+  LOG_WARN_RET(OB_SUCCESS,
+      "async sqc fails, process the callbacks that have not yet got results",
+      K(return_cb_count_), K(callbacks_.count()));
+  ARRAY_FOREACH_X(callbacks_, idx, count, true) {
+    ObSqcAsyncCB &callback = *callbacks_.at(idx);
+    if (!callback.is_visited() &&
+        !(callback.is_processed() || callback.is_timeout() || callback.is_invalid())) {
+      // unregister async callbacks that have not received response.
+      uint64_t gtid = callback.gtid_;
+      uint32_t pkt_id = callback.pkt_id_;
+      int err = 0;
+      if ((err = pn_terminate_pkt(gtid, pkt_id)) != 0) {
+        int ret = tranlate_to_ob_error(err);
+        LOG_WARN("terminate pkt failed", K(ret), K(err));
+      }
+    }
+  }
+  while (return_cb_count_ < callbacks_.count()) {
+    ObThreadCondGuard guard(cond_);
+    ARRAY_FOREACH_X(callbacks_, idx, count, true) {
+      ObSqcAsyncCB &callback = *callbacks_.at(idx);
+      if (!callback.is_visited()) {
+        if (callback.is_processed() || callback.is_timeout() || callback.is_invalid()) {
+          return_cb_count_++;
+          LOG_DEBUG("async sql fails, wait all callbacks", K(return_cb_count_),
+              K(callbacks_.count()));
+          callback.set_visited(true);
+        }
+      }
+    }
+    cond_.wait_us(500);
+  }
+  LOG_WARN_RET(OB_SUCCESS, "async sqc fails, all callbacks have been processed");
+}
+
+} // namespace sql
+} // namespace oceanbase

--- a/src/sql/engine/px/ob_px_target_mgr.h
+++ b/src/sql/engine/px/ob_px_target_mgr.h
@@ -18,12 +18,12 @@
 #define __SQL_ENG_PX_TARGET_MGR_H__
 
 #include "share/ob_thread_pool.h"
-#include "sql/engine/px/ob_px_target_monitor_rpc.h"
 #include "share/ob_define.h"
 #include "ob_px_tenant_target_monitor.h"
 #include "lib/oblog/ob_log_module.h"
 #include "lib/utility/ob_macro_utils.h"
 #include "lib/hash/ob_link_hashmap.h"
+#include "ob_px_rpc_proxy.h"
 
 namespace oceanbase
 {

--- a/src/sql/engine/px/ob_px_tenant_target_monitor.h
+++ b/src/sql/engine/px/ob_px_tenant_target_monitor.h
@@ -18,7 +18,6 @@
 #define __SQL_ENG_PX_TENANT_TARGET_MONITOR_H__
 
 #include "lib/net/ob_addr.h"
-#include "sql/engine/px/ob_px_target_monitor_rpc.h"
 #include "share/ob_define.h"
 #include "common/ob_role.h"
 #include "lib/lock/ob_monitor.h"
@@ -104,8 +103,6 @@ public:
   // for virtual_table iter
   int get_all_target_info(common::ObIArray<ObPxTargetInfo> &target_info_array);
   static uint64_t get_server_index(uint64_t version);
-  // in-process handler for OB_PX_TARGET_REQUEST (single-replica, self target)
-  static int handle_target_request(ObPxRpcFetchStatArgs &arg, ObPxRpcFetchStatResponse &result);
 
   TO_STRING_KV(K_(is_init), K_(tenant_id), K_(server), K_(role), K_(px_target_used));
 

--- a/src/storage/ddl/ob_ddl_redo_log_writer.cpp
+++ b/src/storage/ddl/ob_ddl_redo_log_writer.cpp
@@ -1,4 +1,3 @@
-#include "observer/ob_ex_rpc.h"
 /*
  * Copyright (c) 2025 OceanBase.
  *
@@ -1114,67 +1113,19 @@ int ObDDLRedoLogWriter::remote_write_ddl_macro_redo(
 {
   int ret = OB_SUCCESS;
   const int64_t wait_timeout_us = MAX(ObDDLRedoLogHandle::DDL_REDO_LOG_TIMEOUT, GCONF.rpc_timeout);
+  obrpc::ObSrvRpcProxy *srv_rpc_proxy = nullptr;
   if (OB_UNLIKELY(!redo_info.is_valid() || 0 == task_id)) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid arguments", K(ret), K(redo_info));
+  } else if (OB_ISNULL(srv_rpc_proxy = GCTX.srv_rpc_proxy_)) {
+    ret = OB_ERR_SYS;
+    LOG_WARN("srv rpc proxy is null", K(ret), KP(srv_rpc_proxy));
   } else {
-    obcall::ObCallRemoteWriteDDLRedoLogArg arg;
+    obrpc::ObRpcRemoteWriteDDLRedoLogArg arg;
     if (OB_FAIL(arg.init(MTL_ID(), leader_ls_id_, redo_info, task_id))) {
-      LOG_WARN("fail to init arg", K(ret));
-    } else if (OB_FAIL(ex_rpc::sync_call([&]() -> int {
-  int ret = OB_SUCCESS;
-  uint64_t tenant_id = arg.tenant_id_;
-  if (OB_UNLIKELY(!arg.is_valid())) {
-    ret = OB_INVALID_ARGUMENT;
-    LOG_WARN("invalid arguments", K(ret), K(arg));
-  } else {
-    MTL_SWITCH(tenant_id) {
-      ObRole role = INVALID_ROLE;
-      ObDDLRedoLogWriter sstable_redo_writer;
-      MacroBlockId macro_block_id;
-      ObLSService *ls_service = MTL(ObLSService*);
-      blocksstable::ObMacroBlockHandle macro_handle;
-      ObLSHandle ls_handle;
-      ObLS *ls = nullptr;
-      if (OB_FAIL(ls_service->get_ls(arg.ls_id_, ls_handle, ObLSGetMod::OBSERVER_MOD))) {
-        LOG_WARN("get ls failed", K(ret), K(arg));
-      } else if (OB_ISNULL(ls = ls_handle.get_ls())) {
-        ret = OB_ERR_UNEXPECTED;
-        LOG_WARN("unexpected error", K(ret), K(MTL_ID()), K(arg.ls_id_));
-      } else if (OB_FAIL(ls->get_ls_role(role))) {
-        LOG_WARN("get role failed", K(ret), K(MTL_ID()), K(arg.ls_id_));
-      } else if (ObRole::LEADER != role) {
-        ret = OB_NOT_MASTER;
-        LOG_INFO("not leader", K(ret), K(MTL_ID()), K(arg.ls_id_));
-#ifdef OB_BUILD_SHARED_STORAGE
-      } else {
-        ObTabletHandle tablet_handle;
-        if (OB_FAIL(ls->get_tablet(arg.redo_info_.table_key_.tablet_id_, tablet_handle,
-                    ObTabletCommon::DEFAULT_GET_TABLET_DURATION_US,
-                    ObMDSGetTabletMode::READ_WITHOUT_CHECK))) {
-          LOG_WARN("failed to get tablet handle", K(ret));
-        } else if (OB_FAIL(ObDDLRedoLogWriter::write_gc_flag(tablet_handle,
-                                                             arg.redo_info_.table_key_,
-                                                             arg.redo_info_.parallel_cnt_,
-                                                             arg.redo_info_.cg_cnt_))) {
-          LOG_WARN("failed to write gc flag file", K(ret), K(arg.redo_info_));
-        }
-      }
-      if (OB_FAIL(ret)) {
-#endif
-      } else if (OB_FAIL(ObDDLRedoLogWriter::write_block_to_disk(arg.redo_info_, arg.ls_id_, macro_handle, macro_block_id))) {
-        LOG_WARN("failed to write block to disk", K(ret));
-      } else if (OB_FAIL(sstable_redo_writer.init(arg.ls_id_, arg.redo_info_.table_key_.tablet_id_))) {
-        LOG_WARN("init sstable redo writer", K(ret), K(arg));
-      } else if (OB_FAIL(sstable_redo_writer.write_macro_block_log(arg.redo_info_, macro_block_id, false, arg.task_id_))) {
-        LOG_WARN("fail to write macro redo", K(ret), K(arg), K(macro_block_id));
-      } else if (OB_FAIL(sstable_redo_writer.wait_macro_block_log_finish(arg.redo_info_, macro_block_id))) {
-        LOG_WARN("fail to wait macro redo finish", K(ret), K(arg));
-      }
-    }
-  }
-  return ret;}))) {
-      LOG_WARN("fail to write ddl redo log", K(ret), K_(leader_addr), K(arg));
+      LOG_WARN("fail to init ObRpcRemoteWriteDDLRedoLogArg", K(ret));
+    } else if (OB_FAIL(srv_rpc_proxy->to(leader_addr_).by(MTL_ID()).timeout(wait_timeout_us).remote_write_ddl_redo_log(arg))) {
+      LOG_WARN("fail to remote write ddl redo log", K(ret), K_(leader_addr), K(arg));
     }
   }
   return ret;
@@ -1455,9 +1406,9 @@ int ObDDLRedoLogWriter::write_commit_log(
     }
   }
   if (OB_SUCC(ret) && remote_write_) {
-    obcall::ObCallRemoteWriteDDLCommitLogArg arg;
+    obrpc::ObRpcRemoteWriteDDLCommitLogArg arg;
     if (OB_FAIL(arg.init(MTL_ID(), leader_ls_id_, table_key, start_scn))) {
-      LOG_WARN("fail to init ObCallRemoteWriteDDLCommitLogArg", K(ret));
+      LOG_WARN("fail to init ObRpcRemoteWriteDDLCommitLogArg", K(ret));
     } else if (OB_FAIL(retry_remote_write_commit_clog(arg, commit_scn))) {
       LOG_WARN("remote write ddl commit log failed", K(ret), K(arg));
     } else {
@@ -1540,7 +1491,7 @@ int ObDDLRedoLogWriter::retry_remote_write_macro_redo(
 }
 
 int ObDDLRedoLogWriter::retry_remote_write_commit_clog(
-    const obcall::ObCallRemoteWriteDDLCommitLogArg &arg,
+    const obrpc::ObRpcRemoteWriteDDLCommitLogArg &arg,
     share::SCN &commit_scn)
 {
   int ret = OB_SUCCESS;
@@ -1569,59 +1520,20 @@ int ObDDLRedoLogWriter::retry_remote_write_commit_clog(
 }
 
 
-int ObDDLRedoLogWriter::remote_write_ddl_commit_redo(const obcall::ObCallRemoteWriteDDLCommitLogArg &arg, SCN &commit_scn)
+int ObDDLRedoLogWriter::remote_write_ddl_commit_redo(const obrpc::ObRpcRemoteWriteDDLCommitLogArg &arg, SCN &commit_scn)
 {
   int ret = OB_SUCCESS;
-  obcall::Int64 log_ns;
-  if (OB_UNLIKELY(!arg.is_valid())) {
+  ObSrvRpcProxy *srv_rpc_proxy = GCTX.srv_rpc_proxy_;
+  obrpc::Int64 log_ns;
+  int retry_cnt = 0;
+  if (OB_ISNULL(srv_rpc_proxy)) {
+    ret = OB_ERR_SYS;
+    LOG_WARN("srv rpc proxy or location service is null", K(ret), KP(srv_rpc_proxy));
+  } else if (OB_UNLIKELY(!arg.is_valid())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid arg", K(ret), K(arg));
-  } else if (OB_FAIL(ex_rpc::sync_call([&]() -> int {
-    int ret = OB_SUCCESS;
-    uint64_t tid = arg.tenant_id_;
-    MTL_SWITCH(tid) {
-      ObRole role = INVALID_ROLE;
-      const ObITable::TableKey &table_key = arg.table_key_;
-      ObDDLRedoLogWriter writer;
-      ObLSService *ls_svc = MTL(ObLSService*);
-      ObLSHandle ls_hdl; ObLS *ls = nullptr;
-      auto *tlm = MTL(ObTenantDirectLoadMgr*);
-      ObTabletFullDirectLoadMgr *dtm = nullptr; ObTabletDirectLoadMgrHandle dmh;
-      dmh.reset(); bool major_exist = false;
-      if (OB_FAIL(ls_svc->get_ls(arg.ls_id_, ls_hdl, ObLSGetMod::OBSERVER_MOD))) { LOG_WARN("get ls failed", K(ret)); }
-      else if (OB_ISNULL(ls = ls_hdl.get_ls())) { ret = OB_ERR_UNEXPECTED; }
-      else if (OB_FAIL(ls->get_ls_role(role))) { LOG_WARN("get role failed", K(ret)); }
-      else if (ObRole::LEADER != role) { ret = OB_NOT_MASTER; }
-      else if (OB_ISNULL(tlm)) { ret = OB_ERR_UNEXPECTED; }
-      else if (OB_FAIL(tlm->get_tablet_mgr_and_check_major(arg.ls_id_, table_key.tablet_id_, true, dmh, major_exist))) {
-        if (OB_ENTRY_NOT_EXIST == ret && major_exist) { ret = OB_TASK_EXPIRED; }
-      } else if (OB_ISNULL(dtm = dmh.get_full_obj())) {
-        ret = OB_ERR_UNEXPECTED;
-      }
-      else if (OB_FAIL(writer.init(arg.ls_id_, table_key.tablet_id_))) { LOG_WARN("init failed", K(ret)); }
-      else {
-        uint32_t lock_tid = 0; SCN scn_val; bool remote = false; ObTabletHandle th;
-        if (OB_FAIL(dtm->wrlock(ObTabletDirectLoadMgr::TRY_LOCK_TIMEOUT, lock_tid))) { LOG_WARN("wrlock failed", K(ret)); }
-        else if (OB_FAIL(ls->get_tablet(table_key.tablet_id_, th, ObTabletCommon::DEFAULT_GET_TABLET_DURATION_US, ObMDSGetTabletMode::READ_WITHOUT_CHECK))) { LOG_WARN("get tablet failed", K(ret)); }
-        else if (OB_FAIL(writer.write_commit_log(false, table_key, arg.start_scn_, dmh, th, scn_val, remote, lock_tid))) { LOG_WARN("write commit log failed", K(ret)); }
-        else if (!dtm->get_lob_mgr_handle().is_valid()) {
-          ObTabletBindingMdsUserData ddl_data; ObTabletDirectLoadMgrHandle lob_hdl;
-          if (OB_FAIL(th.get_obj()->ObITabletMdsInterface::get_ddl_data(share::SCN::max_scn(), ddl_data))) { LOG_WARN("get ddl data failed", K(ret)); }
-          else if (ddl_data.lob_meta_tablet_id_.is_valid()) {
-            bool lob_exist = false;
-            if (OB_FAIL(MTL(ObTenantDirectLoadMgr*)->get_tablet_mgr_and_check_major(arg.ls_id_, ddl_data.lob_meta_tablet_id_, true, lob_hdl, lob_exist))) {
-              if (OB_ENTRY_NOT_EXIST != ret || !lob_exist) { LOG_WARN("get lob mgr failed", K(ret)); } else { ret = OB_SUCCESS; }
-            } else if (OB_FAIL(lob_hdl.get_full_obj()->commit(*th.get_obj(), arg.start_scn_, scn_val, arg.table_id_, arg.ddl_task_id_, false))) { LOG_WARN("lob commit failed", K(ret)); }
-          }
-        }
-        if (OB_SUCC(ret) && OB_FAIL(dtm->commit(*th.get_obj(), arg.start_scn_, scn_val, arg.table_id_, arg.ddl_task_id_, false))) { LOG_WARN("kv commit failed", K(ret)); }
-        else if (OB_SUCC(ret)) { log_ns = scn_val.get_val_for_tx(); }
-        if (lock_tid != 0) { dtm->unlock(lock_tid); }
-      }
-    }
-    return ret;
-  }))) {
-    LOG_WARN("write ddl commit log failed", K(ret), K_(leader_ls_id), K_(leader_addr));
+  } else if (OB_FAIL(srv_rpc_proxy->to(leader_addr_).by(MTL_ID()).remote_write_ddl_commit_log(arg, log_ns))) {
+    LOG_WARN("remote write macro redo failed", K(ret), K_(leader_ls_id), K_(leader_addr));
   } else if (OB_FAIL(commit_scn.convert_for_tx(log_ns))) {
     LOG_WARN("convert for tx failed", K(ret));
   }
@@ -2208,9 +2120,9 @@ int ObDDLRedoLogWriter::write_finish_log(
     }
   }
   if (OB_SUCC(ret) && remote_write_) {
-    obcall::ObCallRemoteWriteDDLFinishLogArg arg;
+    obrpc::ObRpcRemoteWriteDDLFinishLogArg arg;
     if (OB_FAIL(arg.init(MTL_ID(), log.get_log_info()))) {
-      LOG_WARN("fail to init ObCallRemoteWriteDDLFinishLogArg", K(ret));
+      LOG_WARN("fail to init ObRpcRemoteWriteDDLFinishLogArg", K(ret));
     } else if (OB_FAIL(retry_remote_write_finish_log(arg))) {
       LOG_WARN("remote write ddl finish log failed", K(ret), K(arg));
     } else if (OB_FAIL(upload_tablet(log, shared_tablet_, allocator_, is_remote_write))) { // TODO @zhuoran.zzr, upload & update in one func
@@ -2298,7 +2210,7 @@ int ObDDLRedoLogWriter::wait_finish_log(
 
 /* TODO @zhuoran.zzr wait to use common logic as commig log */
 int ObDDLRedoLogWriter::retry_remote_write_finish_log(
-    const obcall::ObCallRemoteWriteDDLFinishLogArg &arg)
+    const obrpc::ObRpcRemoteWriteDDLFinishLogArg &arg)
 {
   int ret = OB_SUCCESS;
   int retry_cnt = 0;
@@ -2325,35 +2237,18 @@ int ObDDLRedoLogWriter::retry_remote_write_finish_log(
   return ret;
 }
 
-int ObDDLRedoLogWriter::remote_write_ddl_finish_log(const obcall::ObCallRemoteWriteDDLFinishLogArg &arg)
+int ObDDLRedoLogWriter::remote_write_ddl_finish_log(const obrpc::ObRpcRemoteWriteDDLFinishLogArg &arg)
 {
   int ret = OB_SUCCESS;
+  obrpc::ObSrvRpcProxy *srv_rpc_proxy = nullptr;
   if (OB_UNLIKELY(!arg.is_valid())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid arguments", K(ret), K(arg));
-  } else if (OB_FAIL(ex_rpc::sync_call([&]() -> int {
-    int ret = OB_SUCCESS;
-    const uint64_t tenant_id = arg.tenant_id_;
-    MTL_SWITCH(tenant_id) {
-      ObRole role = INVALID_ROLE; ObDDLFinishLogInfo &log_info = arg.log_info_;
-      ObDDLFinishLog finish_log; ObITable::TableKey &table_key = log_info.table_key_;
-      ObDDLRedoLogWriter writer; ObLSService *ls_svc = MTL(ObLSService*);
-      ObLSHandle ls_hdl; ObLS *ls = nullptr;
-      if (OB_FAIL(finish_log.assign(log_info))) { LOG_WARN("init finish log failed", K(ret)); }
-      else if (OB_FAIL(ls_svc->get_ls(log_info.ls_id_, ls_hdl, ObLSGetMod::OBSERVER_MOD))) { LOG_WARN("get ls failed", K(ret)); }
-      else if (OB_ISNULL(ls = ls_hdl.get_ls())) { ret = OB_ERR_UNEXPECTED; }
-      else if (OB_FAIL(ls->get_ls_role(role))) { LOG_WARN("get role failed", K(ret)); }
-      else if (ObRole::LEADER != role) { ret = OB_NOT_MASTER; }
-      else if (OB_FAIL(writer.init(log_info.ls_id_, log_info.table_key_.tablet_id_))) { LOG_WARN("init failed", K(ret)); }
-      else { bool remote = false; ObTabletHandle th;
-        if (OB_FAIL(ls->get_tablet(table_key.tablet_id_, th, ObTabletCommon::DEFAULT_GET_TABLET_DURATION_US, ObMDSGetTabletMode::READ_WITHOUT_CHECK))) { LOG_WARN("get tablet failed", K(ret)); }
-        else if (OB_FAIL(writer.write_finish_log(false, finish_log, remote))) { LOG_WARN("write finish log failed", K(ret)); }
-        else if (OB_FAIL(writer.wait_finish_log(finish_log.get_ls_id(), finish_log.get_table_key(), finish_log.get_data_format_version()))) { LOG_WARN("wait finish log failed", K(ret)); }
-      }
-    }
-    return ret;
-  }))) {
-    LOG_WARN("write finish log failed", K(ret), K_(leader_addr), K(arg));
+  } else if (OB_ISNULL(srv_rpc_proxy = GCTX.srv_rpc_proxy_)) {
+    ret = OB_ERR_SYS;
+    LOG_WARN("srv rpc proxy is null", K(ret), KP(srv_rpc_proxy));
+  } else if (OB_FAIL(srv_rpc_proxy->to(leader_addr_).by(MTL_ID()).remote_write_ddl_finsih_log(arg))) {
+    LOG_WARN("fail to remote write ddl redo log", K(ret), K_(leader_addr), K(arg));
   }
   return ret;
 }

--- a/src/storage/ddl/ob_ddl_redo_log_writer.h
+++ b/src/storage/ddl/ob_ddl_redo_log_writer.h
@@ -337,13 +337,13 @@ private:
       ObDDLCommitLogHandle &handle,
       uint32_t &lock_tid);
   int remote_write_ddl_commit_redo(
-      const obcall::ObCallRemoteWriteDDLCommitLogArg &arg,
+      const obrpc::ObRpcRemoteWriteDDLCommitLogArg &arg,
       share::SCN &commit_scn);
   int retry_remote_write_macro_redo(
       const int64_t task_id,
       const storage::ObDDLMacroBlockRedoInfo &redo_info);
   int retry_remote_write_commit_clog(
-      const obcall::ObCallRemoteWriteDDLCommitLogArg &arg,
+      const obrpc::ObRpcRemoteWriteDDLCommitLogArg &arg,
       share::SCN &commit_scn);
   int local_write_ddl_macro_redo(
       const storage::ObDDLMacroBlockRedoInfo &redo_info,
@@ -364,10 +364,10 @@ private:
       ObDDLFinishLogHandle &handle);
 
   int retry_remote_write_finish_log(
-      const obcall::ObCallRemoteWriteDDLFinishLogArg &arg);
+      const obrpc::ObRpcRemoteWriteDDLFinishLogArg &arg);
 
   int remote_write_ddl_finish_log(
-      const obcall::ObCallRemoteWriteDDLFinishLogArg &arg);
+      const obrpc::ObRpcRemoteWriteDDLFinishLogArg &arg);
   /* TODO @zhuoran.zzr wait to upload & update tablet meta in one func, use deep copy to avoid lock problem*/
   int upload_tablet(const ObDDLFinishLog &finish_log, ObTablet &shared_tablet, 
                     ObArenaAllocator &allocator, const bool is_remote_write);

--- a/src/storage/ob_storage_rpc.cpp
+++ b/src/storage/ob_storage_rpc.cpp
@@ -21,6 +21,9 @@
 #include "observer/ob_server_event_history_table_operator.h"
 #include "storage/tablet/ob_tablet_iterator.h"
 #include "storage/high_availability/ob_storage_ha_utils.h"
+#ifdef OB_BUILD_SHARED_STORAGE
+#include "storage/shared_storage/prewarm/ob_replica_prewarm_struct.h"
+#endif
 #include "storage/ddl/ob_direct_load_mgr_utils.h"
 #include "lib/thread/thread.h"
 #include "lib/worker.h"
@@ -30,13 +33,13 @@ namespace oceanbase
 using namespace lib;
 using namespace common;
 using namespace share;
-using namespace obcall;
+using namespace obrpc;
 using namespace storage;
 using namespace blocksstable;
 using namespace memtable;
 using namespace share::schema;
 
-namespace obcall
+namespace obrpc
 {
 
 
@@ -627,27 +630,874 @@ ObCopyLSViewArg::ObCopyLSViewArg()
 OB_SERIALIZE_MEMBER(ObCopyLSViewArg, tenant_id_, ls_id_);
 
 
-// ObStorageStreamRpcP<> obcall stream-RPC processor impls deleted — dead in seekdb.
+template <ObRpcPacketCode RPC_CODE>
+ObStorageStreamRpcP<RPC_CODE>::ObStorageStreamRpcP(common::ObInOutBandwidthThrottle *bandwidth_throttle)
+  : bandwidth_throttle_(bandwidth_throttle),
+    last_send_time_(0),
+    allocator_("SSRpcP")
+{
+}
+
+template <ObRpcPacketCode RPC_CODE>
+template <typename Data>
+int ObStorageStreamRpcP<RPC_CODE>::fill_data(const Data &data)
+{
+  int ret = OB_SUCCESS;
+  const int64_t curr_ts = ObTimeUtil::current_time();
+  if (NULL == (this->result_.get_data())) {
+    STORAGE_LOG(WARN, "fail to alloc migration data buffer.");
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+  } else if (serialization::encoded_length(data) > this->result_.get_remain()
+      || (curr_ts - last_send_time_ >= FLUSH_TIME_INTERVAL
+          && this->result_.get_capacity() != this->result_.get_remain())) {
+    if (0 == this->result_.get_position()) {
+      ret = OB_ERR_UNEXPECTED;
+      STORAGE_LOG(ERROR, "data is too large", K(ret));
+    } else if (OB_FAIL(flush_and_wait())) {
+      STORAGE_LOG(WARN, "failed to flush_and_wait", K(ret));
+    }
+  }
+
+  if (OB_SUCC(ret)) {
+    if (OB_FAIL(serialization::encode(this->result_.get_data(),
+                                      this->result_.get_capacity(),
+                                      this->result_.get_position(),
+                                      data))) {
+      STORAGE_LOG(WARN, "failed to encode", K(ret));
+    }
+  }
+  return ret;
+}
+
+template <ObRpcPacketCode RPC_CODE>
+int ObStorageStreamRpcP<RPC_CODE>::fill_buffer(blocksstable::ObBufferReader &data)
+{
+  int ret = OB_SUCCESS;
+  const int64_t curr_ts = ObTimeUtil::current_time();
+  if (NULL == (this->result_.get_data())) {
+    STORAGE_LOG(WARN, "fail to alloc migration data buffer.");
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+  } else {
+    while (OB_SUCC(ret) && data.remain() > 0) {
+      if (0 == this->result_.get_remain()
+          || (curr_ts - last_send_time_ >= FLUSH_TIME_INTERVAL
+              && this->result_.get_capacity() != this->result_.get_remain())) {
+        if (OB_FAIL(flush_and_wait())) {
+          STORAGE_LOG(WARN, "failed to flush_and_wait", K(ret));
+        }
+      } else {
+        int64_t fill_length = std::min(this->result_.get_remain(), data.remain());
+        if (fill_length <= 0) {
+          ret = OB_ERR_UNEXPECTED;
+          STORAGE_LOG(ERROR, "fill_length must larger than 0", K(ret), K(fill_length), K(this->result_), K(data));
+        } else {
+          MEMCPY(this->result_.get_cur_pos(), data.current(), fill_length);
+          this->result_.get_position() += fill_length;
+          if (OB_FAIL(data.advance(fill_length))) {
+            STORAGE_LOG(WARN, "failed to advance fill length", K(ret), K(fill_length), K(data));
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
 
 
-// Legacy shared-storage migrate-warmup obcall RPC arg/result struct impls removed
-// (replaced by gRPC; see ob_storage_grpc.cpp).
+
+template <ObRpcPacketCode RPC_CODE>
+int ObStorageStreamRpcP<RPC_CODE>::flush_and_wait()
+{
+  int ret = OB_SUCCESS;
+  int tmp_ret = OB_SUCCESS;
+  const int64_t max_idle_time = OB_DEFAULT_STREAM_WAIT_TIMEOUT - OB_DEFAULT_STREAM_RESERVE_TIME;
+
+  if (NULL == bandwidth_throttle_) {
+    ret = OB_NOT_INIT;
+    STORAGE_LOG(WARN, "bandwidth_throttle_ must not null", K(ret));
+  } else {
+    if (OB_SUCCESS != (tmp_ret = bandwidth_throttle_->limit_out_and_sleep(
+        this->result_.get_position(), last_send_time_, max_idle_time))) {
+      STORAGE_LOG(WARN, "failed limit out band", K(tmp_ret));
+    }
+
+    if (OB_FAIL(this->check_timeout())) {
+      LOG_WARN("rpc is timeout, no need flush", K(ret));
+    } else if (OB_FAIL(this->flush())) {
+      STORAGE_LOG(WARN, "failed to flush", K(ret));
+    } else {
+      this->result_.get_position() = 0;
+      last_send_time_ = ObTimeUtility::current_time();
+    }
+  }
+  return ret;
+}
 
 
-// cross-tenant LOB obcall RPC removed: ObLobQueryP processor (OB_LOB_QUERY) deleted —
-// cross-tenant LOB read now runs in-process (storage/lob/ob_lob_remote.cpp).
-// Legacy shared-storage migrate-warmup obcall RPC processor impls removed
-// (ObFetchMicroBlockKeysP / ObFetchMicroBlockP / ObGetMicroBlockCacheInfoP /
-//  ObGetMigrationCacheJobInfoP / ObFetchReplicaPrewarmMicroBlockP) — replaced by gRPC.
+template <ObRpcPacketCode RPC_CODE>
+int ObStorageStreamRpcP<RPC_CODE>::is_follower_ls(logservice::ObLogService *log_srv, ObLS *ls, bool &is_ls_follower)
+{
+  int ret = OB_SUCCESS;
+  logservice::ObLogHandler *log_handler = nullptr;
+  int64_t proposal_id = 0;
+  ObRole role;
+  if (OB_ISNULL(log_srv) || OB_ISNULL(ls)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("log handler should not be NULL", K(ret), KP(log_srv), K(ls));
+  } else if (OB_FAIL(log_srv->get_palf_role(ls->get_ls_id(), role, proposal_id))) {
+    LOG_WARN("fail to get role", K(ret), "ls_id", ls->get_ls_id());
+  } else if (!is_follower(role)) {
+    is_ls_follower = false;
+    STORAGE_LOG(WARN, "I am not follower", K(ret), K(role), K(proposal_id));
+  } else {
+    is_ls_follower = true;
+  }
+  return ret;
+}
 
-} //namespace obcall
+#ifdef OB_BUILD_SHARED_STORAGE
+ObGetMicroBlockCacheInfoArg::ObGetMicroBlockCacheInfoArg()
+  : tenant_id_(OB_INVALID_ID),
+    ls_id_()
+{
+}
+
+bool ObGetMicroBlockCacheInfoArg::is_valid() const
+{
+  return OB_INVALID_ID != tenant_id_ && ls_id_.is_valid();
+}
+
+
+OB_SERIALIZE_MEMBER(ObGetMicroBlockCacheInfoArg, tenant_id_, ls_id_);
+
+ObGetMicroBlockCacheInfoRes::ObGetMicroBlockCacheInfoRes()
+  : ls_cache_info_()
+{
+}
+
+
+
+OB_SERIALIZE_MEMBER(ObGetMicroBlockCacheInfoRes, ls_cache_info_);
+
+ObGetMigrationCacheJobInfoArg::ObGetMigrationCacheJobInfoArg()
+  : tenant_id_(OB_INVALID_ID),
+    ls_id_(),
+    task_count_(0)
+{
+}
+
+bool ObGetMigrationCacheJobInfoArg::is_valid() const
+{
+  return OB_INVALID_ID != tenant_id_ && ls_id_.is_valid() && task_count_ > 0;
+}
+
+
+OB_SERIALIZE_MEMBER(ObGetMigrationCacheJobInfoArg, tenant_id_, ls_id_, task_count_);
+
+ObGetMigrationCacheJobInfoRes::ObGetMigrationCacheJobInfoRes()
+  : job_infos_()
+{
+}
+
+
+void ObGetMigrationCacheJobInfoRes::reset()
+{
+  job_infos_.reset();
+}
+
+OB_SERIALIZE_MEMBER(ObGetMigrationCacheJobInfoRes, job_infos_);
+
+ObGetMicroBlockKeyArg::ObGetMicroBlockKeyArg()
+  : tenant_id_(OB_INVALID_ID),
+    ls_id_(),
+    job_info_()
+{
+}
+
+bool ObGetMicroBlockKeyArg::is_valid() const
+{
+  return OB_INVALID_ID != tenant_id_ 
+      && ls_id_.is_valid() 
+      && job_info_.is_valid();
+}
+
+
+OB_SERIALIZE_MEMBER(ObGetMicroBlockKeyArg, tenant_id_, ls_id_, job_info_);
+
+ObCopyMicroBlockKeySetRes::ObCopyMicroBlockKeySetRes()
+  : header_(),
+    key_set_array_()
+{
+}
+
+ObCopyMicroBlockKeySetRes::~ObCopyMicroBlockKeySetRes()
+{
+}
+
+bool ObCopyMicroBlockKeySetRes::is_valid() const
+{
+  return header_.is_valid();
+}
+
+void ObCopyMicroBlockKeySetRes::reset()
+{
+  header_.reset();
+  key_set_array_.reset();
+}
+
+
+OB_SERIALIZE_MEMBER(ObCopyMicroBlockKeySetRes, header_, key_set_array_);
+
+ObMigrateWarmupKeySet::ObMigrateWarmupKeySet()
+  : tenant_id_(OB_INVALID_ID),
+    key_sets_()
+{
+}
+
+bool ObMigrateWarmupKeySet::is_valid() const
+{
+  return OB_INVALID_ID != tenant_id_ && !key_sets_.empty();
+}
+
+void ObMigrateWarmupKeySet::reset()
+{
+  tenant_id_ = OB_INVALID_ID;
+  key_sets_.reset();
+}
+
+int ObMigrateWarmupKeySet::assign(const ObMigrateWarmupKeySet &arg)
+{
+  int ret = OB_SUCCESS;
+  if (!arg.is_valid()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid argument", K(ret), K(arg));
+  } else if (OB_FAIL(key_sets_.assign(arg.key_sets_))) {
+    LOG_WARN("failed to assign arg list", K(ret), K(arg));
+  } else {
+    tenant_id_ = arg.tenant_id_;
+  }
+  return ret;
+}
+
+OB_SERIALIZE_MEMBER(ObMigrateWarmupKeySet, tenant_id_, key_sets_);
+
+ObSSLSFetchMicroBlockArg::ObSSLSFetchMicroBlockArg()
+  : tenant_id_(OB_INVALID_TENANT_ID), micro_metas_()
+{
+}
+
+bool ObSSLSFetchMicroBlockArg::is_valid() const
+{
+  return (is_valid_tenant_id(tenant_id_) && !micro_metas_.empty());
+}
+
+
+int ObSSLSFetchMicroBlockArg::assign(const ObSSLSFetchMicroBlockArg &other)
+{
+  int ret = OB_SUCCESS;
+  if (OB_LIKELY(this != &other)) {
+    tenant_id_ = other.tenant_id_;
+    if (OB_FAIL(micro_metas_.assign(other.micro_metas_))) {
+      LOG_WARN("fail to assign micro keys", KR(ret));
+    }
+  }
+  return ret;
+}
+
+OB_SERIALIZE_MEMBER(ObSSLSFetchMicroBlockArg, tenant_id_, micro_metas_);
+
+#endif
+
+
+ObNotifyRestoreTabletsP::ObNotifyRestoreTabletsP(
+    common::ObInOutBandwidthThrottle *bandwidth_throttle)
+    : ObStorageStreamRpcP(bandwidth_throttle)
+{
+
+}
+
+int ObNotifyRestoreTabletsP::process()
+{
+  int ret = OB_NOT_SUPPORTED;
+  return ret;
+}
+
+
+ObInquireRestoreP::ObInquireRestoreP(
+    common::ObInOutBandwidthThrottle *bandwidth_throttle)
+    : ObStorageStreamRpcP(bandwidth_throttle)
+{
+
+}
+
+int ObInquireRestoreP::process()
+{
+  int ret = OB_SUCCESS;
+  MTL_SWITCH(arg_.tenant_id_) {
+    CONSUMER_GROUP_FUNC_GUARD(ObFunctionType::PRIO_HA_HIGH);
+    ObLSHandle ls_handle;
+    ObLSService *ls_service = nullptr;
+    ObLS *ls = nullptr;
+    logservice::ObLogService *log_srv = nullptr;
+    ObDeviceHealthStatus dhs = DEVICE_HEALTH_NORMAL;
+    int64_t disk_abnormal_time = 0;
+    bool is_follower = false;
+
+    LOG_INFO("start to inquire restore status", K(arg_));
+
+#ifdef ERRSIM
+    if (OB_SUCC(ret) && DEVICE_HEALTH_NORMAL == dhs && GCONF.fake_disk_error) {
+      dhs = DEVICE_HEALTH_ERROR;
+    }
+#endif
+
+    if (!arg_.is_valid()) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("notify follower restore get invalid argument", K(ret), K(arg_));
+    } else if (DEVICE_HEALTH_NORMAL == dhs
+        && OB_FAIL(ObIOManager::get_instance().get_device_health_status(dhs, disk_abnormal_time))) {
+      STORAGE_LOG(WARN, "failed to check is disk error", KR(ret));
+    } else if (DEVICE_HEALTH_ERROR == dhs) {
+      ret = OB_DISK_ERROR;
+      STORAGE_LOG(ERROR, "observer has disk error, cannot restore", KR(ret),
+          "disk_health_status", device_health_status_to_str(dhs), K(disk_abnormal_time));
+    } else if (OB_ISNULL(ls_service = MTL(ObLSService *))) {
+      ret = OB_ERR_UNEXPECTED;
+      STORAGE_LOG(WARN, "ls service should not be null", K(ret), KP(ls_service));
+    } else if (OB_FAIL(ls_service->get_ls(arg_.ls_id_, ls_handle, ObLSGetMod::STORAGE_MOD))) {
+      LOG_WARN("failed to get log stream", K(ret), K(arg_));
+    } else if (OB_ISNULL(ls = ls_handle.get_ls())) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("log stream should not be NULL", K(ret), KP(ls), K(arg_));
+    } else if (OB_ISNULL(log_srv = MTL(logservice::ObLogService*))) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("log srv should not be null", K(ret), KP(log_srv));
+    } else if (OB_FAIL(is_follower_ls(log_srv, ls, is_follower))) {
+      LOG_WARN("failed to check is follower", K(ret), KP(ls), K(arg_));
+    } else if (OB_FAIL(ls->get_restore_status(result_.restore_status_))) {
+      LOG_WARN("fail to get restore status", K(ret));
+    } else if (is_follower) {
+      result_.tenant_id_ = arg_.tenant_id_;
+      result_.ls_id_ = arg_.ls_id_;
+      result_.is_leader_ = false;
+      LOG_INFO("succ to inquire restore status from follower", K(result_));
+    } else {
+      result_.tenant_id_ = arg_.tenant_id_;
+      result_.ls_id_ = arg_.ls_id_;
+      result_.is_leader_ = true;
+      LOG_INFO("succ to inquire restore status from leader", K(ret), K(arg_), K(result_));
+    }
+  }
+  return ret;
+}
+
+ObUpdateLSMetaP::ObUpdateLSMetaP(
+    common::ObInOutBandwidthThrottle *bandwidth_throttle)
+    : ObStorageStreamRpcP(bandwidth_throttle)
+{
+
+}
+
+int ObUpdateLSMetaP::process()
+{
+  int ret = OB_SUCCESS;
+  MTL_SWITCH(arg_.tenant_id_) {
+    CONSUMER_GROUP_FUNC_GUARD(ObFunctionType::PRIO_HA_HIGH);
+    ObLSHandle ls_handle;
+    ObLSService *ls_service = nullptr;
+    ObLS *ls = nullptr;
+    bool is_follower = false;
+    ObDeviceHealthStatus dhs = DEVICE_HEALTH_NORMAL;
+    int64_t disk_abnormal_time = 0;
+
+    LOG_INFO("start to update ls meta", K(arg_));
+
+#ifdef ERRSIM
+    if (OB_SUCC(ret) && DEVICE_HEALTH_NORMAL == dhs && GCONF.fake_disk_error) {
+      dhs = DEVICE_HEALTH_ERROR;
+    }
+#endif
+    if (!arg_.is_valid()) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("notify follower restore get invalid argument", K(ret), K(arg_));
+    } else if (DEVICE_HEALTH_NORMAL == dhs
+        && OB_FAIL(ObIOManager::get_instance().get_device_health_status(dhs, disk_abnormal_time))) {
+      STORAGE_LOG(WARN, "failed to check is disk error", KR(ret));
+    } else if (DEVICE_HEALTH_ERROR == dhs) {
+      ret = OB_DISK_ERROR;
+      STORAGE_LOG(ERROR, "observer has disk error, cannot restore", KR(ret),
+          "disk_health_status", device_health_status_to_str(dhs), K(disk_abnormal_time));
+    } else if (OB_ISNULL(ls_service = MTL(ObLSService *))) {
+      ret = OB_ERR_UNEXPECTED;
+      STORAGE_LOG(WARN, "ls service should not be null", K(ret), KP(ls_service));
+    } else if (OB_FAIL(ls_service->restore_update_ls(arg_.ls_meta_package_))) {
+      LOG_WARN("failed to get log stream", K(ret), K(arg_));
+    } else {
+      LOG_INFO("succ to update ls meta", K(ret), K(arg_));
+    }
+  }
+  return ret;
+}
+
+ObLobQueryP::ObLobQueryP(common::ObInOutBandwidthThrottle *bandwidth_throttle)
+  : ObStorageStreamRpcP(bandwidth_throttle)
+{
+  // the streaming interface may return multi packet. The memory may be freed after the first packet has been sended.
+  // the deserialization of arg_ is shallow copy, so we need deep copy data to processor
+  set_preserve_recv_data();
+}
+
+int64_t ObLobQueryP::get_timeout() const
+{
+  int64_t timeout = 0;
+  const int64_t rpc_timeout = rpc_pkt_->get_timeout();
+  const int64_t send_timestamp = get_send_timestamp();
+  // oversize int64_t if rpc_timeout + send_timestamp > INT64_MAX
+  if (INT64_MAX - rpc_timeout - send_timestamp < 0) {
+    timeout = INT64_MAX;
+  } else {
+    timeout = rpc_timeout + send_timestamp;
+  }
+  return timeout;
+}
+
+int ObLobQueryP::process_read()
+{
+  int ret = OB_SUCCESS;
+  ObLobManager *lob_mngr = MTL(ObLobManager*);
+  ObLobQueryBlock header;
+  blocksstable::ObBufferReader data;
+  char *out_buf = nullptr;
+  int64_t buf_len = ObLobQueryArg::OB_LOB_QUERY_BUFFER_LEN - sizeof(ObLobQueryBlock);
+  if (OB_ISNULL(out_buf = reinterpret_cast<char*>(allocator_.alloc(buf_len)))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    STORAGE_LOG(WARN, "failed to alloc out data buffer.", K(ret));
+  } else {
+    ObString out;
+    ObLobAccessParam param;
+    param.scan_backward_ = arg_.scan_backward_;
+    param.from_rpc_ = true;
+    param.enable_remote_retry_ = arg_.enable_remote_retry_;
+    ObLobQueryIter *iter = nullptr;
+    int64_t timeout = get_timeout();
+    if (OB_FAIL(lob_mngr->build_lob_param(param, allocator_, arg_.cs_type_, arg_.offset_,
+        arg_.len_, timeout, arg_.lob_locator_))) {
+      LOG_WARN("failed to build lob param", K(ret));
+    } else if (OB_FAIL(lob_mngr->query(param, iter))) {
+      LOG_WARN("failed to query lob.", K(ret), K(param));
+    } else {
+      while (OB_SUCC(ret)) {
+        out.assign_buffer(out_buf, buf_len);
+        if (OB_FAIL(iter->get_next_row(out))) {
+          if (OB_ITER_END != ret) {
+            STORAGE_LOG(WARN, "failed to get next buffer", K(ret));
+          }
+        } else {
+          header.size_ = out.length();
+          data.assign(out.ptr(), out.length());
+          // only scan backward need header
+          if (OB_FAIL(fill_data(header))) {
+            STORAGE_LOG(WARN, "failed to fill header", K(ret), K(header));
+          } else if (OB_FAIL(fill_buffer(data))) {
+            STORAGE_LOG(WARN, "failed to fill buffer", K(ret), K(data));
+          }
+        }
+      }
+      if (ret == OB_ITER_END) {
+        ret = OB_SUCCESS;
+      }
+    }
+    if (OB_NOT_NULL(iter)) {
+      iter->reset();
+      OB_DELETE(ObLobQueryIter, "unused", iter);
+    }
+  }
+  return ret;
+}
+
+int ObLobQueryP::process_getlength()
+{
+  int ret = OB_SUCCESS;
+  ObLobManager *lob_mngr = MTL(ObLobManager*);
+  ObLobQueryBlock header;
+  blocksstable::ObBufferReader data;
+  ObLobAccessParam param;
+  param.scan_backward_ = arg_.scan_backward_;
+  param.from_rpc_ = true;
+  param.enable_remote_retry_ = arg_.enable_remote_retry_;
+  header.reset();
+  uint64_t len = 0;
+  int64_t timeout = get_timeout();
+  if (OB_FAIL(lob_mngr->build_lob_param(param, allocator_, arg_.cs_type_, arg_.offset_,
+      arg_.len_, timeout, arg_.lob_locator_))) {
+    LOG_WARN("failed to build lob param", K(ret));
+  } else if (OB_FAIL(lob_mngr->getlength(param, len))) { // reuse size_ for lob_len
+    LOG_WARN("failed to getlength lob.", K(ret), K(param));
+  } else if (FALSE_IT(header.size_ = static_cast<int64_t>(len))) {
+  } else if (OB_FAIL(fill_data(header))) {
+    STORAGE_LOG(WARN, "failed to fill header", K(ret), K(header));
+  }
+  return ret;
+}
+
+int ObLobQueryP::process()
+{
+  int ret = OB_SUCCESS;
+  MTL_SWITCH(arg_.tenant_id_) {
+    ObLobManager *lob_mngr = MTL(ObLobManager*);
+    // init result_
+    char *buf = nullptr;
+    int64_t buf_len = ObLobQueryArg::OB_LOB_QUERY_BUFFER_LEN;
+    if (OB_ISNULL(buf = reinterpret_cast<char*>(allocator_.alloc(buf_len)))) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      STORAGE_LOG(WARN, "failed to alloc result data buffer.", K(ret));
+    } else if (!result_.set_data(buf, buf_len)) {
+      ret = OB_ERR_UNEXPECTED;
+      STORAGE_LOG(WARN, "failed set data to result", K(ret));
+    } else if (!arg_.lob_locator_.is_valid()) {
+      ret = OB_ERR_UNEXPECTED;
+      STORAGE_LOG(WARN, "lob locator is invalid", K(ret));
+    } else if (!arg_.lob_locator_.is_persist_lob()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_WARN("unsupport remote query non-persist lob.", K(ret), K(arg_.lob_locator_));
+    } else if (arg_.qtype_ == ObLobQueryArg::QueryType::READ) {
+      if (OB_FAIL(process_read())) {
+        LOG_WARN("fail to process read", K(ret), K(arg_));
+      }
+    } else if (arg_.qtype_ == ObLobQueryArg::QueryType::GET_LENGTH) {
+      if (OB_FAIL(process_getlength())) {
+        LOG_WARN("fail to process read", K(ret), K(arg_));
+      }
+    } else {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("invalid arg qtype.", K(ret), K(arg_));
+    }
+  }
+  return ret;
+}
+#ifdef OB_BUILD_SHARED_STORAGE
+int ObFetchMicroBlockKeysP::set_header_attr_(
+    const ObCopyMicroBlockKeySetRpcHeader::ConnectStatus connect_status,
+    const int64_t blk_idx, const int64_t count,
+    ObCopyMicroBlockKeySetRpcHeader &header)
+{
+  int ret = OB_SUCCESS;
+  header.reset();
+  if (connect_status < ObCopyMicroBlockKeySetRpcHeader::ConnectStatus::RECONNECT
+      || connect_status >= ObCopyMicroBlockKeySetRpcHeader::ConnectStatus::MAX_STATUS
+      || blk_idx < 0
+      || count < 0) {
+    ret = OB_INVALID_ARGUMENT;
+    STORAGE_LOG(WARN, "header attr is invalid", K(ret), K(connect_status), K(blk_idx), K(count));
+  } else {
+    header.connect_status_ = connect_status;
+    header.end_blk_idx_ = blk_idx;
+    header.object_count_ = count;
+  }
+  return ret;
+}
+
+ERRSIM_POINT_DEF(EN_MICRO_KEY_SET_RECONNECT);
+int ObFetchMicroBlockKeysP::process()
+{
+  int ret = OB_SUCCESS;
+
+  MTL_SWITCH(arg_.tenant_id_) {
+    ObCopyMicroBlockKeySetProducer producer;
+    ObCopyMicroBlockKeySet key_set;
+    ObCopyMicroBlockKeySetRpcHeader rpc_header;
+    int64_t max_key_set_size = WARMUP_MAX_KEY_SET_SIZE_IN_RPC; // 4M;
+    const int64_t start_ts = ObTimeUtil::current_time();
+    int64_t end_blk_idx = 0;
+    int64_t key_set_count = 0;
+    int64_t key_count = 0;
+    ObCopyMicroBlockKeySetRpcHeader::ConnectStatus connect_status = ObCopyMicroBlockKeySetRpcHeader::ConnectStatus::MAX_STATUS;
+    LOG_INFO("start to fetch micro block header", K(arg_));
+
+    if (!arg_.is_valid()) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("get invalid args", K(ret), K_(arg));
+    } else if (OB_FAIL(producer.init(arg_.job_info_, arg_.ls_id_))) {
+      LOG_WARN("failed to init micro block key producer", K(ret), K(arg_));
+    } else {
+      while (OB_SUCC(ret)) {
+        key_set.reset();
+        if (OB_FAIL(producer.get_next_micro_block_key_set(key_set))) {
+          if (OB_ITER_END == ret) {
+            ret = OB_SUCCESS;
+            end_blk_idx = key_set.blk_idx_;
+            connect_status = ObCopyMicroBlockKeySetRpcHeader::ConnectStatus::ENDCONNECT;
+            break;
+          } else {
+            STORAGE_LOG(WARN, "failed to get next micro block key set", K(ret));
+          }
+        } else if (!key_set.is_valid()) {
+          LOG_INFO("skip this key set", K(arg_), K(key_set));
+        } else {
+          // dest will judge ObMigrateWarmupKeySet serialize size,
+          if (OB_FAIL(result_.key_set_array_.key_sets_.push_back(key_set))) {
+            STORAGE_LOG(WARN, "fail to fill key set", K(ret), K(key_set));
+          } 
+#ifdef ERRSIM
+          else if (EN_MICRO_KEY_SET_RECONNECT && key_set_count > 0) {
+            result_.key_set_array_.key_sets_.pop_back();
+            connect_status = ObCopyMicroBlockKeySetRpcHeader::ConnectStatus::RECONNECT;
+            break;
+          }
+#endif
+          else if (result_.key_set_array_.get_serialize_size() > max_key_set_size) {
+            result_.key_set_array_.key_sets_.pop_back();
+            connect_status = ObCopyMicroBlockKeySetRpcHeader::ConnectStatus::RECONNECT;
+            break;
+          } else {
+            key_set_count++;
+            key_count += key_set.micro_block_key_metas_.count();
+            end_blk_idx = key_set.blk_idx_;
+          }
+        }
+      }
+    }
+    if (OB_SUCC(ret)) {
+      if (OB_FAIL(set_header_attr_(connect_status, end_blk_idx, key_set_count, rpc_header))) {
+        LOG_WARN("failed to set header attr", K(ret), K(rpc_header), K(arg_),
+            K(connect_status), K(end_blk_idx), K(key_set_count));
+      } else {
+        result_.header_ = rpc_header;
+      }
+    }
+    LOG_INFO("finish fetch micro block header", K(ret), "cost_ts", ObTimeUtil::current_time() - start_ts, 
+        K(key_count), K(arg_), K(rpc_header));
+  }
+  return ret;
+}
+
+ObFetchMicroBlockP::ObFetchMicroBlockP(
+      common::ObInOutBandwidthThrottle *bandwidth_throttle)
+    : ObStorageStreamRpcP(bandwidth_throttle)
+{
+}
+
+int ObFetchMicroBlockP::process()
+{
+  int ret = OB_SUCCESS;
+
+  MTL_SWITCH(arg_.tenant_id_) {
+    blocksstable::ObBufferReader data;
+    char *buf = NULL;
+    last_send_time_ = this->get_receive_timestamp();
+    int64_t key_count = 0;
+    ObSArray<ObSSMicroBlockCacheKeyMeta> key_meta_array;
+    const int64_t start_ts = ObTimeUtil::current_time();
+    const int64_t first_receive_ts = this->get_receive_timestamp();
+    LOG_INFO("start to fetch micro block", K(arg_));
+    if (!arg_.is_valid()) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("get invalid args", K(ret), K_(arg));
+    }
+    // The reason that apply 6M buffer:
+    // buffer struct: key_meta_array + data
+    // key_meta: key info + other cache info
+    // other cache info: uint32(crc) + bool(in t1/t2), less than key info
+    // data less than 2M, it comes from a cache block
+    // key info array also less than 2M
+    // other cache info array also less than 2M
+    // so key_meta_array + data less than 6M
+    else if (NULL == (buf = reinterpret_cast<char*>(allocator_.alloc(OB_MALLOC_BIG_BLOCK_SIZE * 3)))) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      STORAGE_LOG(WARN, "failed to alloc migrate data buffer.", K(ret));
+    } else if (!result_.set_data(buf, OB_MALLOC_BIG_BLOCK_SIZE * 3)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      STORAGE_LOG(WARN, "failed set data to result", K(ret));
+    } else if (OB_ISNULL(bandwidth_throttle_)) {
+      ret = OB_ERR_UNEXPECTED;
+      STORAGE_LOG(ERROR, "bandwidth_throttle must not null", K(ret), KP_(bandwidth_throttle));
+    } else {
+      SMART_VAR(storage::ObCopyMicroBlockDataProducer, producer) {
+        if (OB_FAIL(producer.init(arg_.key_sets_))) {
+          LOG_WARN("failed to init micro block data producer", K(ret), K(arg_));
+        } else {
+          while (OB_SUCC(ret)) {
+            key_meta_array.reset();
+            if (OB_FAIL(producer.get_next_micro_block_data(key_meta_array, data))) {
+              if (OB_ITER_END != ret) {
+                STORAGE_LOG(WARN, "failed to get next micro block set", K(ret));
+              } else {
+                ret = OB_SUCCESS;
+              }
+              break;
+            } else if (key_meta_array.empty()) {
+              LOG_INFO("skip this key and size arr", K(arg_));
+            } else if (OB_FAIL(fill_data(key_meta_array))) {
+              STORAGE_LOG(WARN, "failed to fill data length", K(ret), K(data.pos()), K(key_meta_array));
+            } else if (OB_FAIL(fill_buffer(data))) {
+              STORAGE_LOG(WARN, "failed to fill data", K(ret), K(key_meta_array));
+            } else {
+              key_count += key_meta_array.count();
+              STORAGE_LOG(INFO, "succeed to fill micro block set",
+                  "key and size array", key_meta_array, K(data));
+            }
+          }
+        }
+      }
+    }
+
+    LOG_INFO("finish fetch micro block set", K(ret),
+        "cost_ts", ObTimeUtil::current_time() - start_ts,
+        "in rpc queue time", start_ts - first_receive_ts, K(key_count));
+  }
+  return ret;
+}
+
+int ObGetMicroBlockCacheInfoP::process()
+{
+  int ret = OB_SUCCESS;
+
+  MTL_SWITCH(arg_.tenant_id_) {
+    ObSSMicroCache *micro_cache = nullptr;
+    if (!arg_.is_valid()) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("get invalid args", K(ret), K_(arg));
+    } else if (OB_ISNULL(micro_cache = MTL(ObSSMicroCache*))) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("micro cache should not be nullptr", K(ret));
+    } else {
+      if (OB_FAIL(micro_cache->get_ls_cache_info(arg_.ls_id_, result_.ls_cache_info_))) {
+        LOG_WARN("fail to get ls cache info", KR(ret), K_(arg));
+      }
+      LOG_INFO("send cache info", K(ret), K(result_), K(arg_));
+    }
+  }
+  return ret;
+}
+
+int ObGetMigrationCacheJobInfoP::process()
+{
+  int ret = OB_SUCCESS;
+
+  MTL_SWITCH(arg_.tenant_id_) {
+    ObSSMicroCache *micro_cache = nullptr;
+    ObArray<ObSSPhyBlockIdxRange> block_ranges;
+    if (!arg_.is_valid()) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("get invalid args", K(ret), K_(arg));
+    } else if (OB_ISNULL(micro_cache = MTL(ObSSMicroCache*))) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("micro cache should not be nullptr", K(ret));
+    } else if (OB_FAIL(micro_cache->divide_phy_block_range(arg_.ls_id_, arg_.task_count_, block_ranges))) {
+      LOG_WARN("failed to divide phy_block range", K(ret), K(arg_));
+    } else if (block_ranges.empty()) {
+      FLOG_INFO("block_ranges is empty", K_(arg));
+    } else if (OB_FAIL(convert_block_range_to_job_infos_(block_ranges, result_.job_infos_))) {
+      LOG_WARN("failed to convert job infos", K(ret), K(block_ranges), K(arg_));
+    } else if (arg_.task_count_ < result_.job_infos_.count()) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("job info count is unexpected", K(ret), K(arg_), K(result_));
+    } else {
+      LOG_INFO("send job info", K(block_ranges), K(result_.job_infos_));
+    }
+  }
+  return ret;
+}
+
+int ObGetMigrationCacheJobInfoP::convert_block_range_to_job_infos_(
+    const ObIArray<ObSSPhyBlockIdxRange> &block_ranges, ObIArray<ObMigrationCacheJobInfo> &job_infos)
+{
+  int ret = OB_SUCCESS;
+  job_infos.reset();
+  if (block_ranges.count() <= 0) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid argument", K(ret));
+  } else {
+    ObMigrationCacheJobInfo job_info;
+    for (int i = 0; i < block_ranges.count() && OB_SUCC(ret); i++) {
+      job_info.reset();
+      if (OB_FAIL(job_info.convert_from(block_ranges.at(i)))) {
+        LOG_WARN("failed to convert from block range", K(ret), "block range", block_ranges.at(i));
+      } else if (OB_FAIL(job_infos.push_back(job_info))) {
+        LOG_WARN("failed to push back to job infos", K(ret), K(job_info));
+      }
+    }
+  }
+  return ret;
+}
+
+ObFetchReplicaPrewarmMicroBlockP::ObFetchReplicaPrewarmMicroBlockP(
+    common::ObInOutBandwidthThrottle *bandwidth_throttle)
+  : ObStorageStreamRpcP(bandwidth_throttle)
+{
+}
+
+int ObFetchReplicaPrewarmMicroBlockP::process()
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(!arg_.is_valid())) {
+    ret = OB_INVALID_ARGUMENT;
+    STORAGE_LOG(WARN, "invalid argument", KR(ret), K_(arg));
+  } else {
+    MTL_SWITCH(arg_.tenant_id_) {
+      blocksstable::ObBufferReader data;
+      char *buf = nullptr;
+      last_send_time_ = this->get_receive_timestamp();
+      const int64_t start_us = ObTimeUtil::current_time();
+      const int64_t first_receive_us = this->get_receive_timestamp();
+
+      if (OB_ISNULL(buf = static_cast<char *>(allocator_.alloc(OB_MALLOC_BIG_BLOCK_SIZE)))) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        STORAGE_LOG(WARN, "fail to alloc data buffer.", KR(ret));
+      } else if (!result_.set_data(buf, OB_MALLOC_BIG_BLOCK_SIZE)) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        STORAGE_LOG(WARN, "fail to set data to result", KR(ret));
+      } else if (OB_ISNULL(bandwidth_throttle_)) {
+        ret = OB_ERR_UNEXPECTED;
+        STORAGE_LOG(ERROR, "bandwidth_throttle must not null", KR(ret), KP_(bandwidth_throttle));
+      } else {
+        SMART_VARS_2((storage::ObReplicaPrewarmMicroBlockProducer, producer),
+                     (ObSSLSFetchMicroBlockArg, arg)) {
+          if (OB_FAIL(arg.assign(arg_))) {
+            LOG_WARN("fail to assign copy fetch micro block arg", KR(ret), K(arg_));
+          } else if (OB_FAIL(producer.init(arg.micro_metas_))) {
+            LOG_WARN("fail to init replica prewarm micro block producer", KR(ret), K(arg));
+          } else {
+            while (OB_SUCC(ret)) {
+              ObSSMicroBlockCacheKeyMeta micro_meta;
+              if (OB_FAIL(producer.get_next_micro_block(micro_meta, data))) {
+                if (OB_ITER_END != ret) {
+                  STORAGE_LOG(WARN, "fail to get next micro block", KR(ret));
+                } else {
+                  ret = OB_SUCCESS;
+                }
+                break;
+              } else if (OB_FAIL(fill_data(micro_meta))) {
+                STORAGE_LOG(WARN, "fail to fill data length", KR(ret), K(data.pos()), K(micro_meta));
+              } else if (OB_FAIL(fill_buffer(data))) {
+                STORAGE_LOG(WARN, "fail to fill data", KR(ret), K(micro_meta));
+              } else {
+                STORAGE_LOG(INFO, "succ to fill micro block", K(micro_meta));
+              }
+            }
+          }
+        }
+      }
+
+      const int64_t cost_us = ObTimeUtil::current_time() - start_us;
+      LOG_INFO("finish fetch replica prewarm micro block", KR(ret), K(cost_us), "in rpc queue time",
+              start_us - first_receive_us);
+    }
+  }
+  return ret;
+}
+
+#endif
+
+} //namespace obrpc
 
 namespace storage
 {
 
 ObStorageRpc::ObStorageRpc()
     : is_inited_(false),
-      rpc_proxy_(NULL)
+      rpc_proxy_(NULL),
+      rs_rpc_proxy_(NULL)
 {
 }
 
@@ -657,20 +1507,22 @@ ObStorageRpc::~ObStorageRpc()
 }
 
 int ObStorageRpc::init(
-    obcall::ObStorageRpcProxy *rpc_proxy,
-    const common::ObAddr &self)
+    obrpc::ObStorageRpcProxy *rpc_proxy,
+    const common::ObAddr &self,
+    obrpc::ObCommonRpcProxy *rs_rpc_proxy)
 {
   int ret = OB_SUCCESS;
   if (is_inited_) {
     ret = OB_INIT_TWICE;
     STORAGE_LOG(WARN, "storage rpc has inited", K(ret));
-  } else if (OB_ISNULL(rpc_proxy) || !self.is_valid()) {
+  } else if (OB_ISNULL(rpc_proxy) || !self.is_valid() || OB_ISNULL(rs_rpc_proxy)) {
     ret = OB_INVALID_ARGUMENT;
     STORAGE_LOG(WARN, "ObStorageRpc init with invalid argument",
-        KP(rpc_proxy), K(self));
+        KP(rpc_proxy), K(self), KP(rs_rpc_proxy));
   } else {
     rpc_proxy_ = rpc_proxy;
     self_ = self;
+    rs_rpc_proxy_ = rs_rpc_proxy;
     is_inited_ = true;
   }
   return ret;
@@ -682,12 +1534,201 @@ void ObStorageRpc::destroy()
     is_inited_ = false;
     rpc_proxy_ = NULL;
     self_ = ObAddr();
+    rs_rpc_proxy_ = NULL;
   }
 }
 
+int ObStorageRpc::notify_restore_tablets(
+      const uint64_t tenant_id,
+      const ObStorageHASrcInfo &follower_info,
+      const share::ObLSID &ls_id,
+      const int64_t &proposal_id,
+      const common::ObIArray<common::ObTabletID>& tablet_id_array,
+      const share::ObLSRestoreStatus &restore_status,
+      obrpc::ObNotifyRestoreTabletsResp &restore_resp)
+{
+  int ret = OB_SUCCESS;
+  ObNotifyRestoreTabletsArg arg;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    STORAGE_LOG(WARN, "storage rpc is not inited", K(ret));
+  } else if (!follower_info.is_valid() || !ls_id.is_valid()
+      || (tablet_id_array.empty() && (restore_status.is_restore_tablets_meta() || restore_status.is_quick_restore() || restore_status.is_restore_major_data()))) {
+    ret = OB_INVALID_ARGUMENT;
+    STORAGE_LOG(WARN, "notify follower restore get invalid argument", K(ret), K(follower_info), K(ls_id), K(tablet_id_array));
+  } else if (OB_FAIL(arg.tablet_id_array_.assign(tablet_id_array))) {
+    STORAGE_LOG(WARN, "failed to assign tablet id array", K(ret), K(follower_info), K(ls_id), K(tablet_id_array));
+  } else {
+    arg.tenant_id_ = tenant_id;
+    arg.ls_id_ = ls_id;
+    arg.restore_status_ = restore_status;
+    arg.leader_proposal_id_ = proposal_id;
+    if (OB_FAIL(rpc_proxy_->to(follower_info.src_addr_).dst_cluster_id(follower_info.cluster_id_)
+        .by(tenant_id)
+        .group_id(share::OBCG_STORAGE)
+        .notify_restore_tablets(arg, restore_resp))) {
+      LOG_WARN("failed to notify follower restore tablets", K(ret), K(arg), K(follower_info), K(ls_id), K(tablet_id_array));
+    } else {
+      FLOG_INFO("notify follower restore tablets successfully", K(arg), K(follower_info), K(ls_id), K(tablet_id_array));
+    }
+  }
+  return ret;
+}
 
-// Legacy shared-storage migrate-warmup ObStorageRpc wrapper impls removed
-// (get_ls_micro_block_cache_info / get_ls_migration_cache_job_info /
-//  get_micro_block_key_set) — replaced by gRPC.
+int ObStorageRpc::inquire_restore(
+    const uint64_t tenant_id,
+    const ObStorageHASrcInfo &src_info,
+    const share::ObLSID &ls_id,
+    const share::ObLSRestoreStatus &restore_status,
+    obrpc::ObInquireRestoreResp &restore_resp)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    STORAGE_LOG(WARN, "storage rpc is not inited", K(ret));
+  } else if (!src_info.is_valid() || !ls_id.is_valid()) {
+    ret = OB_INVALID_ARGUMENT;
+    STORAGE_LOG(WARN, "inquire restore get invalid argument", K(ret), K(src_info), K(ls_id));
+  } else {
+    ObInquireRestoreArg arg;
+    arg.tenant_id_ = tenant_id;
+    arg.ls_id_ = ls_id;
+    arg.restore_status_ = restore_status;
+    if (OB_FAIL(rpc_proxy_->to(src_info.src_addr_).dst_cluster_id(src_info.cluster_id_)
+        .by(tenant_id)
+        .group_id(share::OBCG_STORAGE)
+        .inquire_restore(arg, restore_resp))) {
+      LOG_WARN("failed to inquire restore", K(ret), K(arg), K(src_info));
+    } else {
+      FLOG_INFO("inquire restore status successfully", K(arg), K(src_info));
+    }
+  }
+  return ret;
+}
+
+int ObStorageRpc::update_ls_meta(
+    const uint64_t tenant_id,
+    const ObStorageHASrcInfo &dest_info,
+    const storage::ObLSMetaPackage &ls_meta)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    STORAGE_LOG(WARN, "storage rpc is not inited", K(ret));
+  } else if (!dest_info.is_valid() || !ls_meta.is_valid()) {
+    ret = OB_INVALID_ARGUMENT;
+    STORAGE_LOG(WARN, "invalid argument", K(ret), K(dest_info), K(ls_meta));
+  } else {
+    ObRestoreUpdateLSMetaArg arg;
+    arg.tenant_id_ = tenant_id;
+    arg.ls_meta_package_ = ls_meta;
+    if (OB_FAIL(rpc_proxy_->to(dest_info.src_addr_).dst_cluster_id(dest_info.cluster_id_)
+        .by(tenant_id)
+        .group_id(share::OBCG_STORAGE)
+        .update_ls_meta(arg))) {
+      LOG_WARN("failed to update ls meta", K(ret), K(dest_info), K(ls_meta));
+    } else {
+      FLOG_INFO("update ls meta succ", K(dest_info), K(ls_meta));
+    }
+  }
+
+  return ret;
+}
+
+#ifdef OB_BUILD_SHARED_STORAGE
+int ObStorageRpc::get_ls_micro_block_cache_info(
+    const uint64_t tenant_id,
+    const share::ObLSID &ls_id,
+    const ObStorageHASrcInfo &src_info,
+    ObSSLSCacheInfo &ls_cache_info)
+{
+  int ret = OB_SUCCESS;
+  obrpc::ObGetMicroBlockCacheInfoArg arg;
+  obrpc::ObGetMicroBlockCacheInfoRes res;
+  ls_cache_info.reset();
+
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    STORAGE_LOG(WARN, "storage rpc is not inited", K(ret));
+  } else if (OB_INVALID_ID == tenant_id || !ls_id.is_valid() || !src_info.is_valid()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid argument!", K(ret), K(tenant_id), K(ls_id), K(src_info));
+  } else {
+    arg.tenant_id_ = tenant_id;
+    arg.ls_id_ = ls_id;
+    if (OB_FAIL(rpc_proxy_->to(src_info.src_addr_).dst_cluster_id(src_info.cluster_id_)
+        .by(tenant_id)
+        .group_id(share::OBCG_STORAGE)
+        .get_micro_block_cache_info(arg, res))) {
+      LOG_WARN("fail to get micro block cache info", K(ret), K(tenant_id), K(ls_id), K(src_info));
+    } else {
+      ls_cache_info = res.ls_cache_info_;
+    }
+  }
+  return ret;
+}
+
+int ObStorageRpc::get_ls_migration_cache_job_info(
+    const uint64_t tenant_id,
+    const share::ObLSID &ls_id,
+    const ObStorageHASrcInfo &src_info,
+    const int64_t task_count,
+    obrpc::ObGetMigrationCacheJobInfoRes &res)
+{
+  int ret = OB_SUCCESS;
+  res.reset();
+  obrpc::ObGetMigrationCacheJobInfoArg arg;
+
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    STORAGE_LOG(WARN, "storage rpc is not inited", K(ret));
+  } else if (OB_INVALID_ID == tenant_id || !ls_id.is_valid() || !src_info.is_valid() || task_count <= 0) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid argument", K(ret), K(tenant_id), K(ls_id), K(src_info), K(task_count));
+  } else {
+    arg.tenant_id_ = tenant_id;
+    arg.ls_id_ = ls_id;
+    arg.task_count_ = task_count;
+    if (OB_FAIL(rpc_proxy_->to(src_info.src_addr_).dst_cluster_id(src_info.cluster_id_)
+        .by(tenant_id)
+        .group_id(share::OBCG_STORAGE)
+        .get_migration_cache_job_info(arg, res))) {
+      LOG_WARN("fail to get migration cache job info", K(ret), K(tenant_id), K(ls_id), K(src_info));
+    }
+  }
+  return ret;
+}
+
+int ObStorageRpc::get_micro_block_key_set(
+    const uint64_t tenant_id,
+    const share::ObLSID &ls_id,
+    const ObStorageHASrcInfo &src_info,
+    const ObMigrationCacheJobInfo &job_info,
+    obrpc::ObCopyMicroBlockKeySetRes &res)
+{
+  int ret = OB_SUCCESS;
+  res.reset();
+  obrpc::ObGetMicroBlockKeyArg arg;
+
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    STORAGE_LOG(WARN, "storage rpc is not inited", K(ret));
+  } else if (OB_INVALID_ID == tenant_id || !ls_id.is_valid() || !src_info.is_valid() || !job_info.is_valid()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid argument", K(ret), K(tenant_id), K(ls_id), K(src_info), K(job_info));
+  } else {
+    arg.tenant_id_ = tenant_id;
+    arg.ls_id_ = ls_id;
+    arg.job_info_ = job_info;
+    if (OB_FAIL(rpc_proxy_->to(src_info.src_addr_).dst_cluster_id(src_info.cluster_id_)
+        .by(tenant_id)
+        .group_id(share::OBCG_STORAGE)
+        .fetch_micro_block_keys(arg, res))) {
+      LOG_WARN("fail to fetch micro block keys", K(ret), K(tenant_id), K(ls_id), K(src_info));
+    }
+  }
+  return ret;
+}
+#endif
 } // storage
 } // oceanbase

--- a/src/storage/tablelock/ob_table_lock_service.cpp
+++ b/src/storage/tablelock/ob_table_lock_service.cpp
@@ -16,7 +16,6 @@
 
 #define USING_LOG_PREFIX TABLELOCK
 #include "storage/tablelock/ob_table_lock_service.h"
-#include "storage/tablelock/ob_table_lock_local_executor.h"
 
 #include "storage/tx/ob_trans_service.h"
 #include "storage/tablelock/ob_lock_utils.h" // ObInnerTableLockUtil
@@ -1376,8 +1375,9 @@ int ObTableLockService::batch_pre_check_lock_(ObTableLockCtx &ctx,
   int last_ret = OB_SUCCESS;
   int64_t USLEEP_TIME = 100; // 0.1 ms
   bool need_retry = false;
-  observer::ObLocalBatchLockProxy<ObLockTaskBatchRequest<ObLockParam>> proxy_batch(
-      observer::handle_batch_lock_task);
+  obrpc::ObSrvRpcProxy rpc_proxy(*GCTX.srv_rpc_proxy_);
+  rpc_proxy.set_detect_session_killed(true);
+  ObBatchLockProxy proxy_batch(rpc_proxy, &obrpc::ObSrvRpcProxy::batch_lock_obj);
   // only used in LOCK_TABLE/LOCK_PARTITION
   if (LOCK_TABLE == ctx.task_type_ ||
       LOCK_PARTITION == ctx.task_type_) {
@@ -1659,7 +1659,7 @@ int ObTableLockService::pack_and_call_rpc_(RpcProxy &proxy_batch,
 }
 
 template <>
-int ObTableLockService::pack_and_call_rpc_(observer::ObLocalBatchLockProxy<ObLockTaskBatchRequest<ObReplaceLockParam>> &proxy_batch,
+int ObTableLockService::pack_and_call_rpc_(obrpc::ObBatchReplaceLockProxy &proxy_batch,
                                            ObTableLockCtx &ctx,
                                            const share::ObLSID &ls_id,
                                            const ObLockIDArray &lock_ids,
@@ -1765,17 +1765,16 @@ int ObTableLockService::inner_process_obj_lock_batch_(ObTableLockCtx &ctx,
                                                       const ObLSLockMap &lock_map)
 {
   int ret = OB_SUCCESS;
+  obrpc::ObSrvRpcProxy rpc_proxy(*GCTX.srv_rpc_proxy_);
+  rpc_proxy.set_detect_session_killed(true);
   if (ctx.is_unlock_task()) {
-    observer::ObLocalBatchLockProxy<ObLockTaskBatchRequest<ObLockParam>> proxy_batch(
-        observer::handle_high_priority_batch_lock_task);
+    ObHighPriorityBatchLockProxy proxy_batch(rpc_proxy, &obrpc::ObSrvRpcProxy::batch_unlock_obj);
     ret = batch_rpc_handle_(proxy_batch, ctx, lock_map);
   } else if (ctx.is_replace_task()) {
-    observer::ObLocalBatchLockProxy<ObLockTaskBatchRequest<ObReplaceLockParam>> proxy_batch(
-        observer::handle_batch_replace_lock_task);
+    ObBatchReplaceLockProxy  proxy_batch(rpc_proxy, &obrpc::ObSrvRpcProxy::batch_replace_lock_obj);
     ret = batch_rpc_handle_(proxy_batch, ctx, lock_map);
   } else {
-    observer::ObLocalBatchLockProxy<ObLockTaskBatchRequest<ObLockParam>> proxy_batch(
-        observer::handle_batch_lock_task);
+    ObBatchLockProxy proxy_batch(rpc_proxy, &obrpc::ObSrvRpcProxy::batch_lock_obj);
     ret = batch_rpc_handle_(proxy_batch, ctx, lock_map);
   }
   return ret;

--- a/src/storage/tx/ob_trans_service_v4.cpp
+++ b/src/storage/tx/ob_trans_service_v4.cpp
@@ -799,7 +799,7 @@ int ObTransService::handle_trans_keepalive(const ObTxKeepaliveMsg &msg, ObTransR
   return ret;
 }
 
-int ObTransService::handle_trans_keepalive_response(const ObTxKeepaliveRespMsg &msg, obcall::ObTransRpcResult &result)
+int ObTransService::handle_trans_keepalive_response(const ObTxKeepaliveRespMsg &msg, obrpc::ObTransRpcResult &result)
 {
   int ret = OB_SUCCESS;
   ObPartTransCtx *ctx = NULL;
@@ -1875,7 +1875,7 @@ int ObTransService::handle_trans_abort_request(ObTxAbortMsg &abort_req, ObTransR
 }
 
 int ObTransService::handle_sp_rollback_request(ObTxRollbackSPMsg &msg,
-                                               obcall::ObTxRpcRollbackSPResult &result)
+                                               obrpc::ObTxRpcRollbackSPResult &result)
 {
   int ret = OB_SUCCESS;
   int64_t ctx_born_epoch = -1;
@@ -1929,7 +1929,7 @@ int ObTransService::handle_sp_rollback_request(ObTxRollbackSPMsg &msg,
 }
 
 int ObTransService::handle_sp_rollback_response(ObTxRollbackSPRespMsg &msg,
-                                                obcall::ObTransRpcResult &result)
+                                                obrpc::ObTransRpcResult &result)
 {
   int ret = OB_SUCCESS;
   ret = handle_sp_rollback_resp(msg.sender_,
@@ -3079,7 +3079,7 @@ int ObTransService::mds_infer_standby_trx_state(const ObLS *ls_ptr,
 }
 
 int ObTransService::handle_trans_ask_state(const ObAskStateMsg &msg,
-                                           obcall::ObTransRpcResult &result)
+                                           obrpc::ObTransRpcResult &result)
 {
   int ret = OB_SUCCESS;
 
@@ -3131,7 +3131,7 @@ void ObTransService::build_tx_ask_state_resp_(ObAskStateRespMsg &resp, const ObA
 }
 
 int ObTransService::handle_trans_ask_state_response(const ObAskStateRespMsg &msg,
-                                                    obcall::ObTransRpcResult &result)
+                                                    obrpc::ObTransRpcResult &result)
 {
   int ret = OB_NOT_SUPPORTED;
   TRANS_LOG(ERROR, "handle trans ask state resp state", K(ret), K(msg));
@@ -3139,7 +3139,7 @@ int ObTransService::handle_trans_ask_state_response(const ObAskStateRespMsg &msg
 }
 
 int ObTransService::handle_trans_collect_state(const ObCollectStateMsg &msg,
-                                               obcall::ObTransRpcResult &result)
+                                               obrpc::ObTransRpcResult &result)
 {
   int ret = OB_NOT_SUPPORTED;
   TRANS_LOG(INFO, "handle trans collect state", K(ret), K(msg));
@@ -3160,7 +3160,7 @@ void ObTransService::build_tx_collect_state_resp_(ObCollectStateRespMsg &resp, c
 }
 
 int ObTransService::handle_trans_collect_state_response(const ObCollectStateRespMsg &msg,
-                                                        obcall::ObTransRpcResult &result)
+                                                        obrpc::ObTransRpcResult &result)
 {
   int ret = OB_NOT_SUPPORTED;
   TRANS_LOG(INFO, "handle trans collect state", K(ret), K(msg));

--- a/unittest/storage/tx/it/tx_node.cpp
+++ b/unittest/storage/tx/it/tx_node.cpp
@@ -151,6 +151,7 @@ ObTxNode::ObTxNode(const int64_t ls_id,
                &get_location_adapter_(),
                &get_gti_source_(),
                &get_ts_mgr_(),
+               &rpc_proxy_,
                &schema_service_));
   tenant_.set(&txs_);
   OZ(fake_opt_stat_mgr_.init(tenant_id_));
@@ -481,7 +482,7 @@ int ObTxNode::handle_msg_(MsgPack *pkt)
   case ROLLBACK_SAVEPOINT:
     {
       ObTxRollbackSPMsg msg;
-      obcall::ObTxRpcRollbackSPResult rslt;
+      obrpc::ObTxRpcRollbackSPResult rslt;
       OZ(msg.deserialize(buf, size, pos));
       TRANS_LOG(TRACE, "handle_msg", K(msg), KPC(this));
       OZ(txs_.handle_sp_rollback_request(msg, rslt), msg);


### PR DESCRIPTION
## Task Description
github issue: https://github.com/oceanbase/seekdb/issues/867
Vector APPROXIMATE search fails with -4016 Internal error when the filter column has a prefix-length index.

## Solution Description
In the prefix index scenario, a filter containing a regular field (the `grp` field mentioned in the issue) was directly pushed down to the prefix index table. However, this field does not exist in the prefix index table, causing the plan generated by code generation to attempt to access a non-existent column during execution.
The solution is to remove the push-down filter when the column being pushed down to the index table does not exist. (In the current scenario, the `idx_grp` index will use a range scan instead of pushing down a filter to filter data.)

## Passed Regressions

## Upgrade Compatibility

## Other Information
- DIMA-2026060900116643089

## Release Note
