### PR TITLE
[seekdb][storage] Reduce SHARE_BLOCK resident memory

### DIFF
--- a/src/storage/blockstore/ob_shared_object_reader_writer.cpp
+++ b/src/storage/blockstore/ob_shared_object_reader_writer.cpp
@@ -706,12 +706,51 @@ const char *ObSharedObjectIOCallback::get_data()
 
 //=================================== ObSharedObjectReaderWriter =============================
 const MacroBlockId ObSharedObjectHeader::DEFAULT_MACRO_ID(0, MacroBlockId::AUTONOMIC_BLOCK_INDEX, 0);
+
+struct ObSharedObjectReaderWriter::ObSharedObjectWriteSession final
+{
+public:
+  ObSharedObjectWriteSession()
+    : data_("SHARE_BLOCK", 0, false, false/*use_fixed_blk*/),
+      clean_object_handle_(), clean_offset_(0), clean_align_offset_(0),
+      clean_hanging_(false), has_clean_state_(false)
+  {}
+  ~ObSharedObjectWriteSession() = default;
+
+  void set_clean_state(const ObSharedObjectReaderWriter &writer)
+  {
+    clean_object_handle_ = writer.object_handle_;
+    clean_offset_ = writer.offset_;
+    clean_align_offset_ = writer.align_offset_;
+    clean_hanging_ = writer.hanging_;
+    has_clean_state_ = true;
+  }
+
+  void rollback(ObSharedObjectReaderWriter &writer)
+  {
+    if (has_clean_state_) {
+      writer.object_handle_.reset();
+      writer.object_handle_ = clean_object_handle_;
+      writer.offset_ = clean_offset_;
+      writer.align_offset_ = clean_align_offset_;
+      writer.hanging_ = clean_hanging_;
+    }
+  }
+
+public:
+  ObSelfBufferWriter data_;
+private:
+  ObStorageObjectHandle clean_object_handle_;
+  int64_t clean_offset_;
+  int64_t clean_align_offset_;
+  bool clean_hanging_;
+  bool has_clean_state_;
+};
+
 ObSharedObjectReaderWriter::ObSharedObjectReaderWriter()
-    : mutex_(), data_("SHARE_BLOCK", 0, false, false/*use_fixed_blk*/),
-      object_handle_(), offset_(0), align_offset_(0), write_align_size_(0),
-      hanging_(false), need_align_(false), need_cross_(false),
-      auto_release_data_buffer_(false),
-      is_inited_(false)
+    : mutex_(), object_handle_(), offset_(0), align_offset_(0),
+      write_align_size_(0), hanging_(false), need_align_(false),
+      need_cross_(false), is_inited_(false)
 {}
 
 ObSharedObjectReaderWriter::~ObSharedObjectReaderWriter()
