### PR TITLE
[seekdb][pl] Fix DBMS index refresh in embedded mode

### DIFF
--- a/deps/oblib/src/lib/signal/ob_signal_handlers.cpp
+++ b/deps/oblib/src/lib/signal/ob_signal_handlers.cpp
@@ -206,11 +206,9 @@ void coredump_cb(volatile int sig, volatile int sig_code, void* volatile sig_add
     int64_t ip = con->uc_mcontext.regs[30];
     int64_t bp = con->uc_mcontext.regs[29];
 #endif
-    #ifndef OB_BUILD_EMBED_MODE
-      void* addrs[64];
-      int n_addr = light_backtrace(addrs, ARRAYSIZEOF(addrs), bp);
-      len += safe_parray(bt, sizeof(bt) - 1, (int64_t*)addrs, n_addr);
-    #endif
+    void* addrs[64];
+    int n_addr = light_backtrace(addrs, ARRAYSIZEOF(addrs), bp);
+    len += safe_parray(bt, sizeof(bt) - 1, (int64_t*)addrs, n_addr);
 #else
     int64_t ip = -1;
     int64_t bp = -1;

--- a/src/observer/virtual_table/ob_all_virtual_thread.cpp
+++ b/src/observer/virtual_table/ob_all_virtual_thread.cpp
@@ -75,10 +75,6 @@ int ObAllVirtualThread::inner_get_next_row(common::ObNewRow *&row)
     if (OB_FAIL(FileDirectoryUtils::is_exists(cgroup_path, is_config_cgroup_))) {
       SERVER_LOG(WARN, "fail check file exist", K(cgroup_path), K(ret));
     }
-    #ifdef OB_BUILD_EMBED_MODE
-    ret = OB_NOT_SUPPORTED;
-    return ret;
-    #endif
     #if defined(__APPLE__) || defined(__ANDROID__)
     ret = OB_NOT_SUPPORTED;
     return ret;

--- a/src/pl/ob_pl_compile.cpp
+++ b/src/pl/ob_pl_compile.cpp
@@ -113,67 +113,6 @@ int pl_finalize_expressions(sql::ObSQLSessionInfo &session_info,
   return ret;
 }
 
-int extract_interface_name(const ObPLFunctionAST &func_ast, ObString &interface_name)
-{
-  int ret = OB_SUCCESS;
-  interface_name.reset();
-  const ObPLStmtBlock *body = func_ast.get_body();
-  if (OB_ISNULL(body)) {
-    ret = OB_ERR_UNEXPECTED;
-    LOG_WARN("pl body is null", K(ret), K(func_ast.get_name()));
-  } else if (body->get_stmts().count() != 1) {
-    ret = OB_ERR_UNEXPECTED;
-    LOG_WARN("unexpected interface stmt count", K(ret), K(func_ast.get_name()), "stmt_count", body->get_stmts().count());
-  } else if (OB_ISNULL(body->get_stmts().at(0))) {
-    ret = OB_ERR_UNEXPECTED;
-    LOG_WARN("interface stmt is null", K(ret), K(func_ast.get_name()));
-  } else if (PL_INTERFACE != body->get_stmts().at(0)->get_type()) {
-    ret = OB_ERR_UNEXPECTED;
-    LOG_WARN("unexpected stmt type for interface routine", K(ret), K(func_ast.get_name()), "stmt_type", body->get_stmts().at(0)->get_type());
-  } else {
-    interface_name = static_cast<const ObPLInterfaceStmt *>(body->get_stmts().at(0))->get_entry();
-    if (OB_UNLIKELY(interface_name.empty())) {
-      ret = OB_ERR_UNEXPECTED;
-      LOG_WARN("interface name is empty", K(ret), K(func_ast.get_name()));
-    }
-  }
-  return ret;
-}
-
-int init_interface_routine(const ObPLFunctionAST &func_ast, ObPLFunction &func)
-{
-  int ret = OB_SUCCESS;
-  ObString interface_name;
-  OZ (extract_interface_name(func_ast, interface_name));
-  OZ (func.set_interface_name(interface_name));
-  OZ (func.set_variables(func_ast.get_symbol_table()));
-  OZ (func.set_types(func_ast.get_user_type_table()));
-  OZ (func.get_dependency_table().assign(func_ast.get_dependency_table()));
-  OX (func.set_action((uint64_t)(&ObPL::interface_execute)));
-  OX (func.set_can_cached(func_ast.get_can_cached()));
-  OX (func.set_is_all_sql_stmt(false));
-  OX (func.set_has_parallel_affect_factor(func_ast.has_parallel_affect_factor()));
-  OX (func.add_members(func_ast.get_flag()));
-  OX (func.set_pipelined(func_ast.get_pipelined()));
-  return ret;
-}
-
-bool need_package_level_codegen(const ObPLPackageAST &package_ast)
-{
-  const ObPLStmtBlock *body = package_ast.get_body();
-  return (OB_NOT_NULL(body) && body->get_stmts().count() > 0)
-      || !package_ast.get_obj_access_exprs().empty();
-}
-
-bool should_direct_dispatch_intf(const ObPLFunctionAST &func_ast)
-{
-  return is_embed_mode() && func_ast.get_compile_flag().compile_with_intf();
-}
-
-bool should_codegen_package(const ObPLPackageAST &package_ast)
-{
-  return !is_embed_mode() || need_package_level_codegen(package_ast);
-}
 }
 
 int ObPLCompiler::check_dep_schema(ObSchemaGetterGuard &schema_guard,
@@ -634,17 +573,7 @@ int ObPLCompiler::compile(
   LOG_INFO(">>>>>>>>Resolve Time: ", K(routine.get_routine_id()), K(routine.get_routine_name()), K(resolve_end - parse_end));
   FLT_SET_TAG(pl_compile_resolve_time, resolve_end - parse_end);
   //Step 4: Code Generator
-  // Embedded builds do not provide LLVM, so INTF routines execute via the
-  // pre-registered C interface trampoline instead of JIT codegen.
-  if (OB_SUCC(ret) && should_direct_dispatch_intf(func_ast)) {
-    OZ (init_interface_routine(func_ast, func));
-    OX (func.set_ret_type(func_ast.get_ret_type()));
-    OX (func.get_stat_for_update().schema_version_ = routine.get_schema_version());
-    OX (func.get_stat_for_update().pl_cg_mem_hold_ = 0);
-    OZ (func.set_tenant_sys_schema_version(schema_guard_));
-    OZ (check_dep_schema(schema_guard_, func.get_dependency_table()));
-  } else if (OB_SUCC(ret)) {
-
+  if (OB_SUCC(ret)) {
     {
       // Interpreter path: no LLVM codegen / JIT and no persistent DLL. Prepare the
       // routine's ObSqlExpressions + copy AST metadata onto the func; the tree-walking
@@ -956,9 +885,7 @@ int ObPLCompiler::compile_package(const ObPackageInfo &package_info,
   int64_t resolve_end = ObTimeUtility::current_time();
   FLT_SET_TAG(pl_compile_resolve_time, resolve_end - compile_start);
 
-  // In embedded mode, pure INTF packages can skip LLVM entirely; non-embedded
-  // mode preserves the historical package compilation path.
-  if (OB_SUCC(ret) && should_codegen_package(package_ast)) {
+  if (OB_SUCC(ret)) {
     {
       lib::ObMallocHookAttrGuard malloc_guard(lib::ObMemAttr(GET_PL_MOD_STRING(pl::OB_PL_CODE_GEN)));
       // Interpreter path: prepare the package's expressions only, no LLVM codegen.
@@ -967,8 +894,6 @@ int ObPLCompiler::compile_package(const ObPackageInfo &package_info,
       OZ (pl_finalize_expressions(session_info_, schema_guard_, package_ast, package));
       OX (package.get_stat_for_update().pl_cg_mem_hold_ = 0);
     }
-  } else if (OB_SUCC(ret)) {
-    OX (package.get_stat_for_update().pl_cg_mem_hold_ = 0);
   }
 
   OZ (generate_package(copy_exec_env, package_ast, package));
@@ -1421,35 +1346,23 @@ int ObPLCompiler::compile_subprogram_table(common::ObIAllocator &allocator,
         new (routine) ObPLFunction(compile_unit.get_mem_context());
         OZ (init_function(schema_guard, exec_env, *routine_info, *routine));
         if (OB_SUCC(ret)) {
-          // Embedded builds dispatch INTF routines directly because LLVM is
-          // unavailable; non-embedded builds intentionally keep the normal path.
-          if (should_direct_dispatch_intf(*routine_ast)) {
-            OZ (init_interface_routine(*routine_ast, *routine));
-            OX (routine->set_ret_type(routine_ast->get_ret_type()));
-            if (OB_FAIL(compile_unit.add_routine(routine))) {
-              LOG_WARN("package add routine failed", K(ret));
-            }
-          } else {
-            {
-              lib::ObMallocHookAttrGuard malloc_guard(lib::ObMemAttr(GET_PL_MOD_STRING(pl::OB_PL_CODE_GEN)));
-              // Interpreter path: prepare expressions + copy metadata + retain AST, no LLVM codegen.
-              OZ (pl_prepare_expressions(*routine_ast, *routine));
-              OZ (pl_finalize_expressions(session_info, schema_guard, *routine_ast, *routine));
-              OZ (routine->get_enum_set_ctx().assgin(routine_ast->get_enum_set_ctx()));
-              OZ (routine->set_variables(routine_ast->get_symbol_table()));
-              OZ (routine->set_types(routine_ast->get_user_type_table()));
-              OZ (routine->get_dependency_table().assign(routine_ast->get_dependency_table()));
-              OZ (routine->add_members(routine_ast->get_flag()));
-              OX (routine->set_pipelined(routine_ast->get_pipelined()));
-              OX (routine->set_can_cached(routine_ast->get_can_cached()));
-              OX (routine->set_has_incomplete_rt_dep_error(routine_ast->has_incomplete_rt_dep_error()));
-              OX (routine->set_is_all_sql_stmt(routine_ast->get_is_all_sql_stmt()));
-              OX (routine->set_has_parallel_affect_factor(routine_ast->has_parallel_affect_factor()));
-              OX (routine->set_ret_type(routine_ast->get_ret_type()));
-              OX (routine->set_ast(routine_ast));
-              OZ (compile_unit.add_routine(routine));
-            } // end of HEAP_VAR
-          }
+          lib::ObMallocHookAttrGuard malloc_guard(lib::ObMemAttr(GET_PL_MOD_STRING(pl::OB_PL_CODE_GEN)));
+          // Interpreter path: prepare expressions + copy metadata + retain AST, no LLVM codegen.
+          OZ (pl_prepare_expressions(*routine_ast, *routine));
+          OZ (pl_finalize_expressions(session_info, schema_guard, *routine_ast, *routine));
+          OZ (routine->get_enum_set_ctx().assgin(routine_ast->get_enum_set_ctx()));
+          OZ (routine->set_variables(routine_ast->get_symbol_table()));
+          OZ (routine->set_types(routine_ast->get_user_type_table()));
+          OZ (routine->get_dependency_table().assign(routine_ast->get_dependency_table()));
+          OZ (routine->add_members(routine_ast->get_flag()));
+          OX (routine->set_pipelined(routine_ast->get_pipelined()));
+          OX (routine->set_can_cached(routine_ast->get_can_cached()));
+          OX (routine->set_has_incomplete_rt_dep_error(routine_ast->has_incomplete_rt_dep_error()));
+          OX (routine->set_is_all_sql_stmt(routine_ast->get_is_all_sql_stmt()));
+          OX (routine->set_has_parallel_affect_factor(routine_ast->has_parallel_affect_factor()));
+          OX (routine->set_ret_type(routine_ast->get_ret_type()));
+          OX (routine->set_ast(routine_ast));
+          OZ (compile_unit.add_routine(routine));
         }
       }
       if (OB_FAIL(ret) && OB_NOT_NULL(routine)) {

--- a/src/sql/resolver/dml/ob_dml_resolver.cpp
+++ b/src/sql/resolver/dml/ob_dml_resolver.cpp
@@ -36,8 +36,6 @@
 #include "share/domain_id/ob_domain_id.h"
 #include "share/vector_index/ob_vector_index_util.h"
 #include "sql/engine/expr/ob_expr_regexp.h"
-#ifndef OB_BUILD_EMBED_MODE
-#endif
 #include "share/catalog/ob_catalog_utils.h"
 #include "sql/resolver/dcl/ob_dcl_resolver.h"
 #include "sql/resolver/ddl/ob_ddl_resolver.h"
@@ -8485,7 +8483,8 @@ int ObDMLResolver::resolve_json_table_column_type(const ParseNode &parse_tree,
       ret = OB_INVALID_ARGUMENT;
       LOG_WARN("invalid obj type", K(ret), K(obj_type));
     } else {
-      bool convert_real_to_decimal = (true && GCONF._enable_convert_real_to_decimal);
+      omt::ObTenantConfigGuard tcg(TENANT_CONF());
+      bool convert_real_to_decimal = (tcg.is_valid() && tcg->_enable_convert_real_to_decimal);
       uint64_t tenant_data_version = 0;
       bool enable_mysql_compatible_dates = false;
       if (OB_FAIL(ObSQLUtils::check_enable_mysql_compatible_dates(session_info_, false,
@@ -9676,9 +9675,10 @@ int ObDMLResolver::generate_ddl_sample_info_if_needed(TableItem &table_item)
       sample_info->method_ = SampleInfo::SampleMethod::DDL_BLOCK_SAMPLE;
       sample_info->scope_ = SampleInfo::SAMPLE_ALL_DATA;
       int64_t px_object_sample_rate = 0;
-
-      px_object_sample_rate = GCONF._px_object_sampling;
-
+      omt::ObTenantConfigGuard tenant_config(TENANT_CONF());
+      if (tenant_config.is_valid()) {
+        px_object_sample_rate = tenant_config->_px_object_sampling;
+      }
       sample_info->percent_ = (double)px_object_sample_rate / 1000;
       sample_info->table_id_ = table_item.table_id_;
       // Check if target table is FTS or vector index via upper_insert_resolver_

--- a/src/sql/resolver/dml/ob_dml_resolver.h
+++ b/src/sql/resolver/dml/ob_dml_resolver.h
@@ -24,8 +24,6 @@
 #include "sql/resolver/expr/ob_raw_expr_util.h"
 #include "sql/resolver/dml/ob_select_stmt.h"
 #include "sql/resolver/expr/ob_shared_expr_resolver.h"
-#ifndef OB_BUILD_EMBED_MODE
-#endif
 namespace oceanbase
 {
 namespace sql


### PR DESCRIPTION
## Task Description
In an embedded build created with `-DBUILD_EMBED_MODE=ON`, executing `CALL dbms_index_manager.refresh;` failed with `ERROR 1235 (0A000): Not supported feature or function`.
The package SQL and native implementation were both present, but embedded PL compilation had a separate direct-dispatch path for `PRAGMA INTERFACE` routines. That path skipped the normal interpreter metadata setup used by non-embedded builds.

## Solution Description
Remove the embedded-only PL interface direct-dispatch branch and package codegen skip branch.
Embedded and non-embedded builds now use the same PL compile path: prepare expressions, retain the AST, and let the interpreter execute `PL_INTERFACE -> spi_interface_impl`.

## Passed Regressions
- `ob-make -j4 ob_pl` in `build_release_embedded`
- `ob-make -j4 seekdb` in `build_release_embedded`
- Started the rebuilt embedded `seekdb` on a temporary local port and verified `CALL dbms_index_manager.refresh;` succeeds.
- Server log confirmed `ObDBMSIndexManager::refresh` ran and `change stream refresh scn caught up`.

## Upgrade Compatibility
No schema or data format change. This only aligns embedded PL interface routine compilation with the existing non-embedded path.

## Other Information
MR range contains one commit:
- `ebebc2f1787 fix pl calling in embed mode`

## Release Note
