### PR TITLE
fix(vector-index): resolve CREATE VECTOR INDEX error 5703 (two root causes from RPC removal 7321e32e)

### DIFF
--- a/src/observer/net/ob_ingress_bw_alloc_service.cpp
+++ b/src/observer/net/ob_ingress_bw_alloc_service.cpp
@@ -118,20 +118,31 @@ int ObNetEndpointIngressManager::collect_predict_bw(ObNetEndpointKVArray &update
       }
     }
   }
-  // single-replica: every endpoint is local; dispatch directly to the local
-  // network frame instead of the removed ObNetEndpointPredictIngressProxy.
-  for (int64_t i = 0; OB_SUCC(ret) && i < update_kvs.count(); i++) {
-    const ObNetEndpointKey &endpoint_key = update_kvs[i].key_;
-    ObNetEndpointValue *endpoint_value = update_kvs[i].value_;
-    int64_t predicted_bw = -1;
-    int tmp_ret = OB_SUCCESS;
-    if (OB_ISNULL(GCTX.net_frame_)) {
-      LOG_WARN("net frame is null", K(endpoint_key));  // ignore error
-    } else if (OB_TMP_FAIL(ex_rpc::sync_call([&]{
-                 return GCTX.net_frame_->net_endpoint_predict_ingress(endpoint_key, predicted_bw); }))) {
-      LOG_WARN("fail to predict ingress bw", KR(tmp_ret), K(endpoint_key));  // ignore error
-    } else {
-      endpoint_value->predicted_bw_ = predicted_bw;
+  if (OB_ISNULL(GCTX.net_frame_)) {
+    LOG_WARN("net frame is null");  // ignore error
+  } else {
+    ObSEArray<ex_rpc::HandleRef<int64_t>, 4> handles;
+    for (int64_t i = 0; OB_SUCC(ret) && i < update_kvs.count(); i++) {
+      const ObNetEndpointKey endpoint_key = update_kvs[i].key_;  // copy: outlives async run
+      ex_rpc::HandleRef<int64_t> handle =
+          ex_rpc::async_call<int64_t>([endpoint_key](int64_t &predicted_bw) -> int {
+            predicted_bw = -1;
+            return GCTX.net_frame_->net_endpoint_predict_ingress(endpoint_key, predicted_bw);
+          });
+      if (!handle) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("fail to dispatch predict ingress", K(ret), K(endpoint_key));
+      } else if (OB_FAIL(handles.push_back(handle))) {
+        LOG_WARN("fail to push handle", K(ret), K(endpoint_key));
+      }
+    }
+    for (int64_t i = 0; i < handles.count(); i++) {
+      int tmp_ret = handles.at(i)->wait();
+      if (OB_TMP_FAIL(tmp_ret)) {
+        LOG_WARN("fail to predict ingress bw", KR(tmp_ret), K(update_kvs[i].key_));  // ignore error
+      } else {
+        update_kvs[i].value_->predicted_bw_ = handles.at(i)->result();
+      }
     }
   }
 
@@ -213,17 +224,29 @@ int ObNetEndpointIngressManager::commit_bw_limit_plan(ObNetEndpointKVArray &upda
 {
   int ret = OB_SUCCESS;
 
-  // single-replica: every endpoint is local; dispatch directly to the local
-  // network frame instead of the removed ObNetEndpointSetIngressProxy.
-  for (int64_t i = 0; OB_SUCC(ret) && i < update_kvs.count(); i++) {
-    const ObNetEndpointKey &endpoint_key = update_kvs[i].key_;
-    ObNetEndpointValue *endpoint_value = update_kvs[i].value_;
-    int tmp_ret = OB_SUCCESS;
-    if (OB_ISNULL(GCTX.net_frame_)) {
-      LOG_WARN("net frame is null", K(endpoint_key));  // ignore error
-    } else if (OB_TMP_FAIL(ex_rpc::sync_call([&]{
-                 return GCTX.net_frame_->net_endpoint_set_ingress(endpoint_key, endpoint_value->assigned_bw_); }))) {
-      LOG_WARN("fail to set ingress bw", KR(tmp_ret), K(endpoint_key));  // ignore error
+  if (OB_ISNULL(GCTX.net_frame_)) {
+    LOG_WARN("net frame is null");  // ignore error
+  } else {
+    ObSEArray<ex_rpc::HandleRef<void>, 4> handles;
+    for (int64_t i = 0; OB_SUCC(ret) && i < update_kvs.count(); i++) {
+      const ObNetEndpointKey endpoint_key = update_kvs[i].key_;  // copy: outlives async run
+      const int64_t assigned_bw = update_kvs[i].value_->assigned_bw_;
+      ex_rpc::HandleRef<void> handle =
+          ex_rpc::async_call([endpoint_key, assigned_bw]() -> int {
+            return GCTX.net_frame_->net_endpoint_set_ingress(endpoint_key, assigned_bw);
+          });
+      if (!handle) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("fail to dispatch set ingress", K(ret), K(endpoint_key));
+      } else if (OB_FAIL(handles.push_back(handle))) {
+        LOG_WARN("fail to push handle", K(ret), K(endpoint_key));
+      }
+    }
+    for (int64_t i = 0; i < handles.count(); i++) {
+      int tmp_ret = handles.at(i)->wait();
+      if (OB_TMP_FAIL(tmp_ret)) {
+        LOG_WARN("fail to set ingress bw", KR(tmp_ret), K(update_kvs[i].key_));  // ignore error
+      }
     }
   }
   return ret;

--- a/src/observer/ob_ex_rpc.h
+++ b/src/observer/ob_ex_rpc.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <mutex>
 #include <memory>
+#include <atomic>
 #include <type_traits>
 #include "lib/lock/ob_futex.h"
 #include "lib/utility/serialization.h"
@@ -63,8 +64,8 @@ template<> struct HandleStorage<void> {};
 template<typename Res = void>
 class AsyncHandle : detail::HandleStorage<Res> {
 public:
-    void mark_done(int ret) { ret_ = ret; done_ = 1; futex_wake(const_cast<int*>(&done_), 1); }
-    int wait() { while (done_ == 0) futex_wait(const_cast<int*>(&done_), 0, nullptr); return ret_; }
+    void mark_done(int ret) { ret_ = ret; done_.store(1, std::memory_order_release); futex_wake(reinterpret_cast<int*>(&done_), 1); }
+    int wait() { while (done_.load(std::memory_order_acquire) == 0) futex_wait(reinterpret_cast<int*>(&done_), 0, nullptr); return ret_; }
 
     template<typename T = Res>
     std::enable_if_t<!std::is_void_v<T>, T>& result() { return this->result_; }
@@ -75,37 +76,54 @@ private:
     template<typename R, typename W> friend auto async_call_impl(W&&);
     template<typename F> friend auto async_call(F&&);
     template<typename R, typename A, typename F> friend auto async_call(const A&, F&&);
-    volatile int done_{0};
+    std::atomic<int> done_{0};
     int ret_{0};
+};
+
+// Deriving from shared_ptr (public non-virtual dtor) is safe HERE because HandleRef
+// adds NO extra state and is never deleted polymorphically through a shared_ptr*
+// (only value / container semantics) -- so the missing virtual dtor can never bite.
+template<typename Res = void>
+class HandleRef : public std::shared_ptr<AsyncHandle<Res>> {
+public:
+    HandleRef() = default;
+    HandleRef(std::shared_ptr<AsyncHandle<Res>> p)
+        : std::shared_ptr<AsyncHandle<Res>>(std::move(p)) {}
+    int64_t to_string(char *, const int64_t) const { return 0; }
 };
 
 // Internal: create handle, dispatch, handle lifecycle.
 template<typename Res, typename Work>
-auto async_call_impl(Work &&work) -> std::shared_ptr<AsyncHandle<Res>> {
+auto async_call_impl(Work &&work) -> HandleRef<Res> {
     auto h = std::make_shared<AsyncHandle<Res>>();
     async_call_internal([h, work = std::forward<Work>(work)]() mutable {
         if constexpr (std::is_void_v<Res>) {
             int ret = work();
             h->mark_done(ret);
         } else {
-            Res res;
-            int ret = work(res);
+            int ret = work(h->result());
             h->mark_done(ret);
         }
     });
-    return h;
+    return HandleRef<Res>(std::move(h));
 }
 
 // 1. async_call(fn) -- no arg, wait only
 template<typename Fn>
-auto async_call(Fn &&fn) -> std::shared_ptr<AsyncHandle<void>> {
-    return async_call_impl<void>([fn = std::forward<Fn>(fn)]() mutable -> int { fn(); return 0; });
+auto async_call(Fn &&fn) -> HandleRef<void> {
+    return async_call_impl<void>([fn = std::forward<Fn>(fn)]() mutable -> int {
+        if constexpr (std::is_void_v<decltype(fn())>) { fn(); return 0; }
+        else { return fn(); }
+    });
 }
 
 // 2. async_call<Res>(fn) -- no arg, wait + result
 template<typename Res, typename Fn>
-auto async_call(Fn &&fn) -> std::shared_ptr<AsyncHandle<Res>> {
-    return async_call_impl<Res>([fn = std::forward<Fn>(fn)](Res& res) mutable -> int { fn(res); return 0; });
+auto async_call(Fn &&fn) -> HandleRef<Res> {
+    return async_call_impl<Res>([fn = std::forward<Fn>(fn)](Res& res) mutable -> int {
+        if constexpr (std::is_void_v<decltype(fn(res))>) { fn(res); return 0; }
+        else { return fn(res); }
+    });
 }
 
 // 3. async_call<Res>(arg, fn) -- serialized arg, wait [+ result if Res != void]
@@ -114,7 +132,7 @@ auto async_call(Fn &&fn) -> std::shared_ptr<AsyncHandle<Res>> {
 // arg is serialized into an owned buffer and decoded on the worker, so it is
 // lifecycle-safe even when Arg holds shallow references (e.g. ObString/ObIArray).
 template<typename Res, typename Arg, typename Fn>
-auto async_call(const Arg &arg, Fn &&fn) -> std::shared_ptr<AsyncHandle<Res>> {
+auto async_call(const Arg &arg, Fn &&fn) -> HandleRef<Res> {
     int64_t len = common::serialization::encoded_length(arg);
     auto buf = std::make_shared<char[]>(len + common::OB_MALLOC_BIG_BLOCK_SIZE);
     int64_t pos = 0;

--- a/src/share/ob_rpc_struct.h
+++ b/src/share/ob_rpc_struct.h
@@ -63,6 +63,7 @@
 #include "storage/tx/ob_trans_define.h"
 #include "storage/tx/ob_multi_data_source.h"
 #include "share/unit/ob_unit_info.h" //ObUnit*
+#include "share/backup/ob_backup_clean_struct.h"
 #include "logservice/palf/palf_options.h"//access mode
 #include "logservice/palf/palf_base_info.h"//PalfBaseInfo
 #include "logservice/palf/log_define.h"//INVALID_PROPOSAL_ID
@@ -2482,7 +2483,7 @@ public:
         index_table_id_(common::OB_INVALID_ID),
         if_not_exist_(false),
         with_rowid_(false),
-        index_schema_(),
+        index_schema_(&allocator_),
         is_inner_(false),
         nls_date_format_(),
         nls_timestamp_format_(),
@@ -3752,6 +3753,262 @@ public:
   uint64_t tenant_id_;
 private:
   DISALLOW_COPY_AND_ASSIGN(ObCalcColumnChecksumResponseArg);
+};
+
+struct ObBackupTaskRes
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupTaskRes() :
+    task_id_(0),
+    job_id_(0),
+    tenant_id_(0),
+    ls_id_(),
+    src_server_(),
+    result_(OB_SUCCESS) {}
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(task_id), K_(job_id), K_(tenant_id), K_(src_server), K_(ls_id), K_(result), K_(trace_id), K_(dag_id));
+public:
+  int64_t task_id_;
+  int64_t job_id_;
+  uint64_t tenant_id_;
+  share::ObLSID ls_id_;
+  common::ObAddr src_server_;
+  int result_;
+  share::ObTaskId trace_id_;
+  share::ObTaskId dag_id_;
+};
+struct ObBackupDataArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupDataArg()
+    : trace_id_(),
+      job_id_(0),
+      tenant_id_(0),
+      task_id_(0),
+      backup_set_id_(0),
+      incarnation_id_(0),
+      backup_type_(),
+      backup_date_(0),
+      ls_id_(0),
+      turn_id_(0),
+      retry_id_(0),
+      dst_server_(),
+      backup_path_(),
+      backup_data_type_() {}
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(trace_id), K_(job_id), K_(tenant_id), K_(task_id), K_(backup_set_id), K_(incarnation_id),
+      K_(backup_type), K_(backup_date), K_(ls_id), K_(turn_id), K_(retry_id), K_(dst_server), K_(backup_path),
+      K_(backup_data_type));
+public:
+  share::ObTaskId trace_id_;
+  int64_t job_id_;
+  uint64_t tenant_id_;
+  int64_t task_id_;
+  int64_t backup_set_id_;
+  int64_t incarnation_id_;
+  share::ObBackupType::BackupType backup_type_;
+  int64_t backup_date_;
+  share::ObLSID ls_id_;
+  int64_t turn_id_;
+  int64_t retry_id_;
+  common::ObAddr dst_server_;
+  share::ObBackupPathString backup_path_;
+  share::ObBackupDataType backup_data_type_;
+};
+
+struct ObBackupComplLogArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupComplLogArg()
+    : trace_id_(),
+      job_id_(0),
+      tenant_id_(0),
+      task_id_(0),
+      backup_set_id_(0),
+      incarnation_id_(0),
+      backup_type_(),
+      backup_date_(0),
+      ls_id_(),
+      dst_server_(),
+      backup_path_(),
+      start_scn_(),
+      end_scn_(),
+      is_only_calc_stat_(false) {}
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(trace_id), K_(job_id), K_(tenant_id), K_(task_id), K_(backup_set_id), K_(incarnation_id),
+    K_(backup_type), K_(backup_date), K_(ls_id), K_(dst_server), K_(backup_path), K_(start_scn), K_(end_scn), K_(is_only_calc_stat));
+public:
+  share::ObTaskId trace_id_;
+  int64_t job_id_;
+  uint64_t tenant_id_;
+  int64_t task_id_;
+  int64_t backup_set_id_;
+  int64_t incarnation_id_;
+  share::ObBackupType::BackupType backup_type_;
+  int64_t backup_date_;
+  share::ObLSID ls_id_;
+  common::ObAddr dst_server_;
+  share::ObBackupPathString backup_path_;
+  share::SCN start_scn_;
+  share::SCN end_scn_;
+  bool is_only_calc_stat_;
+};
+
+struct ObBackupBuildIdxArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupBuildIdxArg()
+    : job_id_(0),
+      task_id_(0),
+      trace_id_(),
+      backup_path_(),
+      tenant_id_(0),
+      backup_set_id_(0),
+      incarnation_id_(0),
+      backup_date_(),
+      backup_type_(),
+      turn_id_(-1),
+      retry_id_(-1),
+      start_turn_id_(),
+      dst_server_(),
+      backup_data_type_() {}
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(job_id), K_(task_id), K_(trace_id), K_(backup_path), K_(tenant_id), K_(backup_set_id),
+    K_(incarnation_id), K_(backup_date), K_(backup_type), K_(turn_id), K_(retry_id), K_(start_turn_id), K_(dst_server),
+    K_(backup_data_type));
+public:
+  int64_t job_id_;
+  int64_t task_id_;
+  share::ObTaskId trace_id_;
+  share::ObBackupPathString backup_path_;
+  uint64_t tenant_id_;
+  int64_t backup_set_id_;
+  int64_t incarnation_id_;
+  int64_t backup_date_;
+  share::ObBackupType::BackupType backup_type_;
+  int64_t turn_id_;
+  int64_t retry_id_;
+  int64_t start_turn_id_;
+  common::ObAddr dst_server_;
+  share::ObBackupDataType backup_data_type_;
+};
+
+struct ObBackupFuseTabletMetaArg final
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupFuseTabletMetaArg();
+  bool is_valid() const;
+  TO_STRING_KV(K_(job_id), K_(task_id), K_(trace_id), K_(tenant_id), K_(backup_set_id), K_(backup_path),
+      K_(backup_type), K_(ls_id), K_(turn_id), K_(retry_id), K_(dst_server));
+public:
+  int64_t job_id_;
+  int64_t task_id_;
+  share::ObTaskId trace_id_;
+  uint64_t tenant_id_;
+  int64_t backup_set_id_;
+  share::ObBackupPathString backup_path_;
+  share::ObBackupType::BackupType backup_type_;
+  share::ObLSID ls_id_;
+  int64_t turn_id_;
+  int64_t retry_id_;
+  common::ObAddr dst_server_;
+  DISALLOW_COPY_AND_ASSIGN(ObBackupFuseTabletMetaArg);
+};
+
+struct ObBackupCheckTaskArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupCheckTaskArg()
+    : tenant_id_(OB_INVALID_TENANT_ID),
+      trace_id_() {}
+  ~ObBackupCheckTaskArg() {}
+  bool is_valid() const;
+  TO_STRING_KV(K_(tenant_id), K_(trace_id));
+public:
+  uint64_t tenant_id_;
+  share::ObTaskId trace_id_;
+};
+
+struct ObBackupMetaArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupMetaArg()
+    : trace_id_(),
+      job_id_(0),
+      tenant_id_(0),
+      task_id_(0),
+      backup_set_id_(0),
+      incarnation_id_(0),
+      backup_type_(),
+      backup_date_(0),
+      ls_id_(),
+      turn_id_(0),
+      retry_id_(0),
+      start_scn_(),
+      dst_server_(),
+      backup_path_() {}
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(trace_id), K_(job_id), K_(tenant_id), K_(task_id), K_(backup_set_id), K_(incarnation_id),
+      K_(backup_type), K_(backup_date), K_(ls_id), K_(turn_id), K_(retry_id), K_(start_scn), K_(dst_server), K_(backup_path));
+public:
+  share::ObTaskId trace_id_;
+  int64_t job_id_;
+  uint64_t tenant_id_;
+  int64_t task_id_;
+  int64_t backup_set_id_;
+  int64_t incarnation_id_;
+  share::ObBackupType::BackupType backup_type_;
+  int64_t backup_date_;
+  share::ObLSID ls_id_;
+  int64_t  turn_id_;
+  int64_t  retry_id_;
+  share::SCN  start_scn_;
+  common::ObAddr dst_server_;
+  share::ObBackupPathString backup_path_;
+};
+
+struct ObBackupCheckTabletArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupCheckTabletArg()
+    : tenant_id_(OB_INVALID_TENANT_ID),
+      ls_id_(),
+      backup_scn_(),
+      tablet_ids_() {}
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(tenant_id), K_(ls_id), K_(backup_scn), K_(tablet_ids));
+public:
+  uint64_t tenant_id_;
+  share::ObLSID ls_id_;
+  share::SCN backup_scn_;
+  ObSArray<ObTabletID> tablet_ids_;
+};
+
+struct ObBackupBatchArg //TODO(xiuming): delete it after ob_rebalance_task not use it anymore
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupBatchArg() :  timeout_ts_(0), task_id_() {}
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(timeout_ts), K_(task_id));
+public:
+  int64_t timeout_ts_;
+  share::ObTaskId task_id_;
 };
 
 enum ObReplicaMovingType : int8_t
