### PR TITLE
fix(seekdb): Index may contain entries pointing to deleted rows in main table when ALTER TABLE (add unique index, rename index, modify primary key, etc.) runs concurrently with queries

### DIFF
--- a/src/storage/access/ob_multiple_get_merge.cpp
+++ b/src/storage/access/ob_multiple_get_merge.cpp
@@ -239,7 +239,8 @@ int ObMultipleGetMerge::inner_get_next_row(ObDatumRow &row)
           // When the index lookups the rowkeys from the main table, it should exists
           // and if we find that it does not exist, there must be an anomaly
           if (GCONF.enable_defensive_check()
-              && access_ctx_->query_flag_.is_lookup_for_4377()) {
+              && access_ctx_->query_flag_.is_lookup_for_4377()
+              && !fuse_row.row_flag_.is_delete()) {
             ret = handle_4377("[index lookup]ObMultipleGetMerge::inner_get_next_row");
             STORAGE_LOG(WARN,"[index lookup] row not found", K(ret),
                         K(rowkeys_),

--- a/src/storage/access/ob_single_merge.cpp
+++ b/src/storage/access/ob_single_merge.cpp
@@ -330,7 +330,8 @@ int ObSingleMerge::inner_get_next_row(ObDatumRow &row)
     if (GCONF.enable_defensive_check()
         && access_ctx_->query_flag_.is_lookup_for_4377()
         && !access_ctx_->query_flag_.skip_4377_for_async_index_lookup()
-        && OB_ITER_END == ret) {
+        && OB_ITER_END == ret
+        && !full_row_.row_flag_.is_delete()) {
       ret = handle_4377("[index lookup]ObSingleMerge::inner_get_next_row");
       STORAGE_LOG(WARN, "[index lookup] row not found", K(ret),
                   K(have_uncommited_row),


### PR DESCRIPTION
## Task Description
Fix a false positive error (error code 4377) that occurs during index lookup when ALTER TABLE operations (such as adding a unique index, renaming an index, or modifying the primary key) run concurrently with queries. Under these conditions, an index might contain entries pointing to rows in the main table that have been marked as deleted (either from an uncommitted transaction or a committed one not yet cleaned up). The normal query path (`need_iter_del_row=false`) would encounter these deleted rows and incorrectly trigger the 4377 defense check.

## Solution Description
The fix adds a `&& !xxx.row_flag_.is_delete` check to the conditions that trigger error 4377 in two locations:
1.  In `ObSingleMerge::inner_get_next_row` at `ob_single_merge.cpp:334`.
2.  In `ObMultipleGetMerge::inner_get_next_row` at `ob_multiple_get_merge.cpp:243`.

This ensures rows marked as deleted are not mistakenly reported as errors. The change follows the same design pattern as the existing `skip_4377_for_async_index_lookup` flag.

## Passed Regressions
Local compilation is blocked by Windows 11 WDAC policy (PowerShell ConstrainedLanguage mode), preventing the execution of .NET APIs in `gen_parser_win.ps1` and `build.ps1`. Therefore, local compilation and verification could not be completed. The code change is only 2 lines, and the logic has been validated as correct. Full validation is pending farm test cases.

## Upgrade Compatibility

## Other Information
DIMA: 2026040900115285358

## Release Note
