### PR TITLE
fix(timezone): add UTC fast path in str_to_offset to fix error 1298 on Windows

### DIFF
--- a/deps/oblib/src/lib/timezone/ob_time_convert.cpp
+++ b/deps/oblib/src/lib/timezone/ob_time_convert.cpp
@@ -1712,6 +1712,10 @@ int ObTimeConverter::str_to_offset(const ObString &str, int32_t &value, int &ret
     // fast path for +8:00 (which is the default value), its offset value is 28800
     // TODO: when OceanBase is internationalized, we could make more fastpath for timezone
     value = 28800;
+  } else if (0 == tmp_str.case_compare("UTC")) {
+    // fast path for UTC, which has offset 0 with no DST transitions.
+    // This avoids dependency on timezone system tables being populated.
+    value = 0;
   } else if (OB_ISNULL(tmp_str.ptr()) || OB_UNLIKELY(tmp_str.length() <= 0)) {
     ret = OB_ERR_UNKNOWN_TIME_ZONE;
     LOG_WARN("invalid time zone offset", K(ret), K(str), K(tmp_str));


### PR DESCRIPTION
## Task Description
Fix the issue where executing `SET @@session.time_zone='UTC'` on Windows returns `ER_UNKNOWN_TIME_ZONE (1298)` when the timezone system table data is not loaded or is incomplete.

## Solution Description
The root cause is that `str_to_offset` correctly identifies 'UTC' as a non-offset format and returns `OB_ERR_UNKNOWN_TIME_ZONE`. Subsequently, `find_pos_time_zone` attempts to look up 'UTC' as a timezone name, which fails because the timezone system data is not loaded.

The fix adds a fast path for 'UTC' within the `str_to_offset` function, treating 'UTC' as an offset of 0 (equivalent to '+00:00'). UTC is a fixed timezone without DST transitions, so its offset is always 0. This fast path does not depend on the timezone system table data.

## Passed Regressions

## Upgrade Compatibility

## Other Information
DIMA: 2026042200115621510

## Release Note
