### PR TITLE
Add idle eviction to plan cache

### DIFF
--- a/deps/oblib/src/lib/hash/ob_hashmap.h
+++ b/deps/oblib/src/lib/hash/ob_hashmap.h
@@ -293,6 +293,13 @@ public:
   {
     return ht_.foreach_refactored(callback);
   }
+  template<class _callback>
+  int foreach_refactored_range(_callback &callback,
+                               const int64_t start_bucket,
+                               const int64_t end_bucket) const
+  {
+    return ht_.foreach_refactored_range(callback, start_bucket, end_bucket);
+  }
   int erase_refactored(const _key_type &key, _value_type *value = NULL)
   {
     int ret = OB_SUCCESS;

--- a/deps/oblib/src/lib/hash/ob_hashtable.h
+++ b/deps/oblib/src/lib/hash/ob_hashtable.h
@@ -1526,6 +1526,9 @@ public:
       const int64_t real_end = MAX(0, MIN(end_bucket, bucket_num_));
       for (int64_t i = real_start; OB_SUCC(ret) && i < real_end; i++) {
         hashbucket &bucket = buckets_[i];
+        if (NULL == bucket.node) {
+          continue;
+        }
         bucket_lock_cond blc(bucket);
         readlocker locker(blc.lock());
         hashnode *node = bucket.node;

--- a/deps/oblib/src/lib/hash/ob_hashtable.h
+++ b/deps/oblib/src/lib/hash/ob_hashtable.h
@@ -1492,18 +1492,6 @@ public:
     } else {
       for (int64_t i = 0; OB_SUCC(ret) && i < bucket_num_; i++) {
         hashbucket &bucket = buckets_[i];
-        // Dirty-read bucket.node before acquiring rdlock: empty buckets are skipped
-        // without any locking overhead. The final check is done under the lock below.
-        // This is safe because:
-        //  - a bucket that appears empty but becomes non-empty concurrently is just a
-        //    missed iteration, which foreach_refactored (a non-snapshot scan) already
-        //    tolerates for concurrent inserts on already-scanned buckets.
-        //  - on x86-64 the aligned pointer load is hardware-atomic.
-        // The same dirty-read pattern is used by iterator::operator++, begin() and
-        // destroy() elsewhere in this file.
-        if (NULL == bucket.node) {
-          continue;
-        }
         bucket_lock_cond blc(bucket);
         readlocker locker(blc.lock());
         hashnode *node = bucket.node;
@@ -1511,6 +1499,40 @@ public:
           abort_unless(node->check_magic_code());
           if (OB_FAIL(callback(node->data))) {
             HASH_WRITE_LOG(HASH_WARNING, "fail to do call back, ret=%d", ret);
+          } else {
+            node = node->next;
+          }
+        }
+      }
+    }
+    return ret;
+  }
+
+  // iterate buckets in range [start_bucket, end_bucket) with per-bucket read lock
+  // callback returns OB_SUCCESS to continue, other to stop
+  template<class _callback>
+  int foreach_refactored_range(_callback &callback,
+                               const int64_t start_bucket,
+                               const int64_t end_bucket) const
+  {
+    int ret = OB_SUCCESS;
+    static_assert(std::is_same<decltype(callback(*(_value_type*)0)), int>::value,
+        "hash table foreach callback format error");
+    if (OB_UNLIKELY(!inited(buckets_)) || OB_UNLIKELY(NULL == allocer_)) {
+      HASH_WRITE_LOG(HASH_WARNING, "hashtable not init");
+      ret = OB_NOT_INIT;
+    } else {
+      const int64_t real_start = MAX(0, MIN(start_bucket, bucket_num_));
+      const int64_t real_end = MAX(0, MIN(end_bucket, bucket_num_));
+      for (int64_t i = real_start; OB_SUCC(ret) && i < real_end; i++) {
+        hashbucket &bucket = buckets_[i];
+        bucket_lock_cond blc(bucket);
+        readlocker locker(blc.lock());
+        hashnode *node = bucket.node;
+        while (OB_SUCC(ret) && NULL != node) {
+          abort_unless(node->check_magic_code());
+          if (OB_FAIL(callback(node->data))) {
+            // callback returned non-success, stop iteration
           } else {
             node = node->next;
           }

--- a/src/sql/plan_cache/ob_i_lib_cache_node.cpp
+++ b/src/sql/plan_cache/ob_i_lib_cache_node.cpp
@@ -184,6 +184,23 @@ int64_t ObILibCacheNode::get_mem_size()
   return total_mem_size;
 }
 
+int64_t ObILibCacheNode::get_cache_obj_mem_size()
+{
+  int ret = OB_SUCCESS;
+  int64_t total_mem_size = 0;
+  SpinRLockGuard lock_guard(co_list_lock_);
+  CacheObjList::iterator iter = co_list_.begin();
+  for (; OB_SUCC(ret) && iter != co_list_.end(); iter++) {
+    ObILibCacheObject *obj = *iter;
+    if (OB_ISNULL(obj)) {
+      BACKTRACE(ERROR, true, "invalid cache obj");
+    } else {
+      total_mem_size += obj->get_mem_size();
+    }
+  }
+  return total_mem_size;
+}
+
 int64_t ObILibCacheNode::inc_ref_count(const CacheRefHandleID ref_handle)
 {
   int ret = OB_SUCCESS;
@@ -219,7 +236,7 @@ int64_t ObILibCacheNode::dec_ref_count(const CacheRefHandleID ref_handle)
       LOG_ERROR("invalid null lib cache");
     } else {
       ObLCNodeFactory &ln_factory = lib_cache_->get_cache_node_factory();
-      lib_cache_->dec_mem_used(get_mem_size());
+      lib_cache_->dec_mem_used(get_added_mem_size());
       ln_factory.destroy_cache_node(this);
     }
   } else {

--- a/src/sql/plan_cache/ob_i_lib_cache_node.h
+++ b/src/sql/plan_cache/ob_i_lib_cache_node.h
@@ -109,7 +109,8 @@ public:
       lib_cache_(lib_cache),
       co_list_lock_(common::ObLatchIds::PLAN_SET_LOCK),
       co_list_(allocator_),
-      is_invalid_(false)
+      is_invalid_(false),
+      added_mem_size_(0)
   {
     lock_timeout_ts_ = GCONF.large_query_threshold;
   }
@@ -164,6 +165,9 @@ public:
   common::ObIAllocator &get_allocator_ref() { return allocator_; }
   lib::MemoryContext &get_mem_context() { return mem_context_; }
   int64_t get_mem_size();
+  int64_t get_cache_obj_mem_size();
+  int64_t get_added_mem_size() const { return ATOMIC_LOAD(&added_mem_size_); }
+  void inc_added_mem_size(int64_t delta) { ATOMIC_FAA(&added_mem_size_, delta); }
   ObPlanCache *get_lib_cache() const { return lib_cache_; }
   bool is_invalid() const { return is_invalid_; }
 
@@ -218,6 +222,7 @@ protected:
   common::SpinRWLock co_list_lock_;
   CacheObjList co_list_;
   bool is_invalid_;
+  int64_t added_mem_size_;
 };
 
 } // namespace common

--- a/src/sql/plan_cache/ob_plan_cache.cpp
+++ b/src/sql/plan_cache/ob_plan_cache.cpp
@@ -186,9 +186,14 @@ struct ObNodeStatFilterOp : public ObKVEntryTraverseOp
 {
   ObNodeStatFilterOp(int64_t evict_num,
                      LCKeyValueArray *key_val_list,
-                     const CacheRefHandleID ref_handle)
+                     const CacheRefHandleID ref_handle,
+                     int64_t idle_threshold_us = 0,
+                     LCKeyValueArray *idle_list = NULL)
     : ObKVEntryTraverseOp(key_val_list, ref_handle),
-      evict_num_(evict_num)
+      evict_num_(evict_num),
+      idle_threshold_us_(idle_threshold_us),
+      idle_list_(idle_list),
+      now_(common::ObTimeUtility::current_time())
   {
   }
   virtual int operator()(LibCacheKVEntry &entry)
@@ -199,6 +204,22 @@ struct ObNodeStatFilterOp : public ObKVEntryTraverseOp
       SQL_PC_LOG(WARN, "invalid argument",
       K(key_value_list_), K(entry.first), K(entry.second), K(ret));
     } else {
+      // collect idle-expired nodes if configured
+      if (idle_threshold_us_ > 0 && OB_NOT_NULL(idle_list_)) {
+        const StmtStat *stat = entry.second->get_node_stat();
+        if (OB_NOT_NULL(stat) &&
+            stat->last_active_timestamp_ > 0 &&
+            now_ - stat->last_active_timestamp_ > idle_threshold_us_) {
+          ObLCKeyValue idle_kv(entry.first, entry.second);
+          if (OB_FAIL(idle_list_->push_back(idle_kv))) {
+            SQL_PC_LOG(WARN, "fail to push into idle_list", K(ret));
+          } else {
+            idle_kv.node_->inc_ref_count(ref_handle_);
+          }
+          return ret;
+        }
+      }
+
       ObLCKeyValue lc_kv(entry.first, entry.second);
       if (key_value_list_->count() < evict_num_) {
         if (OB_FAIL(key_value_list_->push_back(lc_kv))) {
@@ -234,6 +255,9 @@ struct ObNodeStatFilterOp : public ObKVEntryTraverseOp
   }
 
   int64_t evict_num_;
+  int64_t idle_threshold_us_;
+  LCKeyValueArray *idle_list_;
+  int64_t now_;
 };
 
 struct ObIdleEvictOp
@@ -292,7 +316,8 @@ ObPlanCache::ObPlanCache()
    pcm_(NULL),
    destroy_(0),
    tg_id_(-1),
-   idle_scan_cursor_(0)
+   idle_scan_cursor_(0),
+   idle_evict_done_round_(false)
 {
 }
 
@@ -1131,6 +1156,7 @@ int ObPlanCache::add_cache_obj(ObILibCacheCtx &ctx,
             cache_node->dec_ref_count(LC_NODE_HANDLE); //cache node dec ref in alloc
           }
         } else {
+          cache_node->inc_added_mem_size(cache_obj->get_mem_size());
           cache_node->unlock();
           cache_node->dec_ref_count(LC_NODE_HANDLE); //cache node dec ref in block
         }
