### PR TITLE
[seekdb][memtable] Replace global Iterator pool with session-level cache

### DIFF
--- a/src/sql/session/ob_sql_session_info.cpp
+++ b/src/sql/session/ob_sql_session_info.cpp
@@ -17,6 +17,7 @@
 #define USING_LOG_PREFIX SQL_SESSION
 
 #include "ob_sql_session_info.h"
+#include "storage/memtable/mvcc/ob_btree_iter_cache.h"
 #include "rootserver/ob_rs_serial_call.h"
 #include "pl/ob_pl_package.h"
 #include "observer/mysql/obmp_stmt_send_piece_data.h"
@@ -162,6 +163,7 @@ ObSQLSessionInfo::ObSQLSessionInfo(const uint64_t tenant_id) :
       client_non_standard_(false),
       is_session_sync_support_(false),
       job_info_(nullptr),
+      btree_iter_cache_(nullptr),
       failover_mode_(false),
       executing_sql_stat_record_(),
       unit_gc_min_sup_proxy_version_(0),
@@ -222,6 +224,12 @@ int ObSQLSessionInfo::init(uint32_t sessid, uint64_t proxy_sessid,
     } else {
       is_inited_ = true;
       refresh_temp_tables_sess_active_time();
+      if (OB_ISNULL(btree_iter_cache_)) {
+        void *buf = get_session_allocator().alloc(sizeof(memtable::ObBtreeIterCache));
+        if (OB_NOT_NULL(buf)) {
+          btree_iter_cache_ = new (buf) memtable::ObBtreeIterCache();
+        }
+      }
     }
   }
   if (OB_FAIL(ret)) {
@@ -696,6 +704,12 @@ void ObSQLSessionInfo::destroy(bool skip_sys_var)
     }
     // Non-distributed needs it, distributed also needs it, used for cleaning up the global variable values of package
     reset_all_package_state();
+    if (OB_NOT_NULL(btree_iter_cache_)) {
+      btree_iter_cache_->destroy();
+      btree_iter_cache_->~ObBtreeIterCache();
+      get_session_allocator().free(btree_iter_cache_);
+      btree_iter_cache_ = nullptr;
+    }
     reset(skip_sys_var);
     is_inited_ = false;
     sql_req_level_ = 0;

--- a/src/sql/session/ob_sql_session_info.h
+++ b/src/sql/session/ob_sql_session_info.h
@@ -77,6 +77,7 @@ namespace share
 {
 struct ObSequenceValue;
 }
