### PR TITLE
Fix missing grammar alternative separator in SQL parser

### DIFF
--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -19273,6 +19273,7 @@ alter_with_opt_hint SYSTEM DISABLE SQL THROTTLE
   (void)($1);
   malloc_terminal_node($$, result->malloc_pool_, T_DISABLE_SQL_THROTTLE);
 }
+|
 alter_with_opt_hint SYSTEM ADD RESTORE SOURCE STRING_VALUE
 {
   (void)($1);


### PR DESCRIPTION
## Summary
- Add the missing `|` between `alter_system_stmt` grammar alternatives in `sql_parser_mysql_mode.y`
- Fixes `./build.sh release --init` failing during bison SQL parser generation on macOS

## Test plan
- [x] `./build.sh release --init` completes successfully on macOS arm64
- [ ] `./build.sh release --init --make` (optional full compile)