@@ -1155,6 +1181,8 @@ int ObPlanCache::add_cache_obj(ObILibCacheCtx &ctx,
       SQL_PC_LOG(WARN, "failed to update node stat", K(ret));
     } else if (OB_FAIL(add_stat_for_cache_obj(ctx, cache_obj))) {
       LOG_WARN("failed to add stat", K(ret), K(ctx));
+    } else {
+      cache_node->inc_added_mem_size(cache_obj->get_mem_size());
     }
     if (OB_FAIL(ret)) {
       if (!ctx.need_destroy_node_ && ret != OB_SQL_PC_PLAN_DUPLICATE) {
@@ -1369,10 +1397,29 @@ int ObPlanCache::cache_evict()
   if (get_mem_hold() > get_mem_high()) {
     if (calc_evict_num(cache_evict_num) && cache_evict_num > 0) {
       LCKeyValueArray to_evict_keys;
-      ObNodeStatFilterOp filter(cache_evict_num, &to_evict_keys, PCV_EXPIRE_BY_MEM_HANDLE);
+      LCKeyValueArray idle_evict_keys;
+      const int64_t idle_threshold_us = IDLE_EVICT_THRESHOLD_US;
+      ObNodeStatFilterOp filter(cache_evict_num, &to_evict_keys, PCV_EXPIRE_BY_MEM_HANDLE,
+                                idle_threshold_us, &idle_evict_keys);
       if (OB_FAIL(foreach_cache_evict(filter))) {
         SQL_PC_LOG(WARN, "failed to foreach cache evict", K(ret));
       }
+      // also evict idle-expired nodes collected during the same scan
+      if (OB_SUCC(ret) && idle_evict_keys.count() > 0) {
+        SQL_PC_LOG(INFO, "idle eviction during memory evict",
+                   K_(tenant_id), "idle_evict_count", idle_evict_keys.count());
+        if (OB_FAIL(batch_remove_cache_node(idle_evict_keys))) {
+          SQL_PC_LOG(WARN, "failed to remove idle cache nodes", K(ret));
+        }
+        for (int64_t i = 0; i < idle_evict_keys.count(); i++) {
+          if (OB_NOT_NULL(idle_evict_keys.at(i).node_)) {
+            idle_evict_keys.at(i).node_->dec_ref_count(PCV_EXPIRE_BY_MEM_HANDLE);
+          }
+        }
+      }
+      // full scan done, reset idle cursor so cache_evict_by_idle can skip
+      idle_scan_cursor_ = 0;
+      idle_evict_done_round_ = true;
     }
   }
   SQL_PC_LOG(INFO, "end lib cache evict",
@@ -2526,7 +2573,10 @@ void ObPlanCacheEliminationTask::run_plan_cache_task()
   }  else if (OB_FAIL(plan_cache_->cache_evict_by_glitch_node())) {
     SQL_PC_LOG(ERROR, "Plan cache evict by glitch failed, please check", K(ret));
   }
-  if (OB_FAIL(plan_cache_->cache_evict_by_idle())) {
+  // skip idle eviction if cache_evict() already did a full scan with idle collection
+  if (plan_cache_->idle_evict_done_round_) {
+    plan_cache_->idle_evict_done_round_ = false;
+  } else if (OB_FAIL(plan_cache_->cache_evict_by_idle())) {
     SQL_PC_LOG(WARN, "Plan cache idle evict failed", K(ret));
   }
 }

--- a/src/sql/plan_cache/ob_plan_cache.cpp
+++ b/src/sql/plan_cache/ob_plan_cache.cpp
@@ -236,6 +236,49 @@ struct ObNodeStatFilterOp : public ObKVEntryTraverseOp
   int64_t evict_num_;
 };
 
+struct ObIdleEvictOp
+{
+  typedef common::hash::HashMapPair<ObILibCacheKey *, ObILibCacheNode *> LibCacheKVEntry;
+  int64_t now_;
+  int64_t idle_threshold_us_;
+  int64_t scanned_nodes_;
+  int64_t max_scan_nodes_;
+  LCKeyValueArray *to_evict_;
+  const CacheRefHandleID ref_handle_;
+
+  ObIdleEvictOp(int64_t now, int64_t idle_threshold_us,
+                int64_t max_scan_nodes, LCKeyValueArray *to_evict)
+    : now_(now), idle_threshold_us_(idle_threshold_us), scanned_nodes_(0),
+      max_scan_nodes_(max_scan_nodes), to_evict_(to_evict),
+      ref_handle_(PCV_EXPIRE_BY_MEM_HANDLE)
+  {}
+
+  int operator()(LibCacheKVEntry &entry)
+  {
+    int ret = common::OB_SUCCESS;
+    if (scanned_nodes_ >= max_scan_nodes_) {
+      ret = OB_ITER_END;
+    } else {
+      ++scanned_nodes_;
+      if (OB_ISNULL(entry.first) || OB_ISNULL(entry.second)) {
+        // skip
+      } else {
+        const StmtStat *stat = entry.second->get_node_stat();
+        if (OB_NOT_NULL(stat) &&
+            stat->last_active_timestamp_ > 0 &&
+            now_ - stat->last_active_timestamp_ > idle_threshold_us_) {
+          if (OB_FAIL(to_evict_->push_back(ObLCKeyValue(entry.first, entry.second)))) {
+            SQL_PC_LOG(WARN, "fail to push back idle evict entry", K(ret));
+          } else {
+            entry.second->inc_ref_count(ref_handle_);
+          }
+        }
+      }
+    }
+    return ret;
+  }
+};
+
 ObPlanCache::ObPlanCache()
   :inited_(false),
    tenant_id_(OB_INVALID_TENANT_ID),
@@ -248,7 +291,8 @@ ObPlanCache::ObPlanCache()
    ref_handle_mgr_(),
    pcm_(NULL),
    destroy_(0),
-   tg_id_(-1)
+   tg_id_(-1),
+   idle_scan_cursor_(0)
 {
 }
 
@@ -1393,6 +1437,59 @@ int ObPlanCache::cache_evict_by_glitch_node()
   }
   return ret;
 }
