### PR TITLE
CI: render the ai_funcs scores in the VLDB benchmark PR comment

### DIFF
--- a/.github/workflows/vldb-benchmark-comment.yml
+++ b/.github/workflows/vldb-benchmark-comment.yml
@@ -43,8 +43,9 @@ jobs:
 
           REPORT_PATH="$ARTIFACT_DIR/report.txt"
           SCORE_PATH="$ARTIFACT_DIR/score.txt"
-          if [[ ! -f "$REPORT_PATH" ]]; then
-            echo "benchmark comment artifact not found, skip PR comment"
+          AI_FUNCS_SCORE_PATH="$ARTIFACT_DIR/ai_funcs_score.txt"
+          if [[ ! -f "$REPORT_PATH" && ! -f "$AI_FUNCS_SCORE_PATH" ]]; then
+            echo "comment artifact has neither benchmark report nor ai_funcs score, skip PR comment"
             exit 0
           fi
 
@@ -107,34 +108,49 @@ jobs:
               )
           PY
 
-          python3 - "$REPORT_PATH" "$SCORE_PATH" "$RUN_URL" "$MARKER" > "$COMMENT_BODY" <<'PY'
+          python3 - "$REPORT_PATH" "$SCORE_PATH" "$AI_FUNCS_SCORE_PATH" "$RUN_URL" "$MARKER" > "$COMMENT_BODY" <<'PY'
           import html
           import json
           from pathlib import Path
           import sys
 
-          report_path, score_path, run_url, marker = sys.argv[1:5]
-          report = Path(report_path).read_text(encoding="utf-8").strip()
-          score = ""
-          if score_path and Path(score_path).is_file():
-              score = Path(score_path).read_text(encoding="utf-8").strip()
+          report_path, score_path, ai_funcs_score_path, run_url, marker = sys.argv[1:6]
 
-          parts = [
-              marker,
-              "### FTS Large Benchmark Score",
-              "",
-              "<pre>",
-              html.escape(score or "score output not found"),
-              "</pre>",
-              "",
-              "### FTS Large Benchmark Report",
-              "",
-              "<pre>",
-              html.escape(report),
-              "</pre>",
-              "",
-              f"[Workflow run]({run_url})",
-          ]
+          def read_optional(path):
+              if path and Path(path).is_file():
+                  return Path(path).read_text(encoding="utf-8").strip()
+              return ""
+
+          report = read_optional(report_path)
+          score = read_optional(score_path)
+          ai_funcs_score = read_optional(ai_funcs_score_path)
+
+          parts = [marker]
+          if ai_funcs_score:
+              parts += [
+                  "### Document AI & IK Custom Dictionary Score",
+                  "",
+                  "<pre>",
+                  html.escape(ai_funcs_score),
+                  "</pre>",
+                  "",
+              ]
+          if report:
+              parts += [
+                  "### FTS Large Benchmark Score",
+                  "",
+                  "<pre>",
+                  html.escape(score or "score output not found"),
+                  "</pre>",
+                  "",
+                  "### FTS Large Benchmark Report",
+                  "",
+                  "<pre>",
+                  html.escape(report),
+                  "</pre>",
+                  "",
+              ]
+          parts.append(f"[Workflow run]({run_url})")
           body = "\n".join(parts)
           print(json.dumps({"body": body}, ensure_ascii=False))
           PY


### PR DESCRIPTION
Read ai_funcs_score.txt out of the comment artifact and emit it as a "Document AI & IK Custom Dictionary Score" section above the FTS sections.

Each section is now emitted only when its input file exists, and the job no longer skips the comment when the FTS benchmark produced no report but the ai_funcs score is present.

This workflow is triggered by workflow_run, so GitHub always runs the copy on the default branch. The change has to land here for PRs targeting vldb_2026 to show the scores.

<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