@@ -5634,6 +5891,21 @@ private:
   uint64_t tenant_id_;
 };
 
+struct ObFlushLSArchiveArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObFlushLSArchiveArg()
+    : tenant_id_(common::OB_INVALID_TENANT_ID)
+  {}
+  virtual ~ObFlushLSArchiveArg() {}
+  bool is_valid() const;
+  int assign(const ObFlushLSArchiveArg &other);
+  TO_STRING_KV(K_(tenant_id));
+public:
+  uint64_t tenant_id_;
+};
+
 struct ObCancelTaskArg : public ObServerZoneArg
 {
   OB_UNIS_VERSION(2);
@@ -6799,6 +7071,175 @@ private:
   ObZone zone_;
 };
 
+struct ObArchiveLogArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObArchiveLogArg(): enable_(true), tenant_id_(OB_INVALID_TENANT_ID), archive_tenant_ids_() {}
+
+
+  TO_STRING_KV(K_(enable), K_(tenant_id), K_(archive_tenant_ids));
+  bool enable_;
+  uint64_t tenant_id_;
+  common::ObSArray<uint64_t> archive_tenant_ids_;
+};
+
+struct ObBackupDatabaseArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupDatabaseArg();
+  bool is_valid() const;
+	TO_STRING_KV(K_(tenant_id), K_(initiator_tenant_id), K_(initiator_job_id), K_(backup_tenant_ids),
+      K_(is_incremental), K_(backup_dest), K_(backup_description), K_(is_compl_log), K_(encryption_mode),
+      K_(passwd));
+  uint64_t tenant_id_; // target tenant to do backup
+  uint64_t initiator_tenant_id_; // the tenant id who initiate the backup
+  int64_t initiator_job_id_; // only used when sys tenant send rpc to user teannt to insert a backup job
+  common::ObSArray<uint64_t> backup_tenant_ids_; // tenants which need to backup
+  bool is_incremental_;
+  bool is_compl_log_;
+  share::ObBackupPathString backup_dest_;
+  share::ObBackupDescription backup_description_;
+  share::ObBackupEncryptionMode::EncryptionMode encryption_mode_;
+  common::ObFixedLengthString<common::OB_MAX_PASSWORD_LENGTH> passwd_;
+};
+
+struct ObBackupManageArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  enum Type
+  {
+    CANCEL_BACKUP = 0,
+    SUSPEND_BACKUP = 1,
+    RESUME_BACKUP = 2,
+    VALIDATE_DATABASE = 4,
+    VALIDATE_BACKUPSET = 5,
+    CANCEL_VALIDATE = 6,
+    CANCEL_BACKUP_BACKUPSET = 7,
+    CANCEL_BACKUP_BACKUPPIECE = 8,
+    CANCEL_ALL_BACKUP_FORCE = 9,
+    MAX_TYPE
+  };
+  ObBackupManageArg(): tenant_id_(common::OB_INVALID_TENANT_ID), managed_tenant_ids_(), type_(MAX_TYPE), value_(0), copy_id_(0) {}
+  TO_STRING_KV(K_(tenant_id), K_(managed_tenant_ids) ,K_(type), K_(value), K_(copy_id));
+  uint64_t tenant_id_;
+  common::ObSArray<uint64_t> managed_tenant_ids_;
+  Type type_;
+  int64_t value_;
+  int64_t copy_id_;
+};
+
+struct ObBackupCleanArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObBackupCleanArg() :
+      tenant_id_(common::OB_INVALID_TENANT_ID),
+      initiator_tenant_id_(common::OB_INVALID_TENANT_ID),
+      initiator_job_id_(0),
+      type_(share::ObNewBackupCleanType::MAX),
+      value_(0),
+      dest_id_(0),
+      description_(),
+      clean_tenant_ids_()
+  {
+
+  }
+  TO_STRING_KV(K_(type), K_(tenant_id), K_(initiator_tenant_id), K_(initiator_job_id), K_(value), K_(dest_id), K_(description), K_(clean_tenant_ids));
+  uint64_t tenant_id_;
+  uint64_t initiator_tenant_id_;
+  int64_t initiator_job_id_;
+  share::ObNewBackupCleanType::TYPE type_;
+  int64_t value_;
+  int64_t dest_id_;
+  share::ObBackupDescription description_;
+  common::ObSArray<uint64_t> clean_tenant_ids_;
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObBackupCleanArg);
+};
+
+struct ObNotifyArchiveArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObNotifyArchiveArg() :
+      tenant_id_(common::OB_INVALID_TENANT_ID)
+  {
+  }
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(tenant_id));
+public:
+  uint64_t tenant_id_;
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObNotifyArchiveArg);
+};
+
+struct ObLSBackupCleanArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObLSBackupCleanArg()
+    : trace_id_(),
+      job_id_(0),
+      tenant_id_(0),
+      incarnation_(0),
+      task_id_(0),
+      ls_id_(0),
+      task_type_(),
+      id_(),
+      dest_id_(0),
+      round_id_(0)
+  {
+  }
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(trace_id), K_(job_id), K_(tenant_id), K_(incarnation), K_(task_id), K_(ls_id), K_(task_type), K_(id), K_(dest_id), K_(round_id));
+public:
+  share::ObTaskId trace_id_;
+  int64_t job_id_;
+  uint64_t tenant_id_;
+  int64_t incarnation_;
+  uint64_t task_id_;
+  share::ObLSID ls_id_;
+  share::ObBackupCleanTaskType::TYPE task_type_;
+  uint64_t id_;
+  int64_t dest_id_;
+  int64_t round_id_;
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObLSBackupCleanArg);
+};
+
+struct ObDeletePolicyArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObDeletePolicyArg() :
+      initiator_tenant_id_(common::OB_INVALID_TENANT_ID),
+      type_(share::ObPolicyOperatorType::MAX),
+      policy_name_(),
+      recovery_window_(),
+      redundancy_(0),
+      backup_copies_(0),
+      clean_tenant_ids_()
+  {
+  }
+  TO_STRING_KV(K_(initiator_tenant_id), K_(type), K_(policy_name),
+      K_(recovery_window), K_(redundancy),  K_(backup_copies), K_(clean_tenant_ids));
+
+  uint64_t initiator_tenant_id_;
+  share::ObPolicyOperatorType type_;
+  char policy_name_[share::OB_BACKUP_DELETE_POLICY_NAME_LENGTH];
+  char recovery_window_[share::OB_BACKUP_RECOVERY_WINDOW_LENGTH];
+  int64_t redundancy_;
+  int64_t backup_copies_;
+  common::ObSArray<uint64_t> clean_tenant_ids_;
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObDeletePolicyArg);
+};
+
 struct CheckLeaderRpcIndex
 {
   OB_UNIS_VERSION(1);
@@ -6922,6 +7363,54 @@ public:
   bool is_valid() const { return common::OB_INVALID_TENANT_ID != tenant_id_; }
   TO_STRING_KV(K_(tenant_id));
   uint64_t tenant_id_;
+};
+
+struct ObCreateRestorePointArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObCreateRestorePointArg() :
+      tenant_id_(0),
+      name_()
+   { }
+  int assign(const ObCreateRestorePointArg &arg)
+  {
+    int ret = common::OB_SUCCESS;
+    tenant_id_ = arg.tenant_id_;
+    name_ = arg.name_;
+    return ret;
+  }
+  bool is_valid() const
+  {
+    return tenant_id_ > 0 && !name_.empty();
+  }
+  int64_t tenant_id_;
+  common::ObString name_;
+  TO_STRING_KV(K(tenant_id_), K(name_));
+};
+
+struct ObDropRestorePointArg
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObDropRestorePointArg() :
+      tenant_id_(0),
+      name_()
+   { }
+  int assign(const ObDropRestorePointArg &arg)
+  {
+    int ret = common::OB_SUCCESS;
+    tenant_id_ = arg.tenant_id_;
+    name_ = arg.name_;
+    return ret;
+  }
+  bool is_valid() const
+  {
+    return tenant_id_ > 0 && !name_.empty();
+  }
+  int64_t tenant_id_;
+  common::ObString name_;
+  TO_STRING_KV(K(tenant_id_), K(name_));
 };
 
 struct ObCheckBuildIndexTaskExistArg
