### PR TITLE
[seekdb][io] Remove disk error isolation logic

### DIFF
--- a/src/share/config/ob_config_helper.cpp
+++ b/src/share/config/ob_config_helper.cpp
@@ -608,16 +608,6 @@ bool ObConfigPartitionBalanceStrategyFuncChecker::check(const ObConfigItem &t) c
   return is_valid;
 }
 
-bool ObConfigOfsBlockVerifyIntervalChecker::check(const ObConfigItem &t) const
-{
-  bool is_valid = true;
-  int64_t value = ObConfigTimeParser::get(t.str(), is_valid);
-  if (is_valid) {
-    is_valid = (0 == value) || (value >= MIN_VALID_INTVL && value <= MAX_VALID_INTVL);
-  }
-  return is_valid;
-}
-
 bool ObLogDiskUsagePercentageChecker::check(const ObConfigItem &t) const
 {
   bool is_valid = false;

--- a/src/share/config/ob_config_helper.h
+++ b/src/share/config/ob_config_helper.h
@@ -604,19 +604,6 @@ private:
   DISALLOW_COPY_AND_ASSIGN(ObConfigAuditModeChecker);
 };
 
-class ObConfigOfsBlockVerifyIntervalChecker
-  : public ObConfigChecker
-{
-public:
-  ObConfigOfsBlockVerifyIntervalChecker() {}
-  virtual ~ObConfigOfsBlockVerifyIntervalChecker() {}
-  bool check(const ObConfigItem &t) const;
-  static constexpr int64_t MIN_VALID_INTVL = 60 * 60 * 1000 * 1000UL; // 1 hour
-  static constexpr int64_t MAX_VALID_INTVL = 30 * 24 * MIN_VALID_INTVL; // 30 days
-private:
-  DISABLE_COPY_ASSIGN(ObConfigOfsBlockVerifyIntervalChecker);
-};
-
 class ObLogDiskUsagePercentageChecker
   : public ObConfigChecker
 {


### PR DESCRIPTION
## Task Description
SeekDB is a standalone product evolved from OceanBase. The old data disk hung detector still retained the distributed database ERROR isolation model: data disk WARNING could escalate to ERROR, foreground data IO could be blocked by health status, and `alter system set disk valid` was used to clear the ERROR state. For standalone SeekDB, this ERROR isolation path is no longer needed.

## Solution Description
Remove the data disk ERROR health state and its escalation path while keeping WARNING diagnostics.
The IO fault detector now only reports NORMAL or WARNING. WARNING maintains logs, an in-memory warning timestamp, and virtual table visibility, and it automatically recovers after the blacklist interval. Foreground data IO no longer fails with `OB_DISK_HUNG` solely because disk health is not normal.
Also remove `data_storage_error_tolerance_time`, the `alter system set disk valid` SQL parser/resolver/executor path, and its unused RPC argument. The `OB_DISK_HUNG` error code itself is kept for downstream compatibility.

## Passed Regressions
- ./gen_parser.sh
- ob-make -j4 test_io_manager
- build_debug/unittest/storage/test_io_manager --gtest_filter='*IOFaultDetector*'
- git diff --check
- rg residual check for DEVICE_HEALTH_ERROR / SET DISK VALID / data_storage_error_tolerance_time

## Upgrade Compatibility
`alter system set disk valid server ...` is no longer supported. Existing virtual table columns are kept for compatibility, but the abnormal time now represents the WARNING start timestamp.

## Other Information
- MR contains one commit: 797345a153e Remove disk error isolation logic
- Related links: DIMA-2026062400116951704

## Release Note