+
+int ObPlanCache::cache_evict_by_idle()
+{
+  int ret = OB_SUCCESS;
+  const int64_t idle_threshold_us = IDLE_EVICT_THRESHOLD_US;
+  if (idle_threshold_us <= 0) {
+    // idle eviction disabled
+  } else {
+    ObGlobalReqTimeService::check_req_timeinfo();
+    const int64_t now = ObTimeUtility::current_time();
+    const int64_t start_cursor = idle_scan_cursor_;
+    int64_t bucket_pos = start_cursor;
+    int64_t scanned_buckets = 0;
+    LCKeyValueArray to_evict;
+    ObIdleEvictOp op(now, idle_threshold_us, IDLE_SCAN_MAX_NODES, &to_evict);
+
+    while (OB_SUCC(ret)
+           && bucket_pos < bucket_num_
+           && scanned_buckets < IDLE_SCAN_MAX_BUCKETS
+           && op.scanned_nodes_ < IDLE_SCAN_MAX_NODES) {
+      int64_t batch_end = MIN(bucket_pos + 256, bucket_num_);
+      scanned_buckets += (batch_end - bucket_pos);
+      int tmp_ret = cache_key_node_map_.foreach_refactored_range(op, bucket_pos, batch_end);
+      if (OB_ITER_END == tmp_ret) {
+        break;
+      } else if (OB_FAIL(tmp_ret)) {
+        SQL_PC_LOG(WARN, "failed to scan buckets for idle eviction", K(ret), K(bucket_pos));
+      }
+      bucket_pos = batch_end;
+    }
+
+    idle_scan_cursor_ = (bucket_pos >= bucket_num_) ? 0 : bucket_pos;
+
+    if (to_evict.count() > 0) {
+      SQL_PC_LOG(INFO, "idle eviction collected plans",
+                 K_(tenant_id),
+                 "idle_evict_count", to_evict.count(),
+                 "scanned_nodes", op.scanned_nodes_,
+                 "scanned_buckets", scanned_buckets,
+                 "start_cursor", start_cursor,
+                 "new_cursor", idle_scan_cursor_);
+      if (OB_FAIL(batch_remove_cache_node(to_evict))) {
+        SQL_PC_LOG(WARN, "failed to remove idle cache nodes", K(ret));
+      }
+      for (int64_t i = 0; i < to_evict.count(); i++) {
+        if (OB_NOT_NULL(to_evict.at(i).node_)) {
+          to_evict.at(i).node_->dec_ref_count(PCV_EXPIRE_BY_MEM_HANDLE);
+        }
+      }
+    }
+  }
+  return ret;
+}
 // int ObPlanCache::load_plan_baseline()
 // {
 //   int ret = OB_SUCCESS;