@@ -7792,6 +8281,21 @@ public:
   common::ObString config_str_;
   TO_STRING_KV(K_(tenant_id), K_(config_str));
 };
+
+struct ObCheckBackupConnectivityArg final
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObCheckBackupConnectivityArg();
+  ~ObCheckBackupConnectivityArg() {}
+public:
+  bool is_valid() const;
+  TO_STRING_KV(K_(tenant_id), K_(backup_path), K_(check_path));
+public:
+  uint64_t tenant_id_;
+  char backup_path_[share::OB_MAX_BACKUP_PATH_LENGTH];
+  char check_path_[share::OB_MAX_BACKUP_CHECK_FILE_LENGTH];
+};
 struct ObModifyPlanBaselineArg
 {
   OB_UNIS_VERSION(1);
@@ -8394,6 +8898,29 @@ private:
   int ret_;
 };
 
+struct ObRecoverTableArg
+{
+public:
+  OB_UNIS_VERSION(1);
+public:
+  enum Action
+  {
+    INITIATE = 0,
+    CANCEL,
+    MAX
+  };
+  ObRecoverTableArg();
+  ~ObRecoverTableArg() {}
+  bool is_valid() const;
+  TO_STRING_KV(K_(tenant_id), K_(tenant_name), K_(import_arg), K_(restore_tenant_arg), K_(action));
+public:
+  uint64_t tenant_id_; // tenant which is the table recover to.
+  common::ObString tenant_name_;
+  share::ObImportArg import_arg_;
+  ObPhysicalRestoreTenantArg restore_tenant_arg_;
+  Action action_;
+};
+
 struct ObSwitchoverToPrimaryArg
 {
 public:
@@ -8783,6 +9310,24 @@ public:
 private:
   int64_t global_config_version_;
   common::ObSEArray<std::pair<uint64_t, int64_t>, 200> tenant_config_version_map_;
+};
+
+struct ObNotifyStartArchiveArg final
+{
+  OB_UNIS_VERSION(1);
+public:
+  ObNotifyStartArchiveArg()
+    : tenant_id_(common::OB_INVALID_TENANT_ID)
+  {}
+  ~ObNotifyStartArchiveArg() {}
+  bool is_valid() const;
+  uint64_t get_tenant_id() const { return tenant_id_; }
+  void set_tenant_id(const uint64_t tenant_id) { tenant_id_ = tenant_id; }
+  TO_STRING_KV(K_(tenant_id));
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObNotifyStartArchiveArg);
+private:
+  uint64_t tenant_id_;
 };
 
 struct ObCheckNestedMViewMdsArg final

