### PR TITLE
PL function has memory leak issue in long running SQL

### DIFF
--- a/src/pl/ob_pl.cpp
+++ b/src/pl/ob_pl.cpp
@@ -2992,17 +2992,10 @@ int ObPLExecState::add_pl_exec_time(int64_t pl_exec_time, bool is_called_from_sq
   return ret;
 }
 
-ObArenaAllocator *ObPLExecCtx::get_top_expr_allocator()
-{
-  return &expr_alloc_;
-}
-
 bool ObPLExecCtx::valid()
 {
   return OB_NOT_NULL(allocator_)
          && OB_NOT_NULL(exec_ctx_)
-         // The interface mapped in through the interface mechanism cannot provide or use the func_ pointer.
-//       && OB_NOT_NULL(func_)
          && OB_NOT_NULL(exec_ctx_->get_sql_ctx())
          && OB_NOT_NULL(exec_ctx_->get_my_session());
 }
@@ -3281,7 +3274,7 @@ int ObPLExecState::init_complex_obj(ObIAllocator &allocator,
       OZ (ns->get_user_type(composite->get_id(), user_type));
       CK (OB_NOT_NULL(user_type));
     } else {
-      ObPLResolveCtx ns(get_exec_ctx().expr_alloc_,
+      ObPLResolveCtx ns(*get_exec_ctx().get_top_expr_allocator(),
                       *session,
                       *schema_guard,
                       *package_guard,
@@ -3301,15 +3294,15 @@ int ObPLExecState::init_complex_obj(ObIAllocator &allocator,
       && OB_NOT_NULL(session->get_pl_context()->get_current_ctx())) {
     pl::ObPLINS *ns = session->get_pl_context()->get_current_ctx();
     CK (OB_NOT_NULL(ns));
-    OZ (ns->init_complex_obj(allocator, get_exec_ctx().expr_alloc_, *real_pl_type, obj, false, set_null));
+    OZ (ns->init_complex_obj(allocator, *get_exec_ctx().get_top_expr_allocator(), *real_pl_type, obj, false, set_null));
   } else {
-    ObPLResolveCtx ns(get_exec_ctx().expr_alloc_,
+    ObPLResolveCtx ns(*get_exec_ctx().get_top_expr_allocator(),
                       *session,
                       *schema_guard,
                       *package_guard,
                       *sql_proxy,
                       false);
-    OZ (ns.init_complex_obj(allocator, get_exec_ctx().expr_alloc_, *real_pl_type, obj, false, set_null));
+    OZ (ns.init_complex_obj(allocator, *get_exec_ctx().get_top_expr_allocator(), *real_pl_type, obj, false, set_null));
   }
   OX (obj.set_udt_id(real_pl_type->get_user_type_id()));
   return ret;
@@ -3928,10 +3921,14 @@ int ObPLExecState::init(const ParamStore *params, bool is_anonymous)
   }
 
   if (OB_SUCC(ret)) {
-    // TODO bin.lb: how about the memory?
-    //
-    OZ(func_.get_frame_info().pre_alloc_exec_memory(*ctx_.exec_ctx_, expr_alloc));
+    // Always realloc frame info:
+    // because in spi_calc_expr, frame dynamic memory may alloc by current routine, then frame info can not reuse.
+    // so here use get_top_expr_allocator() to alloc memory, frame memory will release by current routine finish.
+    OZ (func_.get_frame_info().pre_alloc_exec_memory(*ctx_.exec_ctx_, expr_alloc));
   }
+
+  // Use to Alloc expr ctx, all these expr ctx will destruct on final interface.
+  OX (ctx_.exec_ctx_->set_pl_expr_alloc(ctx_.get_top_expr_allocator()));
 
   // saved self ctx on stack, will used by spi_calc_subprogram_expr
   OX (self_exec_ctx_bak_.backup(*ctx_.exec_ctx_));

--- a/src/pl/ob_pl.h
+++ b/src/pl/ob_pl.h
@@ -661,14 +661,15 @@ struct ObPLExecCtx : public ObPLINS
               bool in_function = false,
               const common::ObIArray<int64_t> *nocopy_params = NULL,
               ObPLPackageGuard *guard = NULL) :
-    allocator_(allocator), exec_ctx_(exec_ctx), params_(params),
-    result_(result), status_(status), func_(func),
-    in_function_(in_function), pl_ctx_(NULL), nocopy_params_(nocopy_params), guard_(guard),
-    expr_alloc_("PlBlockExpr", OB_MALLOC_NORMAL_BLOCK_SIZE, MTL_ID()) {
-      if (NULL != exec_ctx && NULL != exec_ctx_->get_my_session()) {
-        pl_ctx_ = exec_ctx_->get_my_session()->get_pl_context();
-      }
+      allocator_(allocator), exec_ctx_(exec_ctx), params_(params),
+      result_(result), status_(status), func_(func),
+      in_function_(in_function), pl_ctx_(NULL), nocopy_params_(nocopy_params), guard_(guard),
+      local_expr_alloc_("PLBlockExpr", OB_MALLOC_NORMAL_BLOCK_SIZE, MTL_ID())
+  {
+    if (NULL != exec_ctx && NULL != exec_ctx_->get_my_session()) {
+      pl_ctx_ = exec_ctx_->get_my_session()->get_pl_context();
     }
+  }
 
   static uint32_t allocator_offset_bits() { return offsetof(ObPLExecCtx, allocator_) * 8; }
   static uint32_t exec_ctx_offset_bits() { return offsetof(ObPLExecCtx, exec_ctx_) * 8; }
@@ -678,11 +679,11 @@ struct ObPLExecCtx : public ObPLINS
 
   bool valid();
 
-  ObArenaAllocator *get_top_expr_allocator();
+  ObIAllocator *get_top_expr_allocator() { return &local_expr_alloc_; }
 
   virtual int get_user_type(uint64_t type_id,
-                                const ObUserDefinedType *&user_type,
-                                ObIAllocator *allocator = NULL) const;
+                            const ObUserDefinedType *&user_type,
+                            ObIAllocator *allocator = NULL) const;
   virtual int calc_expr(uint64_t package_id, int64_t expr_idx, ObObjParam &result);
   void set_is_sensitive(bool is_sensitive) const
   {
@@ -691,7 +692,7 @@ struct ObPLExecCtx : public ObPLINS
     }
   }
 
-  common::ObIAllocator *allocator_;
+  common::ObIAllocator *allocator_; // Symbol Allocator
   sql::ObExecContext *exec_ctx_;
   ParamStore *params_; // param store, corresponding to the symbol table of PL Function
   common::ObObj *result_;
@@ -701,13 +702,13 @@ struct ObPLExecCtx : public ObPLINS
   ObPLContext *pl_ctx_; // for error stack
   const common::ObIArray<int64_t> *nocopy_params_; // used to describe nocopy parameters
   ObPLPackageGuard *guard_; //corresponding package_guard for this execution
-  ObArenaAllocator expr_alloc_;
+  ObArenaAllocator local_expr_alloc_;
 };
 
 // backup and restore ObExecContext attributes
 struct ExecCtxBak
 {
-#define PL_EXEC_CTX_BAK_ATTRS phy_plan_ctx_,expr_op_ctx_store_,expr_op_size_,has_non_trivial_expr_op_ctx_,frames_,frame_cnt_
+#define PL_EXEC_CTX_BAK_ATTRS phy_plan_ctx_,expr_op_ctx_store_,expr_op_size_,has_non_trivial_expr_op_ctx_,frames_,frame_cnt_,pl_expr_allocator_
 
 #define DEF_BACKUP_ATTR(x) typeof(sql::ObExecContext::x) x = 0
   LST_DO_CODE(DEF_BACKUP_ATTR, EXPAND(PL_EXEC_CTX_BAK_ATTRS));
@@ -845,7 +846,6 @@ public:
                K_(pure_sql_exec_time),
                K_(pure_plsql_exec_time),
                K_(pure_sub_plsql_exec_time));