@@ -2100,6 +2197,19 @@ int ObPlanCache::destroy_cache_obj(const bool is_leaked, const uint64_t object_i
   return ret;
 }
 
+int ObPlanCache::dump_all_objs() const
+{
+  int ret = OB_SUCCESS;
+  ObArray<AllocCacheObjInfo> alloc_obj_list;
+  ObDumpAllCacheObjOp get_all_objs_op(&alloc_obj_list, INT64_MAX);
+  if (OB_FAIL(co_mgr_.foreach_alloc_cache_obj(get_all_objs_op))) {
+    LOG_WARN("failed to traverse alloc cache obj map", K(ret));
+  } else {
+    LOG_INFO("Dumping All Cache Objs", K(alloc_obj_list.count()), K(alloc_obj_list));
+  }
+  return ret;
+}
+
 int ObPlanCache::dump_deleted_objs_by_ns(ObIArray<AllocCacheObjInfo> &deleted_objs,
                                          const int64_t safe_timestamp,
                                          const ObLibCacheNameSpace ns)
@@ -2348,6 +2458,19 @@ int ObPlanCache::flush_pl_cache()
 
 const char *plan_cache_gc_confs[3] = { "OFF", "REPORT", "AUTO" };
 
+int ObPlanCache::get_plan_cache_gc_strategy()
+{
+  PlanCacheGCStrategy strategy = INVALID;
+  for (int i = 0; i < ARRAYSIZEOF(plan_cache_gc_confs) && strategy == INVALID; i++) {
+    if (0 == ObString::make_string(plan_cache_gc_confs[i])
+               .case_compare(GCONF._ob_plan_cache_gc_strategy)) {
+      strategy = static_cast<PlanCacheGCStrategy>(i);
+    }
+  }
+  return strategy;
+}
+
+
 void ObPlanCacheEliminationTask::runTimerTask()
 {
   int ret = OB_SUCCESS;
@@ -2366,6 +2489,11 @@ void ObPlanCacheEliminationTask::runTimerTask()
     SQL_PC_LOG(INFO, "schedule next cache evict task",
               "evict_interval", (int64_t)(GCONF.plan_cache_evict_interval));
   }
