### PR TITLE
Fix bootstrap telemetry lost on fast embedded exit

### DIFF
--- a/src/observer/ob_server.cpp
+++ b/src/observer/ob_server.cpp
@@ -967,7 +967,8 @@ int ObServer::start(bool embed_mode)
     } else {
       FLOG_INFO("success to start root service monitor");
     }
-    if (FAILEDx(ob_service_.start(embed_mode))) {
+    // Treat --embedded as the embed telemetry reporter; ObService reports bootstrap telemetry synchronously.
+    if (FAILEDx(ob_service_.start(embed_mode || embedded_))) {
       LOG_ERROR("fail to start oceanbase service", KR(ret));
     } else {
       FLOG_INFO("success to start oceanbase service");

--- a/src/observer/ob_service.cpp
+++ b/src/observer/ob_service.cpp
@@ -135,11 +135,16 @@ TelemetryTask::TelemetryTask(bool embed_mode)
   : embed_mode_(embed_mode)
 {}
 
-void TelemetryTask::runTimerTask()
+int TelemetryTask::report_(bool embed_mode)
 {
   const char *env_reporter = std::getenv("REPORTER");
-  const char *reporter = env_reporter ? env_reporter : (embed_mode_ ? "embed" : "server");
-  share::report_telemetry(reporter, "bootstraped");
+  const char *reporter = env_reporter ? env_reporter : (embed_mode ? "embed" : "server");
+  return share::report_telemetry(reporter, "bootstraped");
+}
+
+int TelemetryTask::report()
+{
+  return report_(embed_mode_);
 }
 
 //////////////////////////////////////
@@ -243,9 +248,9 @@ int ObService::start(bool embed_mode)
     }
     if (OB_SUCC(ret)) {
       telemetry_task_.embed_mode_ = embed_mode;
-      if (OB_SUCCESS != TG_SCHEDULE(lib::TGDefIDs::ServerGTimer, telemetry_task_,
-          1L * 1000 * 1000, false)) {
-        FLOG_ERROR("fail to schedule telemetry task");
+      int tmp_ret = OB_SUCCESS;
+      if (OB_SUCCESS != (tmp_ret = telemetry_task_.report())) {
+        FLOG_WARN("fail to report bootstrap telemetry synchronously", KR(tmp_ret));
       }
     }
     need_bootstrap_ = false;

--- a/src/observer/ob_service.h
+++ b/src/observer/ob_service.h
@@ -57,11 +57,13 @@ private:
   bool is_inited_;
 };
 
-class TelemetryTask : public common::ObTimerTask {
+class TelemetryTask {
 public:
   TelemetryTask(bool embed_mode);
-  virtual void runTimerTask() override;
+  int report();
   bool embed_mode_;
+private:
+  static int report_(bool embed_mode);
 };
 
 class ObService


### PR DESCRIPTION
## Summary
- Ensure bootstrap telemetry can be synced before fast embedded exits.
- Thread the sync control through the observer service shutdown path.

## Validation
- `git diff --check origin/release/1.3.0..HEAD`