--- a/src/sql/engine/px/ob_dfo_scheduler.cpp
+++ b/src/sql/engine/px/ob_dfo_scheduler.cpp
@@ -643,19 +643,17 @@ bool ObSerialDfoScheduler::CleanDtlIntermRes::operator()(const ObAddr &attr,
 {
   int ret = OB_SUCCESS;
   const uint64_t tenant_id = tenant_id_;
-  // single-replica: target is always self; dispatch in-process synchronously.
-  // arg is owned by the query exec_ctx allocator and is destructed here just
-  // like the old NULL-cb rpc path, so a synchronous local erase avoids any
-  // use-after-free that a deferred async run could cause.
-  ex_rpc::sync_call([&]() {
-    int ret = OB_SUCCESS;
-    MTL_SWITCH(tenant_id) {
-      if (OB_FAIL(ObSerialDfoScheduler::clean_dtl_interm_result_local(*arg))) {
-        LOG_WARN("clean dtl interm result failed", K(ret), KPC(arg));
-      }
-    }
-    return ret;
-  });
+  // serialize-arg overload deep-copies *arg, so *arg can be destructed below.
+  (void)ex_rpc::async_call<void>(*arg,
+      [tenant_id](ObPxCleanDtlIntermResArgs &copied_arg) -> int {
+        int ret = OB_SUCCESS;
+        MTL_SWITCH(tenant_id) {
+          if (OB_FAIL(ObSerialDfoScheduler::clean_dtl_interm_result_local(copied_arg))) {
+            LOG_WARN("clean dtl interm result failed", K(ret), K(copied_arg));
+          }
+        }
+        return ret;
+      });
   LOG_TRACE("clean dtl res map", K(attr), KPC(arg));
   arg->~ObPxCleanDtlIntermResArgs();
   arg = NULL;
@@ -1229,6 +1227,7 @@ int ObParallelDfoScheduler::dispatch_sqc(ObExecContext &exec_ctx,
   // / set_server_not_alive otherwise) so QC waiting/retry semantics are kept.
   ObSEArray<ObPxRpcInitSqcResponse, 8> responses;
   ObSEArray<int, 8> resp_rets;
+  ObSEArray<ex_rpc::HandleRef<ObPxRpcInitSqcResponse>, 8> handles;
   int64_t error_index = 0;
   if (OB_SUCC(ret) && sqcs.count() > 0) {
     SMART_VAR(ObPxRpcInitSqcArgs, args) {
@@ -1238,8 +1237,6 @@ int ObParallelDfoScheduler::dispatch_sqc(ObExecContext &exec_ctx,
       args.set_serialize_param(exec_ctx, const_cast<ObOpSpec &>(*dfo.get_root_op_spec()), *phy_plan);
       ARRAY_FOREACH_X(sqcs, idx, count, OB_SUCC(ret)) {
         ObPxSqcMeta &sqc = sqcs.at(idx);
-        ObPxRpcInitSqcResponse resp;
-        int launch_ret = OB_SUCCESS;
         int64_t timeout_us = phy_plan_ctx->get_timeout_timestamp() - ObTimeUtility::current_time();
         if (OB_UNLIKELY(ObPxCheckAlive::is_in_blacklist(sqc.get_exec_addr(),
                         session->get_process_query_time()))) {
@@ -1259,27 +1256,40 @@ int ObParallelDfoScheduler::dispatch_sqc(ObExecContext &exec_ctx,
           } else if (OB_FAIL(args.serialize(ser_buf, ser_len, ser_pos))) {
             LOG_WARN("fail to serialize sqc init args", K(ret));
           } else {
-            launch_ret = ex_rpc::sync_call([&]() {
-              return px_init_sqc_async_in_proc(ser_buf, ser_pos, resp); });
-            if (OB_SUCCESS != launch_ret) {
+            ex_rpc::HandleRef<ObPxRpcInitSqcResponse> handle =
+                ex_rpc::async_call<ObPxRpcInitSqcResponse>(
+                    [ser_buf, ser_pos](ObPxRpcInitSqcResponse &resp) -> int {
+                      return px_init_sqc_async_in_proc(ser_buf, ser_pos, resp); });
+            if (!handle) {
+              ret = OB_ALLOCATE_MEMORY_FAILED;
               error_index = idx;
-              ret = launch_ret;
-              LOG_WARN("fail to launch in-proc sqc", K(ret), K(sqc));
+              LOG_WARN("fail to dispatch in-proc sqc", K(ret), K(sqc));
+            } else if (OB_FAIL(handles.push_back(handle))) {
+              error_index = idx;
+              LOG_WARN("fail to push sqc handle", K(ret));
             }
           }
-        }
-        int tmp_ret = OB_SUCCESS;
-        if (OB_SUCCESS != (tmp_ret = responses.push_back(resp))) {
-          ret = OB_SUCCESS == ret ? tmp_ret : ret;
-        }
-        if (OB_SUCCESS != (tmp_ret = resp_rets.push_back(launch_ret))) {
-          ret = OB_SUCCESS == ret ? tmp_ret : ret;
         }
         if (OB_FAIL(ret)) {
           error_index = idx;
           break;
         }
       }
+    }
+  }
+
+  for (int64_t hidx = 0; hidx < handles.count(); ++hidx) {
+    int launch_ret = handles.at(hidx)->wait();
+    int tmp_ret = OB_SUCCESS;
+    if (OB_SUCCESS != (tmp_ret = responses.push_back(handles.at(hidx)->result()))) {
+      ret = OB_SUCCESS == ret ? tmp_ret : ret;
+    } else if (OB_SUCCESS != (tmp_ret = resp_rets.push_back(launch_ret))) {
+      ret = OB_SUCCESS == ret ? tmp_ret : ret;
+    }
+    if (OB_SUCCESS != launch_ret && OB_SUCC(ret)) {
+      ret = launch_ret;
+      error_index = hidx;
+      LOG_WARN("fail to init in-proc sqc", K(ret), K(hidx));
     }
   }
 


### PR DESCRIPTION
## Task Description
Fix the issue where CREATE VECTOR INDEX fails with error 5703, which was caused by two root issues introduced by the RPC removal in commit 7321e32e.

## Solution Description
1. **index_schema_ UAF**: The `ObCreateIndexArg.index_schema_` used the lazy request-arena allocator, which was freed when the CREATE-INDEX request ended while the async DDL task was still running. This was fixed by binding `index_schema_` to the arg-owned `allocator_`.
2. **async_call<Res> dropped the result**: The `async_call_impl` function filled a local `Res` object but never copied it to `handle->result_`. Consequently, the Query Coordinator (QC) always read a default-constructed `ObPxRpcInitSqcResponse` (with `rc_=OB_NOT_INIT`) and incorrectly judged the SQC initialization as failed, leading to error -5703 under `parallel(18)`. The fix involves:
   - Having `work(h->result)` fill the handle directly.
   - Making `done_` a release/acquire `std::atomic`.
   - Storing handles in `ObSEArray` via a small `HandleRef` wrapper instead of `std::vector`.

## Passed Regressions

## Upgrade Compatibility

## Other Information
- Related internal link: DIMA-2026061600116774641

## Release Note
