### PR TITLE
[seekdb][vector] Fix HGRAPH snapshot key prefix

### DIFF
--- a/src/storage/ddl/ob_ddl_pipeline.cpp
+++ b/src/storage/ddl/ob_ddl_pipeline.cpp
@@ -497,7 +497,7 @@ int ObHNSWIndexRowIterator::get_next_row(
     } else if (index_type_ == VIAT_HNSW && OB_FAIL(databuff_printf(key_str, OB_VEC_IDX_SNAPSHOT_KEY_LENGTH, key_pos, "%lu_%ld_hnsw_data_part%05ld", tablet_id_.id(), snapshot_version_, cur_row_pos_))) {
       LOG_WARN("fail to build vec snapshot key str", K(ret), K_(index_type));
     } else if (index_type_ == VIAT_HGRAPH &&
-      OB_FAIL(databuff_printf(key_str, OB_VEC_IDX_SNAPSHOT_KEY_LENGTH, key_pos, "%lu_hgraph_data_part%05ld", tablet_id_.id(), cur_row_pos_))) {
+      OB_FAIL(databuff_printf(key_str, OB_VEC_IDX_SNAPSHOT_KEY_LENGTH, key_pos, "%lu_%ld_hgraph_data_part%05ld", tablet_id_.id(), snapshot_version_, cur_row_pos_))) {
       LOG_WARN("fail to build vec hgraph snapshot key str", K(ret), K_(index_type));
     } else if (index_type_ == VIAT_HNSW_SQ && OB_FAIL(databuff_printf(key_str, OB_VEC_IDX_SNAPSHOT_KEY_LENGTH, key_pos, "%lu_%ld_hnsw_sq_data_part%05ld", tablet_id_.id(), snapshot_version_, cur_row_pos_))) {
       LOG_WARN("fail to build sq vec snapshot key str", K(ret), K_(index_type));


### PR DESCRIPTION
## Task Description
Fix a Vsag deserialize failure (`BufferStreamReader: The file size is smaller than the memory you want to read`) that occurs when OceanBase reloads a serialized HGRAPH snapshot index from the snapshot data table. The failure happens because the binary stream reconstructed from snapshot rows can be incomplete or mixed, causing Vsag to attempt reading more bytes than are available.

## Solution Description
The root cause was that the row key for normal DDL HGRAPH snapshot data was generated without the snapshot version (`tabletId_hgraph_data_partNNNNN`), while other vector snapshot paths (direct-load, async refresh) correctly used `tabletId_snapshotVersion_hgraph_data_partNNNNN`. This missing version weakened version isolation.

The fix modifies the normal DDL HGRAPH snapshot key generation to include the `snapshot_version_`, making it `tabletId_snapshotVersion_hgraph_data_partNNNNN`. This aligns it with the existing direct-load and async refresh key formats and restores the invariant shared by write, adapter prefix management, and reload operations.

## Passed Regressions
- `git diff --check`
- `ob-make -j4 ob_storage`

## Upgrade Compatibility
This change only affects newly written HGRAPH snapshot-data row keys generated by normal DDL. It aligns the normal DDL key format with the existing formats used by direct-load and async refresh.

## Other Information
- Local commit: `ca47db833ea fix vector hgraph snapshot key prefix`.
- Untracked local file `2` is not included in this MR.
- Related issue: DIMA-2026062500116993052.

## Release Note
Fixed a Vsag deserialize failure during HGRAPH snapshot index reload by correcting the snapshot data row key prefix for normal DDL operations to include the snapshot version, ensuring proper version isolation.