+  // free cache obj in deleted map
+  if (plan_cache_->get_plan_cache_gc_strategy() > 0) {
+    observer::ObReqTimeGuard req_timeinfo_guard;
+    run_free_cache_obj_task();
+  }
   SQL_PC_LOG(INFO, "schedule next cache evict task",
              "evict_interval", (int64_t)(GCONF.plan_cache_evict_interval));
 }
@@ -2381,6 +2509,39 @@ void ObPlanCacheEliminationTask::run_plan_cache_task()
     SQL_PC_LOG(ERROR, "Plan cache evict failed, please check", K(ret));
   }  else if (OB_FAIL(plan_cache_->cache_evict_by_glitch_node())) {
     SQL_PC_LOG(ERROR, "Plan cache evict by glitch failed, please check", K(ret));
+  }
+  if (OB_FAIL(plan_cache_->cache_evict_by_idle())) {
+    SQL_PC_LOG(WARN, "Plan cache idle evict failed", K(ret));
+  }
+}
+
+void ObPlanCacheEliminationTask::run_free_cache_obj_task()
+{
+  int ret = OB_SUCCESS;
+  ObArray<AllocCacheObjInfo> deleted_objs;
+  int64_t safe_timestamp = INT64_MAX;
+  if (observer::ObGlobalReqTimeService::get_instance()
+                         .get_global_safe_timestamp(safe_timestamp)) {
+    // ignore ret
+    SQL_PC_LOG(ERROR, "failed to get global safe timestamp", K(ret));
+  } else if (OB_FAIL(plan_cache_->dump_deleted_objs<DUMP_ALL>(deleted_objs, safe_timestamp))) {
+    SQL_PC_LOG(WARN, "failed to traverse hashmap", K(ret));
+  } else {
+    int64_t tot_mem_used = 0;
+    for (int k = 0; k < deleted_objs.count(); k++) {
+      tot_mem_used += deleted_objs.at(k).mem_used_;
+    } // end for
+    if (tot_mem_used >= ((plan_cache_->get_mem_limit() / 100) * 30)) {
+      // ignore ret
+      LOG_ERROR("Cache Object Memory Leaked Much!!!", K(tot_mem_used),
+                K(plan_cache_->get_mem_limit()), K(deleted_objs), K(safe_timestamp));
+    } else if (deleted_objs.count() > 0) {
+      LOG_WARN("Cache Object Memory Leaked Much!!!", K(deleted_objs),
+               K(safe_timestamp), K(plan_cache_->get_mem_limit()));
+    }
+  }
+  if (OB_SUCC(ret) && OB_FAIL(plan_cache_->dump_all_objs())) {
+    LOG_WARN("failed to dump deleted map", K(ret));
   }
 }
 

