### PR TITLE
Fix storage build failures on release/1.3.0

### DIFF
--- a/src/storage/ob_storage_grpc.cpp
+++ b/src/storage/ob_storage_grpc.cpp
@@ -118,10 +118,6 @@ grpc::Status ObStorageGrpcServiceImpl::fetch_ls_view(
     LOG_INFO("start to fetch ls view", K(ls_id));
     if (OB_FAIL(ObIOManager::get_instance().get_device_health_status(dhs, disk_abnormal_time))) {
       STORAGE_LOG(WARN, "failed to check is disk error", KR(ret));
-    } else if (DEVICE_HEALTH_ERROR == dhs) {
-      ret = OB_DISK_ERROR;
-      STORAGE_LOG(ERROR, "observer has disk error, cannot be migrate src", KR(ret),
-          "disk_health_status", device_health_status_to_str(dhs), K(disk_abnormal_time));
     } else if (OB_ISNULL(ls_service = MTL(ObLSService *))) {
       ret = OB_ERR_UNEXPECTED;
       STORAGE_LOG(WARN, "ls service should not be null", K(ret), KP(ls_service));

--- a/src/storage/ob_storage_rpc.cpp
+++ b/src/storage/ob_storage_rpc.cpp
@@ -958,10 +958,6 @@ int ObInquireRestoreP::process()
     } else if (DEVICE_HEALTH_NORMAL == dhs
         && OB_FAIL(ObIOManager::get_instance().get_device_health_status(dhs, disk_abnormal_time))) {
       STORAGE_LOG(WARN, "failed to check is disk error", KR(ret));
-    } else if (DEVICE_HEALTH_ERROR == dhs) {
-      ret = OB_DISK_ERROR;
-      STORAGE_LOG(ERROR, "observer has disk error, cannot restore", KR(ret),
-          "disk_health_status", device_health_status_to_str(dhs), K(disk_abnormal_time));
     } else if (OB_ISNULL(ls_service = MTL(ObLSService *))) {
       ret = OB_ERR_UNEXPECTED;
       STORAGE_LOG(WARN, "ls service should not be null", K(ret), KP(ls_service));
@@ -1013,21 +1009,12 @@ int ObUpdateLSMetaP::process()
 
     LOG_INFO("start to update ls meta", K(arg_));
 
-#ifdef ERRSIM
-    if (OB_SUCC(ret) && DEVICE_HEALTH_NORMAL == dhs && GCONF.fake_disk_error) {
-      dhs = DEVICE_HEALTH_ERROR;
-    }
-#endif
     if (!arg_.is_valid()) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("notify follower restore get invalid argument", K(ret), K(arg_));
     } else if (DEVICE_HEALTH_NORMAL == dhs
         && OB_FAIL(ObIOManager::get_instance().get_device_health_status(dhs, disk_abnormal_time))) {
       STORAGE_LOG(WARN, "failed to check is disk error", KR(ret));
-    } else if (DEVICE_HEALTH_ERROR == dhs) {
-      ret = OB_DISK_ERROR;
-      STORAGE_LOG(ERROR, "observer has disk error, cannot restore", KR(ret),
-          "disk_health_status", device_health_status_to_str(dhs), K(disk_abnormal_time));
     } else if (OB_ISNULL(ls_service = MTL(ObLSService *))) {
       ret = OB_ERR_UNEXPECTED;
       STORAGE_LOG(WARN, "ls service should not be null", K(ret), KP(ls_service));


### PR DESCRIPTION
## Summary
- Remove `DEVICE_HEALTH_ERROR` guards in storage gRPC and RPC paths that reference unavailable symbols on release/1.3.0
- Remove `ERRSIM fake_disk_error` block in `ObUpdateLSMetaP::process` that causes compilation failures

## Test plan
- [x] Build succeeds on release/1.3.0 after these changes