-private:
 private:
   ObPLFunction &func_;
   sql::ObPhysicalPlanCtx phy_plan_ctx_; //The runtime param values are stored here, corresponding one-to-one with variables_ in ObPLFunction, default values need to be set during initialization

--- a/src/pl/ob_pl_exception_handling.cpp
+++ b/src/pl/ob_pl_exception_handling.cpp
@@ -178,7 +178,7 @@ ObUnwindException *ObPLEH::eh_create_exception(int64_t pl_context,
     CK (pl_ctx->get_exec_stack().count() > 0);
     CK (OB_NOT_NULL(frame = pl_ctx->get_exec_stack().at(0)));
     CK (frame->is_top_call());
-    CK (OB_NOT_NULL(pl_allocator = &(frame->get_exec_ctx().expr_alloc_)));
+    CK (OB_NOT_NULL(pl_allocator = frame->get_exec_ctx().get_top_expr_allocator()));
     if (OB_FAIL(ret)) {
     } else if (OB_ALLOCATE_MEMORY_FAILED == value->error_code_) {
       unwind = &pre_reserved_e.body_;

--- a/src/sql/engine/expr/ob_expr_udf.cpp
+++ b/src/sql/engine/expr/ob_expr_udf.cpp
@@ -724,16 +724,15 @@ int ObExprUDF::cg_expr(ObExprCGCtx &expr_cg_ctx, const ObRawExpr &raw_expr, ObEx
   return ret;
 }
 
-int ObExprUDF::ObExprUDFCtx::init_param_store(ObIAllocator &allocator,
-                                              int param_num)
+int ObExprUDF::ObExprUDFCtx::init_param_store(int param_num)
 {
   int ret = OB_SUCCESS;
 
-  if (OB_ISNULL(param_store_buf_ = allocator.alloc(sizeof(ParamStore)))) {
+  if (OB_ISNULL(param_store_buf_ = ctx_allocator_.alloc(sizeof(ParamStore)))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("failed to allocate memory", K(ret));
   } else {
-    params_ = new(param_store_buf_)ParamStore(ObWrapperAllocator(allocator));
+    params_ = new(param_store_buf_)ParamStore(ObWrapperAllocator(ctx_allocator_));
   }
   OZ (params_->prepare_allocate(param_num));
   OX (params_->reuse());
@@ -750,7 +749,7 @@ int ObExprUDF::build_udf_ctx(int64_t udf_ctx_id,
   if (OB_ISNULL(udf_ctx = static_cast<ObExprUDFCtx *>(exec_ctx.get_expr_op_ctx(udf_ctx_id)))) {
     if (OB_FAIL(exec_ctx.create_expr_op_ctx(udf_ctx_id, udf_ctx))) {
       LOG_WARN("failed to create operator ctx", K(ret));
-    } else if (OB_FAIL(udf_ctx->init_param_store(exec_ctx.get_allocator(), param_num))) {
+    } else if (OB_FAIL(udf_ctx->init_param_store(param_num))) {
       LOG_WARN("failed to init param", K(ret));
     }
   } else {

--- a/src/sql/engine/expr/ob_expr_udf.h
+++ b/src/sql/engine/expr/ob_expr_udf.h
@@ -82,12 +82,12 @@ class ObExprUDF : public ObFuncExprOperator
     ObExprUDFCtx() :
     ObExprOperatorCtx(),
     param_store_buf_(nullptr),
-    params_(nullptr) {}
+    params_(nullptr),
+    ctx_allocator_("UDFCtxAlloc", OB_MALLOC_NORMAL_BLOCK_SIZE, MTL_ID()) {}
 
     ~ObExprUDFCtx() {}
 
-    int init_param_store(ObIAllocator &allocator,
-                         int param_num);
+    int init_param_store(int param_num);
     void reuse()
     {
       if (OB_NOT_NULL(params_)) {
@@ -101,6 +101,13 @@ class ObExprUDF : public ObFuncExprOperator
     private:
     void* param_store_buf_;
     ParamStore* params_;
+    // ctx-level allocator: the ParamStore is built once per udf_ctx lifetime and
+    // must NOT be allocated on exec_ctx.allocator_ (the outer SQL arena, freed only
+    // at query end). Because PL's reset_expr_op() wipes the cached udf_ctx on every
+    // PL call, build_udf_ctx() re-creates it and re-runs init_param_store() for each
+    // call; allocating on the outer arena would leak ~per-call within one long SQL.
+    // Using this member arena ties the ParamStore lifetime to the udf_ctx itself.
+    common::ObArenaAllocator ctx_allocator_;
   };
 
   OB_UNIS_VERSION(1);

--- a/src/sql/engine/ob_exec_context.cpp
+++ b/src/sql/engine/ob_exec_context.cpp
@@ -156,6 +156,7 @@ ObExecContext::ObExecContext(ObIAllocator &allocator)
     need_disconnect_(true),
     pl_ctx_(NULL),
     package_guard_(NULL),
+    pl_expr_allocator_(NULL),
     row_id_list_(nullptr),
     row_id_list_array_(),
     total_row_count_(0),
@@ -504,13 +505,14 @@ ObIAllocator &ObExecContext::get_allocator()
 int ObExecContext::create_expr_op_ctx(uint64_t op_id, int64_t op_ctx_size, void *&op_ctx)
 {
   int ret = OB_SUCCESS;
+  ObIAllocator &allocator = OB_NOT_NULL(pl_expr_allocator_) ? *pl_expr_allocator_ : allocator_;
   if (OB_UNLIKELY(op_id >= expr_op_size_ || op_ctx_size <= 0 || OB_ISNULL(expr_op_ctx_store_))) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument", K(ret), K(op_id), K(op_ctx_size), K(expr_op_ctx_store_));
   } else if (OB_UNLIKELY(NULL != get_expr_op_ctx(op_id))) {
     ret = OB_INIT_TWICE;
     LOG_WARN("expr operator context has been created", K(op_id));
-  } else if (OB_ISNULL(op_ctx = allocator_.alloc(op_ctx_size))) {
+  } else if (OB_ISNULL(op_ctx = allocator.alloc(op_ctx_size))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_ERROR("allocate memory failed", K(ret), K(op_id), K(op_ctx_size));
   } else {

--- a/src/sql/engine/ob_exec_context.h
+++ b/src/sql/engine/ob_exec_context.h
@@ -409,6 +409,8 @@ public:
   inline pl::ObPLPackageGuard* get_original_package_guard() { return package_guard_; }
   inline void set_package_guard(pl::ObPLPackageGuard* v) { package_guard_ = v; }
   int init_pl_ctx();
+  inline ObIAllocator* get_pl_expr_alloc() { return pl_expr_allocator_; }
+  inline void set_pl_expr_alloc(ObIAllocator *alloc) { pl_expr_allocator_ = alloc; }
 
   ObPartIdRowMapManager& get_part_row_manager() { return part_row_map_manager_; }
 
@@ -672,6 +674,7 @@ protected:
   //@todo: (linlin.xll) ObPLCtx is ambiguous with ObPLContext, need to rename it
   pl::ObPLCtx *pl_ctx_;
   pl::ObPLPackageGuard *package_guard_;
+  ObIAllocator *pl_expr_allocator_;
 
   ObPartIdRowMapManager part_row_map_manager_;
   const common::ObIArray<int64_t> *row_id_list_;

--- a/src/sql/ob_spi.cpp
+++ b/src/sql/ob_spi.cpp
@@ -1855,7 +1855,7 @@ int ObSPIService::spi_check_autonomous_trans(pl::ObPLExecCtx *ctx)
 int ObSPIService::spi_get_current_expr_allocator(pl::ObPLExecCtx *ctx, int64_t *addr)
 {
   int ret = OB_SUCCESS;
-  ObArenaAllocator *alloc = nullptr;
+  ObIAllocator *alloc = nullptr;
   CK (OB_NOT_NULL(ctx));
   CK (OB_NOT_NULL(addr));
   OX (*addr = 0);
@@ -1941,7 +1941,7 @@ int ObSPIService::spi_query(ObPLExecCtx *ctx,
                             bool for_update)
 {
   int ret = OB_SUCCESS;
-  OZ (SMART_CALL(spi_inner_execute(ctx, ctx->expr_alloc_, sql, "", type, NULL, 0,
+  OZ (SMART_CALL(spi_inner_execute(ctx, *ctx->get_top_expr_allocator(), sql, "", type, NULL, 0,
                         into_exprs, into_count,
                         column_types, type_count,
                         exprs_not_null_flag,
@@ -1999,7 +1999,7 @@ int ObSPIService::spi_execute(ObPLExecCtx *ctx,
                               bool for_update)
 {
   int ret = OB_SUCCESS;
-  OZ (SMART_CALL(spi_inner_execute(ctx, ctx->expr_alloc_, NULL, ps_sql, type, param_exprs, param_count,
+  OZ (SMART_CALL(spi_inner_execute(ctx, *ctx->get_top_expr_allocator(), NULL, ps_sql, type, param_exprs, param_count,
                         into_exprs, into_count, column_types, type_count,
                         exprs_not_null_flag, pl_integer_ranges, is_bulk,
                         is_forall, is_type_record, for_update)));
@@ -2766,7 +2766,7 @@ int ObSPIService::spi_execute_immediate(ObPLExecCtx *ctx,
     OX (implicit_cursor->set_rowcount(0));
   } else {
     OZ (SMART_CALL(spi_inner_execute(ctx,
-                                     ctx->expr_alloc_,
+                                     *ctx->get_top_expr_allocator(),
                                      sql_str.ptr(),
                                      ps_sql.ptr(),
                                      stmt_type,
@@ -2836,7 +2836,7 @@ int ObSPIService::spi_cursor_init(ObPLExecCtx *ctx, int64_t cursor_index)
       }
     } else {
       if (obj.is_null()) {
-        OZ (spi_cursor_alloc(ctx->expr_alloc_, obj));
+        OZ (spi_cursor_alloc(*ctx->get_top_expr_allocator(), obj));
         //OZ (spi_cursor_alloc(ctx->exec_ctx_->get_allocator(), obj));
       } else {
         CK (obj.is_pl_extend());
@@ -2972,7 +2972,7 @@ int ObSPIService::cursor_open_check(ObPLExecCtx *ctx,
         OX (obj.set_param_meta());
       } else {
         CK (OB_NOT_NULL(ctx->allocator_));
-        OZ (spi_cursor_alloc(ctx->expr_alloc_, obj));
+        OZ (spi_cursor_alloc(*ctx->get_top_expr_allocator(), obj));
         OX (obj.set_extend(obj.get_ext(), PL_REF_CURSOR_TYPE));
         OX (cursor = reinterpret_cast<ObPLCursorInfo*>(obj.get_ext()));
       }
@@ -4800,19 +4800,19 @@ int ObSPIService::spi_interface_impl(pl::ObPLExecCtx *ctx, const char *interface
     ObString name(interface_name);
     PL_C_INTERFACE_t fp = GCTX.pl_engine_->get_interface_service().get_entry(name);
     if (nullptr != fp) {
-      ParamStore exec_params( (ObWrapperAllocator(ctx->expr_alloc_)) );
+      ParamStore exec_params( (ObWrapperAllocator(*ctx->get_top_expr_allocator())) );
       for (int64_t i = 0; OB_SUCC(ret) && i < ctx->params_->count(); ++i) {
         ObObjParam new_param = ctx->params_->at(i);
         if (ctx->params_->at(i).is_pl_extend()) {
           // do nothing
         } else if (ctx->params_->at(i).need_deep_copy()) {
-          OZ (deep_copy_obj(ctx->expr_alloc_, ctx->params_->at(i), new_param));
+          OZ (deep_copy_obj(*ctx->get_top_expr_allocator(), ctx->params_->at(i), new_param));
         }
         OZ (exec_params.push_back(new_param));
       }
       if (OB_SUCC(ret)) {
         ObIAllocator *old = ctx->allocator_;
-        ctx->allocator_ = &ctx->expr_alloc_;
+        ctx->allocator_ = ctx->get_top_expr_allocator();
         ObObj tmp_result(ObMaxType);
         ret = fp(*ctx, exec_params, tmp_result);
         ctx->allocator_ = old;
@@ -6822,7 +6822,7 @@ int ObSPIService::store_result(ObPLExecCtx *ctx,
                     int64_t init_size = OB_INVALID_SIZE;
                     OZ (ctx->get_user_type(into_record_type->get_record_member_type(k)->get_user_type_id(), type));
                     CK (OB_NOT_NULL(type));
-                    OZ (type->newx(ctx->expr_alloc_, ctx, ptr));
+                    OZ (type->newx(*ctx->get_top_expr_allocator(), ctx, ptr));
                     OZ (type->get_size(PL_TYPE_INIT_SIZE, init_size));
                     OX (obj_array.at(idx).set_extend(ptr, type->get_type(), init_size));
                   }


### PR DESCRIPTION
## Task Description
In long-running SQL statements, frequent calls to PL functions pose a risk of memory leaks.

## Solution Description
1.  **Primary Fix for PL Function Memory Leak:**
    Previously, each call to a PL function could allocate a block of memory using the executor context's allocator. This allocator is an arena allocator, meaning the memory is only freed after the entire SQL statement finishes execution. For SQL statements running for several hours, the memory allocated by PL functions could become substantial.
    The fix changes the allocation to use a temporary allocator specific to the PL function. This memory is released immediately upon completion of each PL function execution.

2.  **Secondary Fix for UDF ParamStore Leak (commit 236ec59):**
    **Symptom:** Similar to the PL `expr_op_ctx` leak, when UDF/PL functions are called repeatedly within a long SQL statement, the `mod=SqlExecutor` memory grows linearly with the number of calls and is only released when the entire SQL statement ends.
    **Root Cause:** `ObExprUDF::ObExprUDFCtx::init_param_store` allocated the UDF's ParamStore (approx. 256B per call) on `exec_ctx.get_allocator()` (the outer SQL's arena). The `build_udf_ctx` function intended to cache the `udf_ctx` via `expr_op_ctx_store_` for reuse. However, the `reset_expr_op` call within the PL function's `final` logic clears this store, causing the cache to be ineffective. This forced a re-initialization of `init_param_store` on every call, leading to repeated allocations on the outer arena that were not freed until SQL completion.
    **Fix:** Added a dedicated `ObArenaAllocator ctx_allocator_` member to `ObExprUDFCtx`. The ParamStore is now allocated on this allocator, binding its lifecycle to the `udf_ctx` itself (freed upon `udf_ctx` destruction) and decoupling it from the outer SQL arena. Since this allocator is a per-instance member, it works correctly for nested/recursive UDFs without requiring backup/restore logic.
    **Changes:** Modified `src/sql/engine/expr/ob_expr_udf.{h,cpp}`, totaling 3 locations and 14 lines added.
    **Verification:** Reproduced locally (`select sum(f_leak(v)) from <large_table>`, with millions of PL calls within a single SQL). Before the fix, `SqlExecutor` memory grew from 16MB to 104MB within 50 seconds. After the fix, memory remained constant at ~2MB (count unchanged) throughout, correctly returned to zero after query completion, and results were correct.

## Passed Regressions

## Upgrade Compatibility

## Other Information
- Related internal link: DIMA-2026042900115822534

## Release Note
Fixed memory leaks in PL functions and UDFs during long-running SQL statements by ensuring temporary memory allocations are freed promptly after each function call, rather than accumulating until the SQL statement finishes.