--- a/src/sql/plan_cache/ob_plan_cache.cpp
+++ b/src/sql/plan_cache/ob_plan_cache.cpp
@@ -1438,6 +1438,22 @@ int ObPlanCache::cache_evict_by_glitch_node()
   return ret;
 }
 
+// Plan cache only evicts plans when memory exceeds the high water mark,
+// so plans that are no longer accessed can stay cached indefinitely,
+// wasting memory until memory pressure triggers eviction.
+//
+// This function adds idle-based eviction: plans not accessed within
+// IDLE_EVICT_THRESHOLD_US (default 30s) are removed proactively.
+//
+// To avoid scanning all buckets and nodes in a single timer round
+// (which could be expensive with tens of thousands of buckets and
+// many nodes per bucket), the scan is rate-limited by two caps:
+//   - IDLE_SCAN_MAX_BUCKETS: max buckets scanned per round
+//   - IDLE_SCAN_MAX_NODES:   max nodes inspected per round
+// A cursor (idle_scan_cursor_) tracks progress across rounds so that
+// all buckets are eventually covered. Each node's existing
+// last_active_timestamp_ (already updated atomically on every access)
+// is checked against the threshold — no extra work on the hot path.
 int ObPlanCache::cache_evict_by_idle()
 {
   int ret = OB_SUCCESS;

--- a/src/sql/plan_cache/ob_plan_cache.h
+++ b/src/sql/plan_cache/ob_plan_cache.h
@@ -325,7 +325,16 @@ public:
   uint64_t dec_mem_used(uint64_t mem_delta)
   {
     SQL_PC_LOG(DEBUG, "before dec mem_used, mem_used", K(mem_used_));
-    return ATOMIC_FAA((uint64_t *)&mem_used_, -mem_delta);
+    int64_t old_val = 0;
+    int64_t new_val = 0;
+    do {
+      old_val = ATOMIC_LOAD(&mem_used_);
+      if (old_val <= 0) {
+        return 0;
+      }
+      new_val = (static_cast<uint64_t>(old_val) > mem_delta) ? (old_val - static_cast<int64_t>(mem_delta)) : 0;
+    } while (!ATOMIC_BCAS(&mem_used_, old_val, new_val));
+    return static_cast<uint64_t>(old_val);
   };
 
   int64_t get_mem_used() const
@@ -486,6 +495,7 @@ private:
   ObPlanCacheEliminationTask evict_task_;
   int tg_id_;
   int64_t idle_scan_cursor_;
+  bool idle_evict_done_round_;
   static const int64_t IDLE_SCAN_MAX_NODES = 1000;
   static const int64_t IDLE_SCAN_MAX_BUCKETS = 5000;
   static const int64_t IDLE_EVICT_THRESHOLD_US = 30L * 1000L * 1000L; // 30s

--- a/src/sql/plan_cache/ob_plan_cache.h
+++ b/src/sql/plan_cache/ob_plan_cache.h
@@ -216,6 +216,8 @@ public:
   void runTimerTask(void);
 private:
   void run_plan_cache_task();
+  //void run_ps_cache_task();
+  void run_free_cache_obj_task();
 public:
   ObPlanCache* plan_cache_;
   int64_t run_task_counter_;
@@ -352,6 +354,7 @@ public:
   //evict plan, adjust mem between hwm and lwm
   int cache_evict();
   int cache_evict_by_glitch_node();
+  int cache_evict_by_idle();
   int cache_evict_plan_by_sql_id(uint64_t db_id, common::ObString sql_id);
   int cache_evict_by_ns(ObLibCacheNameSpace ns);
   template<typename CallBack = ObKVEntryTraverseOp>
@@ -382,6 +385,7 @@ public:
                                           ObFastParserResult &fp_result);
   static int construct_multi_stmt_fast_parser_result(common::ObIAllocator &allocator,
                                                      ObPlanCacheCtx &pc_ctx);
