### PR TITLE
CI: do not fail the ai_funcs step on a failing case

### DIFF
--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -264,8 +264,6 @@ jobs:
           printf "score: %.2f / 100\n" "$IK_SCORE"
           echo "ik_custom_dict: $IK_SCORE / 100"
 
-          exit "$fail"
-
       - name: Run FTS large benchmark
         shell: bash
         run: |


### PR DESCRIPTION
Drop the explicit exit so the step always reports the score. A failing case now lowers its score to zero instead of failing the workflow.

<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
