### PR TITLE
[seekdb][direct_load_lite] Fix PX serial fast-SQC self-deadlock by dispatching SQC asynchronously

### DIFF
--- a/src/share/schema/ob_schema_cache.cpp
+++ b/src/share/schema/ob_schema_cache.cpp
@@ -20,6 +20,7 @@
 #include "ob_schema_cache.h"
 #include "share/cache/ob_cache_name_define.h"
 #include "observer/ob_server_struct.h"
+#include "common/ob_smart_call.h"
 #include "deps/oblib/src/lib/lock/ob_latch.h"
 #include "deps/oblib/src/lib/stat/ob_latch_define.h"
 namespace oceanbase
@@ -1490,11 +1491,11 @@ int ObSchemaFetcher::fetch_##OBJECT_NAME##_info(const ObRefreshSchemaStatus &sch
     if (OB_FAIL(tenant_object_ids.push_back(object_id))) { \
       LOG_WARN("fail to push back object_id for " #OBJECT_NAME, \
                K(object_id), K(ret)); \
-    } else if (OB_FAIL(schema_service_->get_batch_##OBJECT_NAME##s(schema_status, \
-                                                                   schema_version, \
-                                                                   tenant_object_ids, \
-                                                                   *sql_client_, \
-                                                                   object_schema_array))) { \
+    } else if (OB_FAIL(SMART_CALL_LARGE(schema_service_->get_batch_##OBJECT_NAME##s(schema_status, \
+                                                                                    schema_version, \
+                                                                                    tenant_object_ids, \
+                                                                                    *sql_client_, \
+                                                                                    object_schema_array)))) { \
       LOG_WARN("fail to get batch " #OBJECT_NAME, \
                K(tenant_object_ids), K(schema_version), K(ret)); \
     } else if (OB_UNLIKELY(1 != object_schema_array.count())) { \


### PR DESCRIPTION
## Task Description
Fix a deterministic deadlock in PX parallel queries (e.g., `SELECT * FROM tbl_index7 ORDER BY c1` with a plan top of PX COORDINATOR MERGE SORT / EXCHANGE OUT DISTR / PX PARTITION ITERATOR) on a single-seekdb replica, where the query hangs permanently (over 40 hours in production) and `query_timeout` is ineffective. The deadlock occurs whenever the output of a PX DFO exceeds the capacity of a single DTL buffer.

## Solution Description
The root cause was a change in the RPC framework removal refactoring (commit 7321e32e94f), which modified `ObSerialDfoScheduler::dispatch_sqcs` from using an asynchronous RPC (`proxy.fast_init_sqc(args, &ObFastInitSqcCB)`, which returns immediately, with SQC executing on an independent receiver thread) to a blocking `ex_rpc::sync_call(px_init_sqc_fast_in_proc)`. The fast SQC path runs the entire task (including transmit) inline on the calling thread. This caused a deadlock: the QC blocks inside `sync_call` before entering its `msg_loop` to drain data; the SQC's inline transmit fills the QC-SQC DTL send buffer and then blocks in `wait_unblocking`, waiting for the QC to unblock it; the QC is stuck in `sync_call` waiting for the SQC to return.

The fix restores the original thread topology by making the fast SQC startup in the serial scheduler asynchronous again, ensuring the SQC executes on an independent ReqWorker thread and the QC returns immediately to drain the QC-SQC channel.
1.  **ob_dfo_scheduler.cpp (`ObSerialDfoScheduler::dispatch_sqcs`):** Changed `ex_rpc::sync_call([&]{...})` to `(void)ex_rpc::async_call([ser_buf, ser_pos]{ return px_init_sqc_fast_in_proc(ser_buf, ser_pos); })`. `ser_buf`/`ser_pos` are captured by value (since QC no longer blocks, reference capture would dangle). The buffer is allocated on the `exec_ctx` allocator, and the QC blocks in `wait_all_running_dfos_exit` until all SQCs report, ensuring safe lifetime, and a `MEMCPY` is already performed during decode. All pre-dispatch synchronous error handling (blacklist / timeout / EN_PX_SQC_INIT_FAILED errsim + mock_sqc_finish_msg + set_need_report(false)) is preserved.
2.  **ob_px_rpc_processor.cpp (end of `ObInitFastSqcP::process`):** Since it's now fire-and-forget, the in-proc return code is unavailable. Added an `ObInterruptUtil::interrupt_qc` for pre-link failures (where `OB_SQC_HANDLER_QC_SQC_LINKED` is not set, so `destroy_sqc` won't call `report_sqc_finish`). This is placed before `release_handler` to avoid UAF, equivalent to the error path in the old `ObFastInitSqcCB::process`. Post-link failures already self-report via DTL `FINISH_SQC_RESULT`; they are distinguished by the `has_flag(LINKED)` check to avoid duplicate signals.
Key invariant: The QC-SQC channel is linked and registered to the `msg_loop` in steps 0/1 of `do_schedule_dfo`, before `dispatch_sqcs`. `check_all_sqc` waits based on `need_report`; the QC can exit when the SQC reports (clearing the flag), on `server_not_alive`, or on interrupt.

## Passed Regressions
Validated on an isolated instance: Partitioned table + each-column CG unique index + bypass import of 10k rows + `SELECT * FROM tbl_index7 ORDER BY c1`. Before the fix, the query hung for ~41 hours. After the fix, it returns all 10k rows in 0 seconds. Repeated runs are stable at 60-78ms. Tests with wider rows (7MB) and `parallel(4)` also return in seconds. The log shows 0 occurrences of the `wait unblocking` deadlock characteristic.
Pending: Parallel DML (branch_id) / batch-rescan / parallel virtual table mysqltest regressions.

## Upgrade Compatibility
No impact. The change only affects the runtime scheduling thread topology of PX (synchronous -> asynchronous). There are no changes to schema, persistence, or protocol formats, so it does not affect upgrades or mixed-version deployments.

## Other Information
This MR contains two commits:
-   d61b07af6d1: The PX deadlock fix (modifies two PX files, validated by reproduction).
-   4405c13448a: Fixes a stack overflow in DBMS + PL + schema reader (modifies `ob_schema_cache.cpp`). This is unrelated to the PX deadlock and was included by the committer.
Note: The refactored `ex_rpc` framework already provides an asynchronous `async_call` interface. The parallel scheduler `ObParallelDfoScheduler` already uses the asynchronous `px_init_sqc_async_in_proc` via a thread pool and does not deadlock. This fix corrects only the serial fast path, which incorrectly used the blocking `sync_call`.

## Release Note
Fix a deadlock in PX parallel queries where the query coordinator and sub-coordinator could block each other indefinitely when processing large result sets on a single replica.