+  int dump_all_objs() const;
   int dump_deleted_objs_by_ns(ObIArray<AllocCacheObjInfo> &deleted_objs,
                               const int64_t safe_timestamp,
                               const ObLibCacheNameSpace ns);
@@ -455,6 +459,8 @@ private:
   int check_after_get_plan(int tmp_ret, ObILibCacheCtx &ctx, ObILibCacheObject *cache_obj);
   int get_normalized_pattern_digest(const ObPlanCacheCtx &pc_ctx, uint64_t &pattern_digest);
 private:
+  enum PlanCacheGCStrategy { INVALID = -1, OFF = 0, REPORT = 1, AUTO = 2};
+  static int get_plan_cache_gc_strategy();
 private:
   const static int64_t SLICE_SIZE = 1024; //1k
 private:
@@ -479,6 +485,10 @@ private:
   CacheKeyNodeMap cache_key_node_map_;
   ObPlanCacheEliminationTask evict_task_;
   int tg_id_;
+  int64_t idle_scan_cursor_;
+  static const int64_t IDLE_SCAN_MAX_NODES = 1000;
+  static const int64_t IDLE_SCAN_MAX_BUCKETS = 5000;
+  static const int64_t IDLE_EVICT_THRESHOLD_US = 30L * 1000L * 1000L; // 30s
 };
 
 template<typename _callback>


### PR DESCRIPTION
## Task Description
Add an idle eviction mechanism to the plan cache to periodically clean up execution plans that have not been accessed for a long time, preventing stale plans from occupying memory indefinitely.

## Solution Description
Add a `cache_evict_by_idle` batch scanning logic within the existing 5-second timer.
- Use a bucket cursor (`idle_scan_cursor_`) to record the scan progress; each timer round continues from the last position.
- Dual limits control overhead: each round scans at most 5000 buckets (`IDLE_SCAN_MAX_BUCKETS`) and 1000 nodes (`IDLE_SCAN_MAX_NODES`).
- Check the node's `last_active_timestamp_`; plans not accessed for over 30 seconds are evicted in batches.
- Add a `foreach_refactored_range` method to `ObHashTable`/`ObHashMap` to support traversal by bucket range.
Zero overhead on hot paths: the get_plan/add_plan paths are not modified; scanning is performed only in the background timer.

## Passed Regressions

## Upgrade Compatibility
No upgrade compatibility impact; only adds background eviction logic.

## Other Information
![image](/uploads/fb274815e35c0547c407da6785a2e30b/image.png)

## Release Note
