### PR TITLE
Add LLVM Source-based Code Coverage Support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,8 @@ ANDROID_BUILD=false
 LLD_OPTION=ON
 ASAN_OPTION=ON
 STATIC_LINK_LGPL_DEPS_OPTION=ON
+ENABLE_BOLT_OPTION=ON
+WITH_COVERAGE=OFF
 
 echo "$0 ${ALL_ARGS[@]}"
 
@@ -49,6 +51,7 @@ function usage
     echo -e "\nOPTIONS:"
     echo -e "\tBuildType => debug(default), release, errsim, dissearray, rpm"
     echo -e "\t--android  => Cross-compile for Android NDK (arm64-v8a)"
+    echo -e "\t--coverage => turn ON clang source-based coverage (WITH_COVERAGE); omitting it = OFF; also disables BOLT"
     echo -e "\tMakeOptions => Options to make command, default: -j N"
 
     echo -e "\nExamples:"
@@ -85,6 +88,9 @@ function parse_args
         elif [[ "$i" == "-DBUILD_CDC_ONLY=ON" ]]
         then
             BUILD_ARGS+=("$i")
+        elif [[ "$i" == "--coverage" ]]
+        then
+            WITH_COVERAGE=ON
         elif [[ $NEED_MAKE == false ]]
         then
             BUILD_ARGS+=("$i")
@@ -97,6 +103,9 @@ function parse_args
         echo_log '[NOTICE] lld is disabled in kernel release 6'
         LLD_OPTION="OFF"
     fi
+
+    BUILD_ARGS+=("-DWITH_COVERAGE=$WITH_COVERAGE")
+    [[ "$WITH_COVERAGE" == "ON" ]] && BUILD_ARGS+=("-DENABLE_BOLT=OFF")
 }
 
 # try call command make, if use give --make in command line.
@@ -238,9 +247,6 @@ function build
       xrelease_asan)
         do_build "$@" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOB_USE_LLD=$LLD_OPTION -DOB_USE_ASAN=$ASAN_OPTION -DOB_ENABLE_MCMODEL=OFF
         ;;
-      xrelease_coverage)
-        do_build "$@" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOB_USE_LLD=$LLD_OPTION -DWITH_COVERAGE=ON
-        ;;
       xrelease_embedded)
         do_build "$@" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOB_USE_LLD=$LLD_OPTION -DBUILD_EMBED_MODE=ON
         ;;
@@ -281,9 +287,6 @@ function build
       xpackage) 
         # automatic determination of packaging type 
         build_package "$@"
-        ;;
-      xcoverage)
-        do_build "$@" -DCMAKE_BUILD_TYPE=Debug -DOB_USE_LLD=$LLD_OPTION -DWITH_COVERAGE=ON
         ;;
       xsanity)
         do_build "$@" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOB_USE_LLD=$LLD_OPTION -DENABLE_SANITY=ON -DOB_ENABLE_MCMODEL=ON

--- a/cmake/Env.cmake
+++ b/cmake/Env.cmake
@@ -77,11 +77,8 @@ endif()
 message(STATUS "ARCHITECTURE: ${ARCHITECTURE}")
 
 if(WITH_COVERAGE)
-  # -ftest-coverage to generate .gcno file
-  # -fprofile-arcs to generate .gcda file
-  # -DDBUILD_COVERAGE marco use to mark 'coverage build type' and to handle some special case
-  set(CMAKE_COVERAGE_COMPILE_OPTIONS -ftest-coverage -fprofile-arcs -Xclang -coverage-version=408R -DBUILD_COVERAGE)
-  set(CMAKE_COVERAGE_EXE_LINKER_OPTIONS "-ftest-coverage -fprofile-arcs")
+  set(CMAKE_COVERAGE_COMPILE_OPTIONS -fprofile-instr-generate -fcoverage-mapping -mllvm -runtime-counter-relocation -DWITH_COVERAGE)
+  set(CMAKE_COVERAGE_EXE_LINKER_OPTIONS "-fprofile-instr-generate -Wl,-u,__llvm_profile_reset_counters -Wl,-u,__llvm_profile_set_filename -Wl,-u,__llvm_profile_write_file")
 
   add_compile_options(${CMAKE_COVERAGE_COMPILE_OPTIONS})
   set(DEBUG_PREFIX "")

--- a/src/observer/main.cpp
+++ b/src/observer/main.cpp
@@ -16,6 +16,36 @@
 
 #define USING_LOG_PREFIX SERVER
 
+#ifdef WITH_COVERAGE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+// Set LLVM_PROFILE_FILE before the coverage runtime's constructor reads it, so counters go straight
+// to <base_dir>/seekdb.profraw (continuous) and no default.profraw is ever created.
+__attribute__((constructor(101)))
+static void seekdb_cov_init_profile_file(int argc, char **argv)
+{
+  const char *base = ".";
+  for (int i = 1; i < argc; ++i) {
+    if (strncmp(argv[i], "--base-dir=", 11) == 0) { base = argv[i] + 11; break; }
+    if (strcmp(argv[i], "--base-dir") == 0 && i + 1 < argc) { base = argv[i + 1]; break; }
+  }
+  char abs_base[1024];
+  if (base[0] == '/') {
+    snprintf(abs_base, sizeof(abs_base), "%s", base);
+  } else {
+    char cwd[1024] = {0};
+    (void)getcwd(cwd, sizeof(cwd));
+    snprintf(abs_base, sizeof(abs_base), "%s/%s", cwd, base);
+  }
+  char val[1100];
+  snprintf(val, sizeof(val), "%s/seekdb%%c.profraw", abs_base);
+  setenv("LLVM_PROFILE_FILE", val, 1);
+  fprintf(stderr, "Coverage: LLVM_PROFILE_FILE='%s'\n", val);
+}
+#endif
+
 #include "lib/alloc/malloc_hook.h"
 #include "lib/alloc/ob_malloc_allocator.h"
 #include "lib/allocator/ob_malloc.h"

--- a/src/observer/main.cpp
+++ b/src/observer/main.cpp
@@ -21,8 +21,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-// Set LLVM_PROFILE_FILE before the coverage runtime's constructor reads it, so counters go straight
-// to <base_dir>/seekdb.profraw (continuous) and no default.profraw is ever created.
+// Point the coverage runtime at <base_dir>/seekdb.profraw (continuous) from a priority-101
+// constructor, which runs before the runtime's own initializer, so counters go straight there
+// and no default.profraw is ever created.
+extern "C" void __llvm_profile_set_filename(const char *);
 __attribute__((constructor(101)))
 static void seekdb_cov_init_profile_file(int argc, char **argv)
 {
@@ -41,8 +43,8 @@ static void seekdb_cov_init_profile_file(int argc, char **argv)
   }
   char val[1100];
   snprintf(val, sizeof(val), "%s/seekdb%%c.profraw", abs_base);
-  setenv("LLVM_PROFILE_FILE", val, 1);
-  fprintf(stderr, "Coverage: LLVM_PROFILE_FILE='%s'\n", val);
+  __llvm_profile_set_filename(val);
+  fprintf(stderr, "Coverage: set_filename('%s')\n", val);
 }
 #endif
 


### PR DESCRIPTION
## Task Description
Add LLVM source-based code coverage support in seekdb.

## Solution Description

## Passed Regressions

## Upgrade Compatibility

## Other Information
- Related internal link: DIMA-2026062300116930662

## Release Note
