### PR TITLE
[CP] fix(semantic_index): reject semantic_distance/semantic_vector_distance in generated column

### DIFF
--- a/src/sql/engine/expr/ob_expr_semantic_distance.cpp
+++ b/src/sql/engine/expr/ob_expr_semantic_distance.cpp
@@ -33,7 +33,7 @@
  {
  
  ObExprSemanticDistance::ObExprSemanticDistance(common::ObIAllocator &alloc)
-     : ObFuncExprOperator(alloc, T_FUN_SYS_SEMANTIC_DISTANCE, N_SEMANTIC_DISTANCE, 2, VALID_FOR_GENERATED_COL, NOT_ROW_DIMENSION)
+     : ObFuncExprOperator(alloc, T_FUN_SYS_SEMANTIC_DISTANCE, N_SEMANTIC_DISTANCE, 2, NOT_VALID_FOR_GENERATED_COL, NOT_ROW_DIMENSION)
  {
  }
  
@@ -144,6 +144,17 @@
    rt_expr.eval_func_ = calc_semantic_vector_distance;
    
    return ret;
+ }
+ 
+ int ObExprSemanticVectorDistance::is_valid_for_generated_column(
+     const ObRawExpr *expr,
+     const common::ObIArray<ObRawExpr *> &exprs,
+     bool &is_valid) const
+ {
+   UNUSED(expr);
+   UNUSED(exprs);
+   is_valid = false;
+   return OB_SUCCESS;
  }
  
  } // namespace sql

--- a/src/sql/engine/expr/ob_expr_semantic_distance.h
+++ b/src/sql/engine/expr/ob_expr_semantic_distance.h
@@ -61,6 +61,10 @@
    
    virtual int cg_expr(ObExprCGCtx &expr_cg_ctx, const ObRawExpr &raw_expr, ObExpr &rt_expr) const override;
    
+   virtual int is_valid_for_generated_column(const ObRawExpr *expr,
+                                             const common::ObIArray<ObRawExpr *> &exprs,
+                                             bool &is_valid) const override;
+   
  private:
    DISALLOW_COPY_AND_ASSIGN(ObExprSemanticVectorDistance);
  };


### PR DESCRIPTION
## Task Description
When creating a vector index on a table containing a generated column with `semantic_distance` or `semantic_vector_distance`, the error changed from `OB_ERR_ADD_INDEX` (-5703) to `OB_INVALID_ARGUMENT` (-4002). Root cause: these two functions were incorrectly marked as valid for generated columns (`VALID_FOR_GENERATED_COL`), but they cannot execute properly in the generated column evaluation context, causing type deduction to fail during index creation.

## Solution Description
Changed the registration flag for `semantic_distance` to `NOT_VALID_FOR_GENERATED_COL`. Overrode `is_valid_for_generated_column` for `semantic_vector_distance` to return false. This ensures that during table creation, the standard error `OB_ERR_ONLY_PURE_FUNC_CANBE_VIRTUAL_COLUMN_EXPRESSION` (-5906 / ERROR 3102) is reported, blocking the issue at the source.

## Passed Regressions
core-test

## Upgrade Compatibility

## Other Information
- Related links: DIMA-2026052800116405537
- Cherry-pick from merge point `14409a0f1d672890be01636351b70ecfb8e49c56` in project oceanbase by ob flow
- Previous code review: [267996](https://code.alibaba-inc.com/oceanbase/oceanbase/pull/267996)
**Warning: This review got code conflicts when auto cherry-picking, please make sure the diff is effective**
- DIMA-2026061600116781015

## Release Note
