### PR TITLE
slog: buffer allocation on-demand

### DIFF
--- a/src/storage/slog/ob_storage_logger_manager.cpp
+++ b/src/storage/slog/ob_storage_logger_manager.cpp
@@ -31,6 +31,7 @@ namespace storage
 {
 ObStorageLoggerManager::ObStorageLoggerManager()
     : allocator_(SET_USE_UNEXPECTED_500("StorageLoggerM")),
+      allocator_lock_(),
       log_dir_(nullptr),
       max_log_file_size_(0),
       is_inited_(false),
@@ -59,9 +60,9 @@ int ObStorageLoggerManager::init(
   } else if (OB_UNLIKELY(nullptr == log_dir || nullptr == data_dir || max_log_file_size <= 0)) {
     ret = OB_INVALID_ARGUMENT;
     STORAGE_REDO_LOG(WARN, "invalid arguments", K(ret), KP(log_dir), KP(data_dir), K(max_log_file_size));
-  } else if (OB_FAIL(prepare_log_buffers(MAX_CONCURRENT_ITEM_CNT, NORMAL_LOG_ITEM_SIZE))) {
+  } else if (OB_FAIL(prepare_log_buffers(MAX_CONCURRENT_ITEM_CNT))) {
     STORAGE_REDO_LOG(WARN, "fail to prepare log buffers", K(ret),
-        LITERAL_K(MAX_CONCURRENT_ITEM_CNT), LITERAL_K(NORMAL_LOG_ITEM_SIZE));
+        LITERAL_K(MAX_CONCURRENT_ITEM_CNT));
   } else if (OB_FAIL(prepare_log_items(MAX_CONCURRENT_ITEM_CNT))) {
     STORAGE_REDO_LOG(WARN, "fail to prepare log items", K(ret), LITERAL_K(MAX_CONCURRENT_ITEM_CNT));
   } else if (OB_FAIL(check_log_disk(data_dir, log_dir))) {
@@ -146,7 +147,9 @@ int ObStorageLoggerManager::alloc_item(
     const int64_t num)
 {
   int ret = OB_SUCCESS;
+  int tmp_ret = OB_SUCCESS;
   void *log_buffer = nullptr;
+  log_item = nullptr;
   bool alloc_locally = buf_size > NORMAL_LOG_ITEM_SIZE;
   int64_t total_size = buf_size;
 
@@ -168,16 +171,26 @@ int ObStorageLoggerManager::alloc_item(
       ret = OB_SIZE_OVERFLOW;
       STORAGE_REDO_LOG(ERROR, "Log item is too large", K(ret),
           K(total_size), LITERAL_K(ObLogConstants::LOG_ITEM_MAX_LENGTH));
-    } else if (!alloc_locally && OB_FAIL(alloc_log_buffer(log_buffer))) {
-      STORAGE_REDO_LOG(WARN, "Fail to alloc memory for log buffer", K(ret));
     } else if (OB_FAIL(alloc_log_item(log_item))) {
       STORAGE_REDO_LOG(WARN, "Fail to alloc memory for log item", K(ret));
+    } else if (!alloc_locally && OB_FAIL(alloc_log_buffer(log_buffer))) {
+      STORAGE_REDO_LOG(WARN, "Fail to alloc memory for log buffer", K(ret));
     } else if (OB_FAIL(log_item->init(reinterpret_cast<char *>(log_buffer),
         total_size, ObLogConstants::LOG_FILE_ALIGN_SIZE, num))) {
       STORAGE_REDO_LOG(WARN, "Fail to init log item", K(ret));
     } else {
       STORAGE_REDO_LOG(DEBUG, "Successfully alloc memory", K(ret));
     }
+  }
+
+  if (OB_FAIL(ret)) {
+    if (log_buffer != nullptr && OB_TMP_FAIL(free_log_buffer(log_buffer))) {
+      STORAGE_REDO_LOG(WARN, "Fail to revert log buffer", K(tmp_ret), K(ret), KP(log_buffer));
+    }
+    if (log_item != nullptr && OB_TMP_FAIL(slog_items_.push(log_item))) {
+      STORAGE_REDO_LOG(WARN, "Fail to revert log item", K(tmp_ret), K(ret), KP(log_item));
+    }
+    log_item = nullptr;
   }
 
   return ret;
@@ -209,11 +222,26 @@ int ObStorageLoggerManager::free_item(ObStorageLogItem *log_item)
 int ObStorageLoggerManager::alloc_log_buffer(void *&log_buffer)
 {
   int ret = OB_SUCCESS;
+  const int64_t alloc_size = NORMAL_LOG_ITEM_SIZE
+      + ObLogConstants::LOG_FILE_ALIGN_SIZE - 1;
+  char *raw_buffer = nullptr;
+  log_buffer = nullptr;
 
   if (OB_FAIL(log_buffers_.pop(log_buffer))) {
     if (OB_ENTRY_NOT_EXIST == ret) {
-      ret = OB_SLOG_REACH_MAX_CONCURRENCY;
-      STORAGE_REDO_LOG(WARN, "Log buffer reach maximum", K(ret), K(log_buffers_.capacity()));
+      common::ObSpinLockGuard guard(allocator_lock_);
+      // Reserve alignment padding while keeping the buffer owned by the arena.
+      if (OB_ISNULL(raw_buffer = static_cast<char *>(allocator_.alloc(alloc_size)))) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        STORAGE_REDO_LOG(WARN, "Fail to allocate log buffer",
+            K(ret), K(alloc_size), LITERAL_K(NORMAL_LOG_ITEM_SIZE));
+      } else {
+        // manually align address
+        log_buffer = reinterpret_cast<char *>(upper_align(
+            reinterpret_cast<int64_t>(raw_buffer),
+            ObLogConstants::LOG_FILE_ALIGN_SIZE));
+        ret = OB_SUCCESS;
+      }
     } else {
       STORAGE_REDO_LOG(WARN, "Fail to pop log buffer", K(ret));
     }
@@ -259,7 +287,7 @@ int ObStorageLoggerManager::free_log_item(ObStorageLogItem *log_item)
   return ret;
 }
 
-int ObStorageLoggerManager::prepare_log_buffers(const int64_t count, const int64_t log_buf_size)
+int ObStorageLoggerManager::prepare_log_buffers(const int64_t count)
 {
   int ret = OB_SUCCESS;
 
@@ -268,18 +296,6 @@ int ObStorageLoggerManager::prepare_log_buffers(const int64_t count, const int64
     STORAGE_REDO_LOG(WARN, "Invalid argument", K(ret), K(count));
   } else if (OB_FAIL(log_buffers_.init(count))) {
     STORAGE_REDO_LOG(WARN, "Fail to init log buffers", K(ret), K(count));
-  } else {
-    abort_unless(0 == (log_buf_size & (ObLogConstants::LOG_FILE_ALIGN_SIZE - 1)));
-    char *buf = nullptr;
-    if (OB_ISNULL(buf = (char*)allocator_.alloc_aligned(log_buf_size * count, ObLogConstants::LOG_FILE_ALIGN_SIZE))) {
-      ret = OB_ALLOCATE_MEMORY_FAILED;
-      STORAGE_REDO_LOG(ERROR, "Fail to alloc memory for buffers", K(ret), K(log_buf_size));
-    }
-    for (int64_t i = 0; OB_SUCC(ret) && i < count; ++i) {
-      if (OB_FAIL(log_buffers_.push(buf + i * log_buf_size))) {
-        STORAGE_REDO_LOG(ERROR, "Fail to push log buffer", K(ret), KP(buf));
-      }
-    }
   }
 
   return ret;

--- a/src/storage/slog/ob_storage_logger_manager.h
+++ b/src/storage/slog/ob_storage_logger_manager.h
@@ -22,6 +22,7 @@
 #include "lib/queue/ob_fixed_queue.h"
 #include "storage/blocksstable/ob_log_file_spec.h"
 #include "lib/allocator/ob_concurrent_fifo_allocator.h"
+#include "lib/lock/ob_spin_lock.h"
 #include "common/log/ob_log_cursor.h"
 
 
@@ -60,7 +61,7 @@ public:
 private:
 
   // prepare for log items and their buffers
-  int prepare_log_buffers(const int64_t count, const int64_t log_buf_size);
+  int prepare_log_buffers(const int64_t count);
   int prepare_log_items(const int64_t count);
 
   // allocate buffer
@@ -83,6 +84,7 @@ private:
   static constexpr int64_t MAX_CONCURRENT_ITEM_CNT = 128;
 
   common::ObArenaAllocator allocator_;
+  common::ObSpinLock allocator_lock_;
   const char *log_dir_;
   int64_t max_log_file_size_;
   bool is_inited_;

--- a/unittest/storage/slog/test_storage_logger_manager.cpp
+++ b/unittest/storage/slog/test_storage_logger_manager.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
 #include "storage/blocksstable/ob_data_file_prepare.h"
 #include "storage/slog/simple_ob_storage_log.h"
 #include "storage/slog/ob_storage_log_batch_header.h"
@@ -55,12 +56,14 @@ public:
 
 public:
   static const int64_t MAX_FILE_SIZE = 256 * 1024 * 1024;
-  const int64_t MAX_CONCURRENT_ITEM_CNT = 128;
+  static const int64_t MAX_CONCURRENT_ITEM_CNT = 128;
 
 public:
   ObLogCursor start_cursor_;
   blocksstable::ObLogFileSpec log_file_spec_;
 };
+
+const int64_t TestStorageLoggerManager::MAX_CONCURRENT_ITEM_CNT;
 
 void TestStorageLoggerManager::SetUp()
 {
@@ -93,7 +96,9 @@ TEST_F(TestStorageLoggerManager, test_manager_basic)
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_TRUE(slogger_mgr.need_reserved_);
   ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.log_buffers_.capacity());
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
   ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.slog_items_.capacity());