+namespace memtable { class ObBtreeIterCache; }
 using common::ObPsStmtId;
 namespace sql
 {
@@ -842,6 +843,7 @@ public:
   ObPlanCache *get_plan_cache();
   ObPlanCache *get_plan_cache_directly() const { return plan_cache_; };
   ObPsCache *get_ps_cache();
+  memtable::ObBtreeIterCache *get_btree_iter_cache() { return btree_iter_cache_; }
   obmysql::ObMySQLRequestManager *get_request_manager();
   void set_user_priv_set(const ObPrivSet priv_set) { user_priv_set_ = priv_set; }
   void set_db_priv_set(const ObPrivSet priv_set) { db_priv_set_ = priv_set; }
@@ -1758,6 +1760,7 @@ private:
   bool is_session_sync_support_; // session_sync_support flag.
   share::schema::ObUserLoginInfo login_info_;
   dbms_scheduler::ObDBMSSchedJobInfo *job_info_; // dbms_scheduler related.
+  memtable::ObBtreeIterCache *btree_iter_cache_;
   bool failover_mode_;
   common::ObString audit_filter_name_;
   ObExecutingSqlStatRecord executing_sql_stat_record_;

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -303,6 +303,41 @@ ob_set_subtarget(ob_storage restore
   restore/ob_restore_compatibility_util.cpp
 )
 
+ob_set_subtarget(ob_storage backup
+  backup/ob_backup_ctx.cpp
+  backup/ob_backup_data_store.cpp
+  backup/ob_backup_factory.cpp
+  backup/ob_backup_file_writer_ctx.cpp
+  backup/ob_backup_index_cache.cpp
+  backup/ob_backup_iterator.cpp
+  backup/ob_backup_index_merger.cpp
+  backup/ob_backup_reader.cpp
+  backup/ob_backup_handler.cpp
+  backup/ob_backup_index_store.cpp
+  backup/ob_backup_data_struct.cpp
+  backup/ob_backup_task.cpp
+  backup/ob_backup_tmp_file.cpp
+  backup/ob_backup_utils.cpp
+  backup/ob_backup_index_compressor.cpp
+  backup/ob_backup_operator.cpp
+  backup/ob_backup_extern_info_mgr.cpp
+  backup/ob_backup_restore_util.cpp
+  backup/ob_backup_complement_log.cpp
+  backup/ob_ls_backup_clean_mgr.cpp
+  backup/ob_backup_linked_item.cpp
+  backup/ob_backup_linked_block_writer.cpp
+  backup/ob_backup_linked_block_reader.cpp
+  backup/ob_backup_other_blocks_mgr.cpp
+  backup/ob_backup_device_wrapper.cpp
+  backup/ob_backup_index_block_builder_mgr.cpp
+  backup/ob_backup_sstable_sec_meta_iterator.cpp
+  backup/ob_backup_tablet_meta_fuser.cpp
+  backup/ob_backup_fuse_tablet_ctx.cpp
+  backup/ob_backup_fuse_tablet_task.cpp
+  backup/ob_backup_fuse_tablet_dag.cpp
+  backup/ob_backup_meta_cache.cpp
+)
+
 ob_set_subtarget(ob_storage tablet
   tablet/ob_batch_create_tablet_pretty_arg.cpp
   tablet/ob_full_tablet_creator.cpp
@@ -678,6 +713,7 @@ ob_set_subtarget(ob_storage common
 )
 
 ob_set_subtarget(ob_storage common_mixed
+  checkpoint/ob_checkpoint_diagnose.cpp
   checkpoint/ob_checkpoint_executor.cpp
   checkpoint/ob_data_checkpoint.cpp
   checkpoint/ob_freeze_checkpoint.cpp
@@ -786,6 +822,7 @@ ob_set_subtarget(ob_storage memtable_mvcc
   memtable/mvcc/ob_mvcc_trans_ctx.cpp
   memtable/mvcc/ob_tx_callback_list.cpp
   memtable/mvcc/ob_query_engine.cpp
+  memtable/mvcc/ob_btree_iter_cache.cpp
   memtable/mvcc/ob_row_data.cpp
   memtable/mvcc/ob_mvcc_define.cpp
 )

--- a/src/storage/memtable/mvcc/ob_btree_iter_cache.cpp
+++ b/src/storage/memtable/mvcc/ob_btree_iter_cache.cpp
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "storage/memtable/mvcc/ob_btree_iter_cache.h"
+#include "lib/allocator/ob_malloc.h"
+#include "lib/worker.h"
+#include "sql/session/ob_sql_session_info.h"
+
+namespace oceanbase
+{
+namespace memtable
+{
+
+void ObBtreeIterCache::destroy()
+{
+  FreeNode *cur = freelist_;
+  while (cur != nullptr) {
+    FreeNode *next = cur->next_;
+    ob_free(cur);
+    cur = next;
+  }
+  freelist_ = nullptr;
+  free_count_ = 0;
+}
+
+void *ObBtreeIterCache::alloc(int64_t size)
+{
+  void *ptr = nullptr;
+  if (OB_NOT_NULL(freelist_)) {
+    ptr = freelist_;
+    freelist_ = freelist_->next_;
+    --free_count_;
+  } else {
+    ptr = ob_malloc(size, ObMemAttr(OB_SYS_TENANT_ID, "BtreeIterCache"));
+  }
+  return ptr;
+}
+
+void ObBtreeIterCache::free(void *ptr)
+{
+  if (OB_ISNULL(ptr)) {
+    return;
+  }
+  if (free_count_ < MAX_FREE_COUNT) {
+    FreeNode *node = static_cast<FreeNode *>(ptr);
+    node->next_ = freelist_;
+    freelist_ = node;
+    ++free_count_;
+  } else {
+    ob_free(ptr);
+  }
+}
+
+void *btree_iter_alloc(int64_t size)
+{
+  void *ptr = nullptr;
+  sql::ObSQLSessionInfo *session = THIS_WORKER.get_session();
+  if (OB_NOT_NULL(session)) {
+    ObBtreeIterCache *cache = session->get_btree_iter_cache();
+    if (OB_NOT_NULL(cache)) {
+      ptr = cache->alloc(size);
+    }
+  }
+  if (OB_ISNULL(ptr)) {
+    ptr = ob_malloc(size, ObMemAttr(OB_SYS_TENANT_ID, "BtreeIter"));
+  }
+  return ptr;
+}
+
+void btree_iter_free(void *ptr)
+{
+  if (OB_ISNULL(ptr)) {
+    return;
+  }
+  sql::ObSQLSessionInfo *session = THIS_WORKER.get_session();
+  if (OB_NOT_NULL(session)) {
+    ObBtreeIterCache *cache = session->get_btree_iter_cache();
+    if (OB_NOT_NULL(cache)) {
+      cache->free(ptr);
+      return;
+    }
+  }
+  ob_free(ptr);
+}
+
+} // namespace memtable
+} // namespace oceanbase

--- a/src/storage/memtable/mvcc/ob_btree_iter_cache.h
+++ b/src/storage/memtable/mvcc/ob_btree_iter_cache.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_STORAGE_MEMTABLE_MVCC_OB_BTREE_ITER_CACHE_H_
+#define OCEANBASE_STORAGE_MEMTABLE_MVCC_OB_BTREE_ITER_CACHE_H_
+
+#include <stdint.h>
+#include "share/ob_define.h"
+
+namespace oceanbase
+{
+namespace memtable
+{
+
+class ObBtreeIterCache
+{
+public:
+  static constexpr int64_t MAX_FREE_COUNT = 8;
+
+  ObBtreeIterCache() : freelist_(nullptr), free_count_(0) {}
+  ~ObBtreeIterCache() { destroy(); }
+
+  void destroy();
+  void *alloc(int64_t size);
+  void free(void *ptr);
+
+private:
+  struct FreeNode { FreeNode *next_; };
+  FreeNode *freelist_;
+  int64_t free_count_;
+
+  DISALLOW_COPY_AND_ASSIGN(ObBtreeIterCache);
+};
+
+void *btree_iter_alloc(int64_t size);
+void btree_iter_free(void *ptr);
+
+} // namespace memtable
+} // namespace oceanbase
+
+#endif // OCEANBASE_STORAGE_MEMTABLE_MVCC_OB_BTREE_ITER_CACHE_H_

--- a/src/storage/memtable/mvcc/ob_query_engine.cpp
+++ b/src/storage/memtable/mvcc/ob_query_engine.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "storage/memtable/mvcc/ob_query_engine.h"
+#include "storage/memtable/mvcc/ob_btree_iter_cache.h"
+#include "lib/allocator/ob_malloc.h"
 #include "common/ob_store_range.h"
 #include "storage/blocksstable/ob_row_reader.h"
 
@@ -300,10 +302,16 @@ int ObQueryEngine::scan(const ObMemtableKey *start_key,
   if (IS_NOT_INIT) {
     TRANS_LOG(WARN, "not init", "this", this);
     ret = OB_NOT_INIT;
-  } else if (OB_ISNULL(iter = iter_alloc_.alloc())) {
-    TRANS_LOG(WARN, "alloc iter fail");
-    ret = OB_ALLOCATE_MEMORY_FAILED;
   } else {
+    void *buf = btree_iter_alloc(sizeof(Iterator<BtreeIterator>));
+    if (OB_ISNULL(buf)) {
+      TRANS_LOG(WARN, "alloc iter fail");
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else {
+      iter = new (buf) Iterator<BtreeIterator>();
+    }
+  }
+  if (OB_SUCC(ret)) {
     ObStoreRowkeyWrapper scan_start_key_wrapper(start_key->get_rowkey());
     ObStoreRowkeyWrapper scan_end_key_wrapper(end_key->get_rowkey());
     iter->reset();
@@ -333,8 +341,11 @@ int ObQueryEngine::scan(const ObMemtableKey *start_key,
 
 void ObQueryEngine::revert_iter(ObIQueryEngineIterator *iter)
 {
-  iter_alloc_.free((Iterator<BtreeIterator> *)iter);
-  iter = NULL;
+  if (OB_NOT_NULL(iter)) {
+    auto *typed = static_cast<Iterator<BtreeIterator> *>(iter);
+    typed->~Iterator();
+    btree_iter_free(typed);
+  }
 }
 
 int ObQueryEngine::sample_rows(Iterator<BtreeRawIterator> *iter,
@@ -426,10 +437,16 @@ int ObQueryEngine::init_raw_iter_for_estimate(Iterator<BtreeRawIterator>*& iter,
   if (IS_NOT_INIT) {
     TRANS_LOG(WARN, "not init", "this", this);
     ret = OB_NOT_INIT;
-  } else if (OB_ISNULL(iter = raw_iter_alloc_.alloc())) {
-    TRANS_LOG(WARN, "alloc raw iter fail");
-    ret = OB_ALLOCATE_MEMORY_FAILED;
   } else {
+    void *buf = ob_malloc(sizeof(Iterator<BtreeRawIterator>), ObMemAttr(OB_SYS_TENANT_ID, "BtreeRawIter"));
+    if (OB_ISNULL(buf)) {
+      TRANS_LOG(WARN, "alloc raw iter fail");
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else {
+      iter = new (buf) Iterator<BtreeRawIterator>();
+    }
+  }
+  if (OB_SUCC(ret)) {
     ObStoreRowkeyWrapper start_key_wrapper(start_key->get_rowkey());
     ObStoreRowkeyWrapper end_key_wrapper(end_key->get_rowkey());
     iter->reset();
@@ -523,8 +540,8 @@ int ObQueryEngine::split_range(const ObMemtableKey *start_key,
       }
 
       if (OB_NOT_NULL(iter)) {
-        iter->reset();
-        raw_iter_alloc_.free(iter);
+        iter->~Iterator();
+        ob_free(iter);
         iter = NULL;
       }
     } while (OB_SUCC(ret) && need_retry);
@@ -570,8 +587,8 @@ int ObQueryEngine::inner_loop_find_level_(const ObMemtableKey *start_key,
       }
     }
     if (OB_NOT_NULL(iter)) {
-      iter->reset();
-      raw_iter_alloc_.free(iter);
+      iter->~Iterator();
+      ob_free(iter);
       iter = NULL;
     }
   }
@@ -658,9 +675,16 @@ int ObQueryEngine::estimate_row_count(const transaction::ObTransID &tx_id,
   } else if (OB_ISNULL(start_key) || OB_ISNULL(end_key)) {
     ret = OB_INVALID_ARGUMENT;
     TRANS_LOG(WARN, "invalid param", KR(ret));
-  } else if (OB_ISNULL((iter = raw_iter_alloc_.alloc()))) {
-    TRANS_LOG(WARN, "alloc raw iter fail");
-    ret = OB_ALLOCATE_MEMORY_FAILED;
+  } else {
+    void *buf = ob_malloc(sizeof(Iterator<BtreeRawIterator>), ObMemAttr(OB_SYS_TENANT_ID, "BtreeRawIter"));
+    if (OB_ISNULL(buf)) {
+      TRANS_LOG(WARN, "alloc raw iter fail");
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else {
+      iter = new (buf) Iterator<BtreeRawIterator>();
+    }
+  }
+  if (OB_FAIL(ret)) {
   } else if (OB_FAIL(sample_rows(iter, end_key, end_exclude, start_key, start_exclude, tx_id,
       log_row_count1, phy_row_count1, ratio1))) {
     if (OB_ITER_END != ret) {
@@ -696,7 +720,8 @@ int ObQueryEngine::estimate_row_count(const transaction::ObTransID &tx_id,
     }
   }
   if (OB_NOT_NULL(iter)) {
-    raw_iter_alloc_.free(iter);
+    iter->~Iterator();
+    ob_free(iter);
     iter = NULL;
   }
   ret = OB_ITER_END == ret ? OB_SUCCESS : ret;

--- a/src/storage/memtable/mvcc/ob_query_engine.h
+++ b/src/storage/memtable/mvcc/ob_query_engine.h
@@ -19,7 +19,6 @@
 
 #include "lib/container/ob_iarray.h"
 #include "lib/oblog/ob_log_module.h"
-#include "lib/objectpool/ob_concurrency_objpool.h"
 #include "storage/memtable/mvcc/ob_keybtree.h"
 #include "storage/memtable/ob_memtable_key.h"
 #include "storage/memtable/ob_mt_hash.h"
@@ -132,18 +131,6 @@ public:
     ObMvccRow *value_;
   };
 
-  template <typename BtreeIterator>
-  class IteratorAlloc
-  {
-  public:
-    IteratorAlloc() {}
-    ~IteratorAlloc() {}
-    Iterator<BtreeIterator> *alloc() { return op_reclaim_alloc(Iterator<BtreeIterator>); }
-    void free(Iterator<BtreeIterator> *iter) { op_reclaim_free(iter); }
-  private:
-    DISALLOW_COPY_AND_ASSIGN(IteratorAlloc);
-  };
-
 public:
   enum {
     MAX_SAMPLE_ROW_COUNT = 500,
@@ -253,9 +240,6 @@ private:
   KeyBtree keybtree_;
   // The hashtable optimized for fast point select
   KeyHash keyhash_;
-  // Iterator allocator for read and estimation
-  IteratorAlloc<BtreeIterator> iter_alloc_;
-  IteratorAlloc<BtreeRawIterator> raw_iter_alloc_;
 };
 
 } // namespace memtable


### PR DESCRIPTION
## Task Description
Replace the global object pool used for allocating memtable range scan iterators (`Iterator<BtreeIterator>`, ~5KB each) with a session-level caching mechanism. The global pool, allocated from the 500 tenant memory, was not observable, never shrank, and did not release memory when idle.

## Solution Description
Introduced a two-path dispatch mechanism to replace the global object pool:
- **Foreground SQL**: Obtains the session via `THIS_WORKER.get_session` and uses a session-level free list (`ObBtreeIterCache`) to cache iterators. Iterators are reused across SQL statements within the same session (zero allocation after prewarm). All memory is released when the session disconnects.
- **Background merge/row estimation**: Session is `nullptr`, uses direct `ob_malloc`/`ob_free`. Memory is released immediately upon task completion.
- **Thread safety**: Only one worker thread executes per session at any given time (PX workers have independent deserialized sessions), so the free list requires no locking.

## Passed Regressions
- `test_query_engine`: PASSED (1/1)
- `test_mvcc_callback`: PASSED (19/19)
- Functional verification: All passed for range scans, point queries, multi-range, scans after DML, transaction scans, reverse scans, LIMIT, scans after freeze+merge, cross-layer scans, concurrent 10 connections, and PX PARALLEL(4).
- sysbench `oltp_read_only` 4 threads 30s: TPS=278, QPS=4444, zero errors.
- sysbench `oltp_point_select` 4 threads 30s: TPS=3519, QPS=3519, zero errors.
- Memory verification: `BtreeIterCache` fully releases after session disconnect, `BtreeIter` is freed immediately after merge completion, and the old `Iterator<BtreeI` tag is completely gone.

## Upgrade Compatibility
No impact on upgrades. This is a pure internal memory management change with no persistent format modifications.

## Other Information
All btree iterator-related memory returns to zero when idle, resolving the issue of permanent peak memory occupancy by the global pool.

Performance Regression:
```
┌──────────────────────┬─────────────┬─────────────┬────────┐
│ Scenario            │ master      │ Current     │ Change │
├──────────────────────┼─────────────┼─────────────┼────────┤
│ point_select        │ 112,973 qps │ 117,432 qps │ +3.9%  │
├──────────────────────┼─────────────┼─────────────┼────────┤
│ oltp_read_write     │ 2,291 tps   │ 2,229 tps   │ -2.7%  │
├──────────────────────┼─────────────┼─────────────┼────────┤
│ select_random_ranges│ 44,357 qps  │ 52,333 qps  │ +18.0% │
└──────────────────────┴─────────────┴─────────────┴────────┘
```
Performance data only confirms no regression.

## Release Note