@@ -721,8 +760,7 @@ ObSharedObjectReaderWriter::~ObSharedObjectReaderWriter()
 
 int ObSharedObjectReaderWriter::init(
     const bool need_align,
-    const bool need_cross,
-    const bool auto_release_data_buffer)
+    const bool need_cross)
 {
   int ret = OB_SUCCESS;
   if (IS_INIT) {
@@ -738,24 +776,12 @@ int ObSharedObjectReaderWriter::init(
     hanging_ = false;
     need_align_ = need_align;
     need_cross_ = need_cross;
-    auto_release_data_buffer_ = auto_release_data_buffer;
-    if (auto_release_data_buffer_) {
-      is_inited_ = true;
-    } else if (OB_FAIL(data_.ensure_space(DEFAULT_MACRO_BLOCK_SIZE))) {
-      LOG_WARN("Fail to ensure space", K(ret));
-    } else if (OB_FAIL(data_.clean())) {
-      LOG_WARN("fail to memset 0 data_", KR(ret));
-    } else if (OB_FAIL(reserve_header())) {
-      LOG_WARN("fail to reserve header when init", K(ret));
-    } else {
-      is_inited_ = true;
-    }
+    is_inited_ = true;
   }
   return ret;
 }
 void ObSharedObjectReaderWriter::reset()
 {
-  data_.reset();
   object_handle_.reset();
   offset_ = 0;
   align_offset_ = 0;
@@ -763,49 +789,28 @@ void ObSharedObjectReaderWriter::reset()
   hanging_ = false;
   need_align_ = false;
   need_cross_ = false;
-  auto_release_data_buffer_ = false;
   is_inited_ = false;
 }
 
-int ObSharedObjectReaderWriter::ensure_data_buffer_for_write_()
+int ObSharedObjectReaderWriter::ensure_data_buffer_for_write_(ObSharedObjectWriteSession &write_session)
 {
   int ret = OB_SUCCESS;
-  if (data_.is_valid()) {
-    if (OB_FAIL(data_.set_pos(offset_))) {
-      LOG_WARN("fail to restore data buffer position", K(ret), K_(offset), K(data_));
-    }
-  } else if (OB_FAIL(data_.ensure_space(DEFAULT_MACRO_BLOCK_SIZE))) {
+  if (!write_session.data_.is_valid()
+      && OB_FAIL(write_session.data_.ensure_space(DEFAULT_MACRO_BLOCK_SIZE))) {
     LOG_WARN("Fail to ensure space", K(ret));
-  } else if (OB_FAIL(data_.clean())) {
+  } else if (OB_SUCC(ret)
+      && DEFAULT_MACRO_BLOCK_SIZE == write_session.data_.capacity()
+      && 0 == write_session.data_.pos()
+      && OB_FAIL(write_session.data_.clean())) {
     LOG_WARN("fail to memset 0 data_", KR(ret));
   } else if (0 == offset_) {
-    if (OB_FAIL(reserve_header())) {
+    if (OB_FAIL(reserve_header(write_session))) {
       LOG_WARN("fail to reserve header for shared object writer", K(ret));
     }
-  } else if (hanging_ && 0 == align_offset_) {
-    ObMacroBlockCommonHeader common_header;
-    common_header.reset();
-    if (OB_FAIL(common_header.set_attr(ObMacroBlockCommonHeader::MacroBlockType::SharedMetaData))) {
-      LOG_WARN("fail to set type for common header", K(ret), K(common_header));
-    } else if (OB_UNLIKELY(offset_ != common_header.get_serialize_size())) {
-      ret = OB_ERR_UNEXPECTED;
-      LOG_WARN("unexpected hanging shared object writer state", K(ret), K_(offset), K_(align_offset), K_(hanging));
-    } else if (OB_FAIL(common_header.build_serialized_header(data_.data(), common_header.get_serialize_size()))) {
-      LOG_WARN("fail to write common header", K(ret), K(common_header));
-    } else if (OB_FAIL(data_.set_pos(offset_))) {
-      LOG_WARN("fail to restore data buffer position", K(ret), K_(offset), K(data_));
-    }
-  } else if (OB_FAIL(data_.set_pos(offset_))) {
-    LOG_WARN("fail to restore data buffer position", K(ret), K_(offset), K(data_));
+  } else if (OB_FAIL(write_session.data_.set_pos(offset_))) {
+    LOG_WARN("fail to restore data buffer position", K(ret), K_(offset), K(write_session.data_));
   }
   return ret;
-}
-
-void ObSharedObjectReaderWriter::release_data_buffer_if_needed_()
-{
-  if (auto_release_data_buffer_ && data_.is_valid()) {
-    data_.reset();
-  }
 }
 
 int callback_do_write_io(const ObSharedObjectWriteInfo &write_info) 
@@ -844,7 +849,8 @@ int ObSharedObjectReaderWriter::async_write(
   write_args.object_opt_ = curr_opt;
   ObSharedObjectHeader header;
   ObSharedObjectsWriteCtx tmp_write_ctx;
-  bool need_callback_do_write_io = true;
+  ObSharedObjectWriteSession write_session;
+  bool need_callback_do_write_io = false;
   {
     lib::ObMutexGuard guard(mutex_);
     if (IS_NOT_INIT) {
@@ -853,10 +859,14 @@ int ObSharedObjectReaderWriter::async_write(
     } else if (OB_UNLIKELY(!write_info.is_valid())) {
       ret = OB_INVALID_ARGUMENT;
       LOG_WARN("invalid arg", K(ret), K(write_info));
-    } else if (auto_release_data_buffer_ && OB_FAIL(ensure_data_buffer_for_write_())) {
-      LOG_WARN("fail to ensure shared object data buffer", K(ret), K_(offset), K_(align_offset));
+    } else if (OB_UNLIKELY(hanging_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected dirty shared object writer state", K(ret), K_(offset), K_(align_offset), K_(hanging));
+    } else {
+      write_session.set_clean_state(*this);
     }
     if (FAILEDx(inner_write_block(
+        write_session,
         header,
         write_info,
         write_args,
@@ -864,13 +874,10 @@ int ObSharedObjectReaderWriter::async_write(
         tmp_write_ctx))) {
       LOG_WARN("fail to write block", K(ret), K(write_info), K(write_args));
     }
-    if (auto_release_data_buffer_) {
-      need_callback_do_write_io = false;
-      if (OB_FAIL(ret)) {
-      } else if (OB_FAIL(callback_do_write_io(write_info))) {
-        LOG_WARN("failed to start write callback", K(ret));
-      }
-      release_data_buffer_if_needed_();
+    if (OB_FAIL(ret)) {
+      write_session.rollback(*this);
+    } else {
+      need_callback_do_write_io = true;
     }
   }
   if (OB_FAIL(ret)) {
@@ -886,6 +893,7 @@ int ObSharedObjectReaderWriter::async_batch_write(
     blocksstable::ObStorageObjectOpt &curr_opt)
 {
   int ret = OB_SUCCESS;
+  ObSharedObjectWriteSession write_session;
   if (IS_NOT_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("Not init", K(ret));
@@ -893,19 +901,28 @@ int ObSharedObjectReaderWriter::async_batch_write(
     lib::ObMutexGuard guard(mutex_);
     ObSharedObjectWriteArgs write_args;
     ObSharedObjectsWriteCtx write_ctx;
+    if (OB_UNLIKELY(hanging_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected dirty shared object writer state", K(ret), K_(offset), K_(align_offset), K_(hanging));
+    } else {
+      write_session.set_clean_state(*this);
+    }
     for (int64_t i = 0; OB_SUCC(ret) && i < write_infos.count(); ++i) {
       // only the last need flush and align
       write_args.need_flush_ = (i == write_infos.count() - 1);
       write_args.need_align_ = (i == write_infos.count() - 1) ? need_align_ : false;
       write_args.object_opt_ = curr_opt;
       write_ctx.clear();
-      if (OB_FAIL(inner_async_write(write_infos.at(i), write_args, shared_obj_handle, write_ctx))) {
+      if (OB_FAIL(inner_async_write(write_session, write_infos.at(i), write_args, shared_obj_handle, write_ctx))) {
         LOG_WARN("Fail to async write block", K(ret), K(i), K(write_infos.at(i)), K(write_args));
       } else if (OB_FAIL(shared_obj_handle.write_ctxs_.push_back(write_ctx))) {
         LOG_WARN("Fail to add write ctx", K(ret), K(write_ctx));
       } else {
         curr_opt = write_ctx.next_opt_;
       }
+    }
+    if (OB_FAIL(ret)) {
+      write_session.rollback(*this);
     }
   }
 
@@ -922,6 +939,7 @@ int ObSharedObjectReaderWriter::async_link_write(
     ObSharedObjectLinkHandle &shared_obj_handle)
 {
   int ret = OB_SUCCESS;
+  ObSharedObjectWriteSession write_session;
   {
     lib::ObMutexGuard guard(mutex_);
     ObSharedObjectWriteArgs write_args;
@@ -933,11 +951,16 @@ int ObSharedObjectReaderWriter::async_link_write(
     if (IS_NOT_INIT) {
       ret = OB_NOT_INIT;
       LOG_WARN("Not init", K(ret));
+    } else if (OB_UNLIKELY(hanging_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected dirty shared object writer state", K(ret), K_(offset), K_(align_offset), K_(hanging));
     } else if (OB_FAIL(shared_obj_handle.wait())) {
       LOG_WARN("Fail to wait other blocks finish", K(ret), K(shared_obj_handle));
+    } else {
+      write_session.set_clean_state(*this);
     }
 
-    if (FAILEDx(inner_async_write(write_info, write_args, shared_obj_handle, write_ctx))) {
+    if (FAILEDx(inner_async_write(write_session, write_info, write_args, shared_obj_handle, write_ctx))) {
       LOG_WARN("Fail to inner async write block", K(ret), K(write_info), K(write_args));
     } else if (OB_FAIL(shared_obj_handle.write_ctx_.set_addr(write_ctx.addr_))) {
       LOG_WARN("Fail to set addr to write ctx", K(ret), K(write_ctx));
@@ -948,6 +971,9 @@ int ObSharedObjectReaderWriter::async_link_write(
         }
       }
     }
+    if (OB_FAIL(ret)) {
+      write_session.rollback(*this);
+    }
   }
   if (OB_FAIL(ret)) {
   } else if (OB_FAIL(callback_do_write_io(write_info))) {
@@ -957,21 +983,22 @@ int ObSharedObjectReaderWriter::async_link_write(
 }
 
 int ObSharedObjectReaderWriter::inner_async_write(
+    ObSharedObjectWriteSession &write_session,
     const ObSharedObjectWriteInfo &write_info,
     const ObSharedObjectWriteArgs &write_args,
     ObSharedObjectBaseHandle &shared_obj_handle,
     ObSharedObjectsWriteCtx &write_ctx)
 {
   int ret = OB_SUCCESS;
-  if (need_cross_ && OB_FAIL(write_cross_block(write_info, write_args, shared_obj_handle))) {
+  if (need_cross_ && OB_FAIL(write_cross_block(write_session, write_info, write_args, shared_obj_handle))) {
     LOG_WARN("Fail to write cross block", K(ret), K(write_info));
-  } else if (OB_FAIL(write_block(write_info, write_args, shared_obj_handle, write_ctx))) {
+  } else if (OB_FAIL(write_block(write_session, write_info, write_args, shared_obj_handle, write_ctx))) {
     LOG_WARN("Fail to write block", K(ret), K(write_info));
   }
   return ret;
 }
 
-int ObSharedObjectReaderWriter::reserve_header()
+int ObSharedObjectReaderWriter::reserve_header(ObSharedObjectWriteSession &write_session)
 {
   int ret = OB_SUCCESS;
   ObMacroBlockCommonHeader common_header;
@@ -981,9 +1008,10 @@ int ObSharedObjectReaderWriter::reserve_header()
   } else if (OB_UNLIKELY(offset_ > 0 || align_offset_ > 0)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("fail to reserve header", K(ret), K_(offset), K_(align_offset));
-  } else if (OB_FAIL(common_header.build_serialized_header(data_.current(), common_header.get_serialize_size()))) {
+  } else if (OB_FAIL(common_header.build_serialized_header(
+      write_session.data_.current(), common_header.get_serialize_size()))) {
     LOG_WARN("fail to write common header", K(ret), K(common_header));
-  } else if (OB_FAIL(data_.advance(common_header.get_serialize_size()))) {
+  } else if (OB_FAIL(write_session.data_.advance(common_header.get_serialize_size()))) {
     LOG_WARN("Fail to advance size", K(ret), K(common_header));
   } else {
     offset_ = common_header.get_serialize_size();
@@ -993,20 +1021,21 @@ int ObSharedObjectReaderWriter::reserve_header()
   if (OB_FAIL(ret)) { // recover from failure
     offset_ = 0;
     hanging_ = false;
-    data_.reuse();
-    data_.clean();
+    write_session.data_.reuse();
+    write_session.data_.clean();
   }
   return ret;
 }
 
-int ObSharedObjectReaderWriter::switch_object(ObStorageObjectHandle &object_handle,
+int ObSharedObjectReaderWriter::switch_object(ObSharedObjectWriteSession &write_session,
+                                              ObStorageObjectHandle &object_handle,
                                               const blocksstable::ObStorageObjectOpt &next_opt)
 {
   int ret = OB_SUCCESS;
   object_handle.reset();
   if (hanging_) {
     ObStorageObjectWriteInfo write_info;
-    write_info.buffer_ = data_.data() + align_offset_;
+    write_info.buffer_ = write_session.data_.data() + align_offset_;
     write_info.offset_ = align_offset_;
     write_info.size_ = upper_align(offset_ - align_offset_, write_align_size_);
     write_info.io_desc_.set_wait_event(ObWaitEventIds::DB_FILE_COMPACT_WRITE);
@@ -1020,29 +1049,26 @@ int ObSharedObjectReaderWriter::switch_object(ObStorageObjectHandle &object_hand
     }
   }
   if (OB_SUCC(ret)) {
-    if (OB_FAIL(do_switch(next_opt))) {
+    if (OB_FAIL(do_switch(write_session, next_opt))) {
       LOG_WARN("fail to switch block", K(ret), K(next_opt));
     }
   }
   return ret;
 }
 
-int ObSharedObjectReaderWriter::do_switch(const ObStorageObjectOpt &opt)
+int ObSharedObjectReaderWriter::do_switch(ObSharedObjectWriteSession &write_session,
+                                          const ObStorageObjectOpt &opt)
 {
   int ret = OB_SUCCESS;
   hanging_ = false;
-  data_.reuse();
+  write_session.data_.reuse();
   object_handle_.reset();
   offset_ = 0;
   align_offset_ = 0;
   if (OB_FAIL(OB_STORAGE_OBJECT_MGR.alloc_object(opt, object_handle_))) {
     LOG_WARN("fail to alloc object", K(ret));
-  } else if (OB_FAIL(data_.clean())) {
+  } else if (OB_FAIL(write_session.data_.clean())) {
     LOG_WARN("fail to memset 0 data_", KR(ret));
-  } else {
-    if (OB_FAIL(reserve_header())) {
-      LOG_WARN("fail to reserve header when init", K(ret));
-    }
   }
   return ret;
 }
@@ -1069,7 +1095,25 @@ int ObSharedObjectReaderWriter::calc_store_size(
   return ret;
 }
 
+int ObSharedObjectReaderWriter::check_object_size_(
+    const int64_t total_size,
+    const bool need_align)
+{
+  int ret = OB_SUCCESS;
+  ObMacroBlockCommonHeader common_header;
+  const int64_t header_size = common_header.get_serialize_size();
+  const int64_t next_align_offset = upper_align(header_size + total_size, write_align_size_);
+  const int64_t store_size = need_align ? next_align_offset - header_size : total_size;
+  if (OB_UNLIKELY(header_size + store_size > DEFAULT_MACRO_BLOCK_SIZE)) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_WARN("Not supported object size", K(ret), K(total_size), K(need_align),
+        K(header_size), K(store_size));
+  }
+  return ret;
+}
+
 int ObSharedObjectReaderWriter::inner_write_block(
+    ObSharedObjectWriteSession &write_session,
     const ObSharedObjectHeader &header,
     const ObSharedObjectWriteInfo &write_info,
     const ObSharedObjectWriteArgs &write_args,
@@ -1084,7 +1128,11 @@ int ObSharedObjectReaderWriter::inner_write_block(
   bool need_align = write_args.need_align_;
   bool need_flush = write_args.need_flush_;
   write_ctx.next_opt_ = write_args.object_opt_;
-  if (OB_FAIL(calc_store_size(blk_size, need_align, store_size, align_store_size))) {
+  if (OB_FAIL(check_object_size_(blk_size, need_align))) {
+    LOG_WARN("object is too large for shared object writer", K(ret), K(blk_size), K(need_align));
+  } else if (OB_FAIL(ensure_data_buffer_for_write_(write_session))) {
+    LOG_WARN("fail to ensure shared object data buffer", K(ret), K_(offset), K_(align_offset));
+  } else if (OB_FAIL(calc_store_size(blk_size, need_align, store_size, align_store_size))) {
     LOG_WARN("fail to calc store size", K(ret));
   } else if (!object_handle_.get_macro_id().is_valid()
       && OB_FAIL(OB_STORAGE_OBJECT_MGR.alloc_object(write_args.object_opt_, object_handle_))) {
@@ -1092,28 +1140,36 @@ int ObSharedObjectReaderWriter::inner_write_block(
   } else if (store_size + offset_ > DEFAULT_MACRO_BLOCK_SIZE) {
     if (OB_FAIL(write_ctx.advance_data_seq())) {
       LOG_WARN("Fail to get next opt", K(ret), K(write_args), K(write_ctx.next_opt_));
-    } else if (OB_FAIL(switch_object(object_handle, write_ctx.next_opt_))) {
+    } else if (OB_FAIL(switch_object(write_session, object_handle, write_ctx.next_opt_))) {
       LOG_WARN("Fail to switch new block", K(ret));
-    } else if (object_handle.is_valid() && OB_FAIL(shared_obj_handle.add_object_handle(object_handle))) {
-      LOG_WARN("Fail to flush last macro block", K(ret), K(object_handle));
-    } else if (OB_FAIL(calc_store_size(blk_size, need_align, store_size, align_store_size))) {
-      LOG_WARN("fail to calc store size", K(ret));
+    } else {
+      write_session.set_clean_state(*this);
+      if (object_handle.is_valid() && OB_FAIL(shared_obj_handle.add_object_handle(object_handle))) {
+        LOG_WARN("Fail to flush last macro block", K(ret), K(object_handle));
+      } else if (OB_FAIL(ensure_data_buffer_for_write_(write_session))) {
+        LOG_WARN("fail to ensure shared object data buffer", K(ret), K_(offset), K_(align_offset));
+      } else if (OB_FAIL(calc_store_size(blk_size, need_align, store_size, align_store_size))) {
+        LOG_WARN("fail to calc store size", K(ret));
+      } else if (OB_UNLIKELY(store_size + offset_ > DEFAULT_MACRO_BLOCK_SIZE)) {
+        ret = OB_NOT_SUPPORTED;
+        LOG_WARN("Not supported object size", K(ret), K_(offset), K_(align_offset), K(store_size));
+      }
     }
   }
 
   if (OB_SUCC(ret)) {
     object_handle.reset();
     int64_t pos = 0;
-    const int64_t prev_pos = data_.pos();
+    const int64_t prev_pos = write_session.data_.pos();
     const int64_t prev_offset = offset_;
     const int64_t prev_align_offset = align_offset_;
     const bool prev_hanging = hanging_;
-    if (write_args.with_header_ && OB_FAIL(header.serialize(data_.current(), header.header_size_, pos))) {
+    if (write_args.with_header_ && OB_FAIL(header.serialize(write_session.data_.current(), header.header_size_, pos))) {
       LOG_WARN("Fail to serialize header", K(ret), K(header));
     } else {
-      MEMCPY(data_.current() + pos, write_info.buffer_, write_info.size_);
+      MEMCPY(write_session.data_.current() + pos, write_info.buffer_, write_info.size_);
       ObStorageObjectWriteInfo object_info;
-      object_info.buffer_ = data_.data() + align_offset_;
+      object_info.buffer_ = write_session.data_.data() + align_offset_;
       object_info.offset_ = align_offset_;
       object_info.size_ = align_store_size;
       object_info.mtl_tenant_id_ = MTL_ID();
@@ -1140,7 +1196,7 @@ int ObSharedObjectReaderWriter::inner_write_block(
           LOG_WARN("Fail to set block addr", K(ret));
         } else if (OB_FAIL(shared_obj_handle.add_meta_addr(addr))) {
           LOG_WARN("Fail to add meta addr", K(ret), K(addr));
-        } else if (OB_FAIL(data_.advance(store_size))) {
+        } else if (OB_FAIL(write_session.data_.advance(store_size))) {
           LOG_WARN("Fail to advance size", K(ret), K(store_size));
         } else if (OB_FAIL(write_ctx.set_addr(addr))) {
           LOG_WARN("Fail to add addr to write ctx", K(ret), K(addr));
@@ -1161,6 +1217,7 @@ int ObSharedObjectReaderWriter::inner_write_block(
           } else {
             hanging_ = false;
             align_offset_ = lower_align(offset_, write_align_size_);
+            write_session.set_clean_state(*this);
           }
         } else if (!need_flush) {
           hanging_ = true;
@@ -1173,7 +1230,7 @@ int ObSharedObjectReaderWriter::inner_write_block(
     // roll back status
     if (OB_FAIL(ret)) {
       int tmp_ret = OB_SUCCESS;
-      if (OB_TMP_FAIL(data_.set_pos(prev_pos))) {
+      if (OB_TMP_FAIL(write_session.data_.set_pos(prev_pos))) {
         LOG_ERROR("fail to roll back data buffer", K(ret), K(tmp_ret), K(prev_pos), K(header), K(write_args));
         ob_usleep(1000 * 1000);
         ob_abort();
@@ -1194,6 +1251,7 @@ void ObSharedObjectReaderWriter::get_cur_shared_block(blocksstable::MacroBlockId
 }
 
 int ObSharedObjectReaderWriter::write_block(
+    ObSharedObjectWriteSession &write_session,
     const ObSharedObjectWriteInfo &write_info,
     const ObSharedObjectWriteArgs &write_args,
     ObSharedObjectBaseHandle &shared_obj_handle,
@@ -1218,7 +1276,7 @@ int ObSharedObjectReaderWriter::write_block(
     header.next_macro_id_ = ObSharedObjectHeader::DEFAULT_MACRO_ID;
     header.prev_addr_ = prev_addr;
     header.header_size_ = header.get_serialize_size();
-    if (OB_FAIL(inner_write_block(header, write_info, write_args, shared_obj_handle, write_ctx))) {
+    if (OB_FAIL(inner_write_block(write_session, header, write_info, write_args, shared_obj_handle, write_ctx))) {
       LOG_WARN("Fail to write block", K(ret), K(write_info), K(write_args));
     }
   }
@@ -1226,10 +1284,12 @@ int ObSharedObjectReaderWriter::write_block(
 }
 
 int ObSharedObjectReaderWriter::write_cross_block(
+    ObSharedObjectWriteSession &write_session,
     const ObSharedObjectWriteInfo &write_info,
     const ObSharedObjectWriteArgs &write_args,
     ObSharedObjectBaseHandle &shared_obj_handle)
 {
+  UNUSED(write_session);
   UNUSED(write_info);
   UNUSED(write_args);
   UNUSED(shared_obj_handle);

--- a/src/storage/blockstore/ob_shared_object_reader_writer.cpp
+++ b/src/storage/blockstore/ob_shared_object_reader_writer.cpp
@@ -749,8 +749,7 @@ private:
 
 ObSharedObjectReaderWriter::ObSharedObjectReaderWriter()
     : mutex_(), object_handle_(), offset_(0), align_offset_(0),
-      write_align_size_(0), hanging_(false), need_align_(false),
-      need_cross_(false), is_inited_(false)
+      write_align_size_(0), hanging_(false), is_inited_(false)
 {}
 
 ObSharedObjectReaderWriter::~ObSharedObjectReaderWriter()
@@ -758,24 +757,17 @@ ObSharedObjectReaderWriter::~ObSharedObjectReaderWriter()
   reset();
 }
 
-int ObSharedObjectReaderWriter::init(
-    const bool need_align,
-    const bool need_cross)
+int ObSharedObjectReaderWriter::init()
 {
   int ret = OB_SUCCESS;
   if (IS_INIT) {
     ret = OB_INIT_TWICE;
     LOG_WARN("Init twice", K(ret));
-  } else if (!need_align || need_cross) {
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("Not supported", K(ret), K(need_align), K(need_cross));
   } else {
     offset_ = 0;
     align_offset_ = 0;
     write_align_size_ = DIO_READ_ALIGN_SIZE; // 4K
     hanging_ = false;
-    need_align_ = need_align;
-    need_cross_ = need_cross;
     is_inited_ = true;
   }
   return ret;
@@ -787,8 +779,6 @@ void ObSharedObjectReaderWriter::reset()
   align_offset_ = 0;
   write_align_size_ = 0;
   hanging_ = false;
-  need_align_ = false;
-  need_cross_ = false;
   is_inited_ = false;
 }
 
@@ -910,7 +900,7 @@ int ObSharedObjectReaderWriter::async_batch_write(
     for (int64_t i = 0; OB_SUCC(ret) && i < write_infos.count(); ++i) {
       // only the last need flush and align
       write_args.need_flush_ = (i == write_infos.count() - 1);
-      write_args.need_align_ = (i == write_infos.count() - 1) ? need_align_ : false;
+      write_args.need_align_ = (i == write_infos.count() - 1);
       write_args.object_opt_ = curr_opt;
       write_ctx.clear();
       if (OB_FAIL(inner_async_write(write_session, write_infos.at(i), write_args, shared_obj_handle, write_ctx))) {
@@ -946,7 +936,7 @@ int ObSharedObjectReaderWriter::async_link_write(
     ObSharedObjectsWriteCtx write_ctx;
     write_args.object_opt_ = curr_opt;
     write_args.need_flush_ = true;
-    write_args.need_align_ = need_align_;
+    write_args.need_align_ = true;
     write_args.is_linked_ = true;
     if (IS_NOT_INIT) {
       ret = OB_NOT_INIT;
@@ -990,9 +980,7 @@ int ObSharedObjectReaderWriter::inner_async_write(
     ObSharedObjectsWriteCtx &write_ctx)
 {
   int ret = OB_SUCCESS;
-  if (need_cross_ && OB_FAIL(write_cross_block(write_session, write_info, write_args, shared_obj_handle))) {
-    LOG_WARN("Fail to write cross block", K(ret), K(write_info));
-  } else if (OB_FAIL(write_block(write_session, write_info, write_args, shared_obj_handle, write_ctx))) {
+  if (OB_FAIL(write_block(write_session, write_info, write_args, shared_obj_handle, write_ctx))) {
     LOG_WARN("Fail to write block", K(ret), K(write_info));
   }
   return ret;
@@ -1281,19 +1269,6 @@ int ObSharedObjectReaderWriter::write_block(
     }
   }
   return ret;
-}
-
-int ObSharedObjectReaderWriter::write_cross_block(
-    ObSharedObjectWriteSession &write_session,
-    const ObSharedObjectWriteInfo &write_info,
-    const ObSharedObjectWriteArgs &write_args,
-    ObSharedObjectBaseHandle &shared_obj_handle)
-{
-  UNUSED(write_session);
-  UNUSED(write_info);
-  UNUSED(write_args);
-  UNUSED(shared_obj_handle);
-  return OB_NOT_SUPPORTED;
 }
 
 int ObSharedObjectReaderWriter::async_read(

--- a/src/storage/blockstore/ob_shared_object_reader_writer.cpp
+++ b/src/storage/blockstore/ob_shared_object_reader_writer.cpp
@@ -710,6 +710,7 @@ ObSharedObjectReaderWriter::ObSharedObjectReaderWriter()
     : mutex_(), data_("SHARE_BLOCK", 0, false, false/*use_fixed_blk*/),
       object_handle_(), offset_(0), align_offset_(0), write_align_size_(0),
       hanging_(false), need_align_(false), need_cross_(false),
+      auto_release_data_buffer_(false),
       is_inited_(false)
 {}
 
@@ -720,7 +721,8 @@ ObSharedObjectReaderWriter::~ObSharedObjectReaderWriter()
 
 int ObSharedObjectReaderWriter::init(
     const bool need_align,
-    const bool need_cross)
+    const bool need_cross,
+    const bool auto_release_data_buffer)
 {
   int ret = OB_SUCCESS;
   if (IS_INIT) {
@@ -729,10 +731,6 @@ int ObSharedObjectReaderWriter::init(
   } else if (!need_align || need_cross) {
     ret = OB_NOT_SUPPORTED;
     LOG_WARN("Not supported", K(ret), K(need_align), K(need_cross));
-  } else if (OB_FAIL(data_.ensure_space(DEFAULT_MACRO_BLOCK_SIZE))) {
-    LOG_WARN("Fail to ensure space", K(ret));
-  } else if (OB_FAIL(data_.clean())) {
-    LOG_WARN("fail to memset 0 data_", KR(ret));
   } else {
     offset_ = 0;
     align_offset_ = 0;
@@ -740,11 +738,18 @@ int ObSharedObjectReaderWriter::init(
     hanging_ = false;
     need_align_ = need_align;
     need_cross_ = need_cross;
-    if (OB_FAIL(reserve_header())) {
-        LOG_WARN("fail to reserve header when init", K(ret));
-      } else {
-        is_inited_ = true;
-      }
+    auto_release_data_buffer_ = auto_release_data_buffer;
+    if (auto_release_data_buffer_) {
+      is_inited_ = true;
+    } else if (OB_FAIL(data_.ensure_space(DEFAULT_MACRO_BLOCK_SIZE))) {
+      LOG_WARN("Fail to ensure space", K(ret));
+    } else if (OB_FAIL(data_.clean())) {
+      LOG_WARN("fail to memset 0 data_", KR(ret));
+    } else if (OB_FAIL(reserve_header())) {
+      LOG_WARN("fail to reserve header when init", K(ret));
+    } else {
+      is_inited_ = true;
+    }
   }
   return ret;
 }
@@ -758,7 +763,49 @@ void ObSharedObjectReaderWriter::reset()
   hanging_ = false;
   need_align_ = false;
   need_cross_ = false;
+  auto_release_data_buffer_ = false;
   is_inited_ = false;
+}
+
+int ObSharedObjectReaderWriter::ensure_data_buffer_for_write_()
+{
+  int ret = OB_SUCCESS;
+  if (data_.is_valid()) {
+    if (OB_FAIL(data_.set_pos(offset_))) {
+      LOG_WARN("fail to restore data buffer position", K(ret), K_(offset), K(data_));
+    }
+  } else if (OB_FAIL(data_.ensure_space(DEFAULT_MACRO_BLOCK_SIZE))) {
+    LOG_WARN("Fail to ensure space", K(ret));
+  } else if (OB_FAIL(data_.clean())) {
+    LOG_WARN("fail to memset 0 data_", KR(ret));
+  } else if (0 == offset_) {
+    if (OB_FAIL(reserve_header())) {
+      LOG_WARN("fail to reserve header for shared object writer", K(ret));
+    }
+  } else if (hanging_ && 0 == align_offset_) {
+    ObMacroBlockCommonHeader common_header;
+    common_header.reset();
+    if (OB_FAIL(common_header.set_attr(ObMacroBlockCommonHeader::MacroBlockType::SharedMetaData))) {
+      LOG_WARN("fail to set type for common header", K(ret), K(common_header));
+    } else if (OB_UNLIKELY(offset_ != common_header.get_serialize_size())) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected hanging shared object writer state", K(ret), K_(offset), K_(align_offset), K_(hanging));
+    } else if (OB_FAIL(common_header.build_serialized_header(data_.data(), common_header.get_serialize_size()))) {
+      LOG_WARN("fail to write common header", K(ret), K(common_header));
+    } else if (OB_FAIL(data_.set_pos(offset_))) {
+      LOG_WARN("fail to restore data buffer position", K(ret), K_(offset), K(data_));
+    }
+  } else if (OB_FAIL(data_.set_pos(offset_))) {
+    LOG_WARN("fail to restore data buffer position", K(ret), K_(offset), K(data_));
+  }
+  return ret;
+}
+
+void ObSharedObjectReaderWriter::release_data_buffer_if_needed_()
+{
+  if (auto_release_data_buffer_ && data_.is_valid()) {
+    data_.reset();
+  }
 }
 
 int callback_do_write_io(const ObSharedObjectWriteInfo &write_info) 
@@ -797,6 +844,7 @@ int ObSharedObjectReaderWriter::async_write(
   write_args.object_opt_ = curr_opt;
   ObSharedObjectHeader header;
   ObSharedObjectsWriteCtx tmp_write_ctx;
+  bool need_callback_do_write_io = true;
   {
     lib::ObMutexGuard guard(mutex_);
     if (IS_NOT_INIT) {
@@ -805,6 +853,8 @@ int ObSharedObjectReaderWriter::async_write(
     } else if (OB_UNLIKELY(!write_info.is_valid())) {
       ret = OB_INVALID_ARGUMENT;
       LOG_WARN("invalid arg", K(ret), K(write_info));
+    } else if (auto_release_data_buffer_ && OB_FAIL(ensure_data_buffer_for_write_())) {
+      LOG_WARN("fail to ensure shared object data buffer", K(ret), K_(offset), K_(align_offset));
     }
     if (FAILEDx(inner_write_block(
         header,
@@ -814,9 +864,17 @@ int ObSharedObjectReaderWriter::async_write(
         tmp_write_ctx))) {
       LOG_WARN("fail to write block", K(ret), K(write_info), K(write_args));
     }
+    if (auto_release_data_buffer_) {
+      need_callback_do_write_io = false;
+      if (OB_FAIL(ret)) {
+      } else if (OB_FAIL(callback_do_write_io(write_info))) {
+        LOG_WARN("failed to start write callback", K(ret));
+      }
+      release_data_buffer_if_needed_();
+    }
   }
   if (OB_FAIL(ret)) {
-  } else if (OB_FAIL(callback_do_write_io(write_info))) {
+  } else if (need_callback_do_write_io && OB_FAIL(callback_do_write_io(write_info))) {
     LOG_WARN("failed to start write callback", K(ret));
   }
   return ret;

--- a/src/storage/blockstore/ob_shared_object_reader_writer.h
+++ b/src/storage/blockstore/ob_shared_object_reader_writer.h
@@ -275,9 +275,7 @@ private:
 public:
   ObSharedObjectReaderWriter();
   ~ObSharedObjectReaderWriter();
-  int init(
-      const bool need_align = true,
-      const bool need_cross = false);
+  int init();
   void reset();
   void get_cur_shared_block(blocksstable::MacroBlockId &macro_id);
   static int async_read(const ObSharedObjectReadInfo &read_info, ObSharedObjectReadHandle &shared_obj_handle);
@@ -310,12 +308,7 @@ private:
       const ObSharedObjectWriteInfo &write_info,
       const ObSharedObjectWriteArgs &write_args,
       ObSharedObjectBaseHandle &shared_obj_handle,
-      ObSharedObjectsWriteCtx &write_ctx); // not cross
-  int write_cross_block(
-      ObSharedObjectWriteSession &write_session,
-      const ObSharedObjectWriteInfo &write_info,
-      const ObSharedObjectWriteArgs &write_args,
-      ObSharedObjectBaseHandle &shared_obj_handle); // cross
+      ObSharedObjectsWriteCtx &write_ctx);
   int calc_store_size(
       const int64_t total_size,
       const bool need_align,
@@ -358,8 +351,6 @@ private:
   int64_t align_offset_;
   int64_t write_align_size_;
   bool hanging_;
-  bool need_align_;
-  bool need_cross_;
   bool is_inited_;
   DISALLOW_COPY_AND_ASSIGN(ObSharedObjectReaderWriter);
 };

--- a/src/storage/blockstore/ob_shared_object_reader_writer.h
+++ b/src/storage/blockstore/ob_shared_object_reader_writer.h
@@ -276,7 +276,8 @@ public:
   ~ObSharedObjectReaderWriter();
   int init(
       const bool need_align = true,
-      const bool need_cross = false);
+      const bool need_cross = false,
+      const bool auto_release_data_buffer = false);
   void reset();
   void get_cur_shared_block(blocksstable::MacroBlockId &macro_id);
   static int async_read(const ObSharedObjectReadInfo &read_info, ObSharedObjectReadHandle &shared_obj_handle);
@@ -327,6 +328,8 @@ private:
                     const blocksstable::ObStorageObjectOpt &next_opt);
   int do_switch(const blocksstable::ObStorageObjectOpt &opt);
   int reserve_header();
+  int ensure_data_buffer_for_write_();
+  void release_data_buffer_if_needed_();
 private:
 struct ObSharedObjectWriteArgs final
 {
@@ -352,6 +355,7 @@ private:
   bool hanging_;
   bool need_align_;
   bool need_cross_;
+  bool auto_release_data_buffer_;
   bool is_inited_;
   DISALLOW_COPY_AND_ASSIGN(ObSharedObjectReaderWriter);
 };

--- a/src/storage/blockstore/ob_shared_object_reader_writer.h
+++ b/src/storage/blockstore/ob_shared_object_reader_writer.h
@@ -271,13 +271,13 @@ class ObSharedObjectReaderWriter final
 {
 private:
   struct ObSharedObjectWriteArgs;
+  struct ObSharedObjectWriteSession;
 public:
   ObSharedObjectReaderWriter();
   ~ObSharedObjectReaderWriter();
   int init(
       const bool need_align = true,
-      const bool need_cross = false,
-      const bool auto_release_data_buffer = false);
+      const bool need_cross = false);
   void reset();
   void get_cur_shared_block(blocksstable::MacroBlockId &macro_id);
   static int async_read(const ObSharedObjectReadInfo &read_info, ObSharedObjectReadHandle &shared_obj_handle);
@@ -300,16 +300,19 @@ public:
       ObSharedObjectLinkHandle &shared_obj_handle);
 private:
   int inner_async_write(
+      ObSharedObjectWriteSession &write_session,
       const ObSharedObjectWriteInfo &write_info,
       const ObSharedObjectWriteArgs &write_args,
       ObSharedObjectBaseHandle &shared_obj_handle,
       ObSharedObjectsWriteCtx &write_ctx);
   int write_block(
+      ObSharedObjectWriteSession &write_session,
       const ObSharedObjectWriteInfo &write_info,
       const ObSharedObjectWriteArgs &write_args,
       ObSharedObjectBaseHandle &shared_obj_handle,
       ObSharedObjectsWriteCtx &write_ctx); // not cross
   int write_cross_block(
+      ObSharedObjectWriteSession &write_session,
       const ObSharedObjectWriteInfo &write_info,
       const ObSharedObjectWriteArgs &write_args,
       ObSharedObjectBaseHandle &shared_obj_handle); // cross
@@ -319,17 +322,20 @@ private:
       int64_t &store_size,
       int64_t &align_store_size);
   int inner_write_block(
+      ObSharedObjectWriteSession &write_session,
       const ObSharedObjectHeader &header,
       const ObSharedObjectWriteInfo &write_info,
       const ObSharedObjectWriteArgs &write_args,
       ObSharedObjectBaseHandle &shared_obj_handle,
       ObSharedObjectsWriteCtx &write_ctx);
-  int switch_object(blocksstable::ObStorageObjectHandle &object_handle,
+  int switch_object(ObSharedObjectWriteSession &write_session,
+                    blocksstable::ObStorageObjectHandle &object_handle,
                     const blocksstable::ObStorageObjectOpt &next_opt);
-  int do_switch(const blocksstable::ObStorageObjectOpt &opt);
-  int reserve_header();
-  int ensure_data_buffer_for_write_();
-  void release_data_buffer_if_needed_();
+  int do_switch(ObSharedObjectWriteSession &write_session,
+                const blocksstable::ObStorageObjectOpt &opt);
+  int reserve_header(ObSharedObjectWriteSession &write_session);
+  int ensure_data_buffer_for_write_(ObSharedObjectWriteSession &write_session);
+  int check_object_size_(const int64_t total_size, const bool need_align);
 private:
 struct ObSharedObjectWriteArgs final
 {
@@ -347,7 +353,6 @@ public:
 };
 private:
   lib::ObMutex mutex_;
-  blocksstable::ObSelfBufferWriter data_;
   blocksstable::ObStorageObjectHandle object_handle_;
   int64_t offset_;
   int64_t align_offset_;
@@ -355,7 +360,6 @@ private:
   bool hanging_;
   bool need_align_;
   bool need_cross_;
-  bool auto_release_data_buffer_;
   bool is_inited_;
   DISALLOW_COPY_AND_ASSIGN(ObSharedObjectReaderWriter);
 };

--- a/src/storage/meta_store/ob_tenant_storage_meta_service.cpp
+++ b/src/storage/meta_store/ob_tenant_storage_meta_service.cpp
@@ -65,8 +65,7 @@ int ObTenantStorageMetaService::init()
     LOG_WARN("fail to init replayer", K(ret));
   } else if (OB_FAIL(shared_object_rwriter_.init())) {
     LOG_WARN("fail to init shared block rwriter", K(ret));
-  } else if (OB_FAIL(shared_object_raw_rwriter_.init(
-      true /*need_align*/, false /*need_cross*/, true /*auto_release_data_buffer*/))) {
+  } else if (OB_FAIL(shared_object_raw_rwriter_.init())) {
     LOG_WARN("fail to init shared block raw rwriter", K(ret));
   } else {
     

--- a/src/storage/meta_store/ob_tenant_storage_meta_service.cpp
+++ b/src/storage/meta_store/ob_tenant_storage_meta_service.cpp
@@ -65,7 +65,8 @@ int ObTenantStorageMetaService::init()
     LOG_WARN("fail to init replayer", K(ret));
   } else if (OB_FAIL(shared_object_rwriter_.init())) {
     LOG_WARN("fail to init shared block rwriter", K(ret));
-  } else if (OB_FAIL(shared_object_raw_rwriter_.init())) {
+  } else if (OB_FAIL(shared_object_raw_rwriter_.init(
+      true /*need_align*/, false /*need_cross*/, true /*auto_release_data_buffer*/))) {
     LOG_WARN("fail to init shared block raw rwriter", K(ret));
   } else {
     


### PR DESCRIPTION
## Task Description
`ObTenantStorageMetaService` kept two `ObSharedObjectReaderWriter` instances for tablet/sstable metadata persistence. Each writer held a 2MB `SHARE_BLOCK` buffer for the tenant lifetime, so `shared_object_rwriter_` and `shared_object_raw_rwriter_` contributed resident memory even when no metadata write was in progress.

## Solution Description
Introduce a per-call write session inside `ObSharedObjectReaderWriter` and move the 2MB `SHARE_BLOCK` buffer lifetime into that session. The writer object now keeps only the shared macro append state, while raw, batch, and linked writes allocate the 2MB buffer on demand, flush through the existing shared object layout, and release the buffer when the write call exits.
The change preserves existing address semantics and disk layout: `BLOCK` and `RAW_BLOCK` remain unchanged, shared macro blocks continue appending by `offset_`, and block switching still happens only when the current macro block cannot fit the next logical object. A single object that cannot fit into an empty shared macro block is rejected with `OB_NOT_SUPPORTED`.

## Passed Regressions
- `git diff --check`
- `ob-make --inc -s src/storage/blockstore/ob_shared_object_reader_writer.cpp -j 8`
- `ob-make -j8 test_sstable_meta`
- `./unittest/storage/blocksstable/test_sstable_meta`
- `ob-make -j8 test_tablet`
- `./unittest/storage/test_tablet`
- `ob-make -j8 test_linked_macro_block`
- `./unittest/storage/test_linked_macro_block`
- Manual debug process check: after startup and a metadata workload, `oceanbase.v$ob_memory` reported `SHARE_BLOCK` hold/used/count as `0/0/0`.

## Upgrade Compatibility
No data format or address format change. The change only adjusts in-memory buffer ownership during metadata write calls.

## Other Information
This MR includes two commits: an initial raw-writer optimization and a follow-up refactor that unifies both shared object writers under the session-based temporary buffer model.

## Release Note