+  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.slog_items_.get_curr_total());
 
   ObStorageLogItem *log_item = nullptr;
   ObStorageLogItem *log_item_local = nullptr;
@@ -106,22 +111,71 @@ TEST_F(TestStorageLoggerManager, test_manager_basic)
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_TRUE(log_item->is_inited_);
   ASSERT_FALSE(log_item->is_local_);
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
+  char *standard_log_buffer = log_item->get_buf();
+  ASSERT_NE(nullptr, standard_log_buffer);
+  ASSERT_EQ(
+      static_cast<uintptr_t>(0),
+      reinterpret_cast<uintptr_t>(standard_log_buffer) & ObLogConstants::LOG_FILE_ALIGN_MASK);
   // test normal item allocation (local)
   ret = slogger_mgr.alloc_item(513 * 1024, log_item_local, 1);
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_TRUE(log_item_local->is_inited_);
   ASSERT_TRUE(log_item_local->is_local_);
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
 
   // test invalid item free
   ret = slogger_mgr.free_item(nullptr);
   ASSERT_NE(OB_SUCCESS, ret);
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
   // test normal item free
   ret = slogger_mgr.free_item(log_item);
   ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(1, slogger_mgr.log_buffers_.get_curr_total());
   ret = slogger_mgr.free_item(log_item_local);
   ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(1, slogger_mgr.log_buffers_.get_curr_total());
+
+  // test standard log buffer reuse
+  ObStorageLogItem *reused_log_item = nullptr;
+  ret = slogger_mgr.alloc_item(3 * 1024, reused_log_item, 1);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_FALSE(reused_log_item->is_local());
+  ASSERT_EQ(standard_log_buffer, reused_log_item->get_buf());
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
+  ret = slogger_mgr.free_item(reused_log_item);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(1, slogger_mgr.log_buffers_.get_curr_total());
 
   slogger_mgr.destroy();
+}
+
+TEST_F(TestStorageLoggerManager, test_max_concurrent_items)
+{
+  int ret = OB_SUCCESS;
+  ObStorageLoggerManager &slogger_mgr = SERVER_STORAGE_META_SERVICE.get_slogger_manager();
+  ObStorageLogItem *log_items[MAX_CONCURRENT_ITEM_CNT] = {nullptr};
+  ObStorageLogItem *extra_log_item = nullptr;
+
+  for (int64_t i = 0; i < MAX_CONCURRENT_ITEM_CNT; ++i) {
+    ret = slogger_mgr.alloc_item(3 * 1024, log_items[i], 1);
+    ASSERT_EQ(OB_SUCCESS, ret);
+    ASSERT_NE(nullptr, log_items[i]);
+  }
+  ASSERT_EQ(0, slogger_mgr.slog_items_.get_curr_total());
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
+
+  ret = slogger_mgr.alloc_item(3 * 1024, extra_log_item, 1);
+  ASSERT_EQ(OB_SLOG_REACH_MAX_CONCURRENCY, ret);
+  ASSERT_EQ(nullptr, extra_log_item);
+  ASSERT_EQ(0, slogger_mgr.slog_items_.get_curr_total());
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
+
+  for (int64_t i = 0; i < MAX_CONCURRENT_ITEM_CNT; ++i) {
+    ASSERT_EQ(OB_SUCCESS, slogger_mgr.free_item(log_items[i]));
+  }
+  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.slog_items_.get_curr_total());
+  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.log_buffers_.get_curr_total());
 }
 
 TEST_F(TestStorageLoggerManager, test_slogger_basic)
@@ -196,7 +250,7 @@ TEST_F (TestStorageLoggerManager, test_build_item)
   ret = slogger->build_log_item(slog_param, log_item);
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT - 1, slogger_mgr.slog_items_.get_curr_total());
-  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT - 1, slogger_mgr.log_buffers_.get_curr_total());
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
   data_len = dummy_header.get_serialize_size() +
             dummy_entry.get_serialize_size() +
             12;
@@ -209,7 +263,7 @@ TEST_F (TestStorageLoggerManager, test_build_item)
   ret = slogger_mgr.free_item(log_item);
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.slog_items_.get_curr_total());
-  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.log_buffers_.get_curr_total());
+  ASSERT_EQ(1, slogger_mgr.log_buffers_.get_curr_total());
 
   // test build single-param large-size item
   SimpleObSlog simple_slog2(512<<10, 't');
@@ -217,7 +271,7 @@ TEST_F (TestStorageLoggerManager, test_build_item)
   ret = slogger->build_log_item(slog_param, log_item);
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT - 1, slogger_mgr.slog_items_.get_curr_total());
-  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.log_buffers_.get_curr_total());
+  ASSERT_EQ(1, slogger_mgr.log_buffers_.get_curr_total());
   data_len = dummy_header.get_serialize_size() +
              dummy_entry.get_serialize_size() +
              (512<<10);
@@ -234,7 +288,7 @@ TEST_F (TestStorageLoggerManager, test_build_item)
   ret = slogger_mgr.free_item(log_item);
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.slog_items_.get_curr_total());
-  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.log_buffers_.get_curr_total());
+  ASSERT_EQ(1, slogger_mgr.log_buffers_.get_curr_total());
 
   ObStorageLogParam slog_param_batch1;
   slog_param_batch1.cmd_ = 39;
@@ -256,7 +310,7 @@ TEST_F (TestStorageLoggerManager, test_build_item)
   ret = slogger->build_log_item(param_arr, log_item);
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT - 1, slogger_mgr.slog_items_.get_curr_total());
-  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT - 1, slogger_mgr.log_buffers_.get_curr_total());
+  ASSERT_EQ(0, slogger_mgr.log_buffers_.get_curr_total());
   data_len = dummy_header.get_serialize_size() +
              3 * dummy_entry.get_serialize_size() +
              111;
@@ -269,7 +323,7 @@ TEST_F (TestStorageLoggerManager, test_build_item)
   ret = slogger_mgr.free_item(log_item);
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.slog_items_.get_curr_total());
-  ASSERT_EQ(MAX_CONCURRENT_ITEM_CNT, slogger_mgr.log_buffers_.get_curr_total());
+  ASSERT_EQ(1, slogger_mgr.log_buffers_.get_curr_total());
 
   slogger->destroy();
   slogger_mgr.destroy();


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

Closes #999.

`ObStorageLoggerManager` previously pre-allocated 128 standard slog buffers during initialization. Each buffer is 8 KB, causing more than 1 MB of `StorageLoggerM` memory to be allocated even when no slog write is performed.

This change allocates standard slog buffers on-demand while preserving the existing buffer size, alignment, concurrency limit, reuse semantics, and error behavior.

### Solution Description

<!-- Please clearly and consice descipt the solution. -->
- Initialize only the fixed queue used to manage standard slog buffers during startup.
- Allocate an 8 KB standard slog buffer when the free buffer queue is empty.
- Preserve `LOG_FILE_ALIGN_SIZE` address alignment for newly allocated buffers.
- Protect concurrent arena allocation with `ObSpinLockGuard`.
- Reuse released standard buffers through the existing fixed queue.
- Allocate the slog item before its buffer so that `MAX_CONCURRENT_ITEM_CNT` remains the concurrency limit.
- Roll back the allocated item and buffer if a later allocation or initialization step fails.
- Add unit tests covering lazy allocation, address alignment, buffer reuse, and the maximum concurrency limit.

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->
The following relevant tests passed:

- test_storage_logger_manager: 4/4 passed
- test_storage_log_read_write: 8/8 passed
- test_storage_log_replay: 3/3 passed

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

This change does not change any public API, slog file format, standard buffer size, alignment requirement, or maximum concurrency limit. No upgrade or migration action is required.

### Other Information

<!-- Any information helping to review this pull request. -->
Standard slog buffers are aligned to `LOG_FILE_ALIGN_SIZE` using `upper_align`, preserving the existing buffer alignment requirement.

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->

Reduce slog startup memory usage by allocating standard 8 KB slog buffers on-demand.