### PR TITLE
Vldb trim mysqltests

### DIFF
--- a/tools/deploy/mysql_test/test_suite/ai_funcs/r/ik_custom_dict.result
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/r/ik_custom_dict.result
@@ -34,23 +34,4 @@ INSERT INTO articles (title) VALUES ('包含新词汇的标题');
 SELECT id, title FROM articles WHERE MATCH(title) AGAINST('新词汇' IN BOOLEAN MODE) ORDER BY id;
 id	title
 3	包含新词汇的标题
-# TOKENIZE preview: an UNQUALIFIED dict_table resolves against the current database.
-# 数据库 / 介绍 / 使用指南 break into single chars; the dictionary words stay whole.
-SELECT id, TOKENIZE(title, 'ik', '[{"output":"all"},{"additional_args":[{"dict_table":"my_dict"}]}]') AS toks
-FROM articles ORDER BY id;
-id	toks
-1	{"tokens": [{"介": 1}, {"库": 1}, {"oceanbase": 1}, {"据": 1}, {"绍": 1}, {"数": 1}], "doc_len": 6}
-2	{"tokens": [{"南": 1}, {"指": 1}, {"全文索引": 1}, {"用": 1}, {"使": 1}], "doc_len": 5}
-3	{"tokens": [{"的": 1}, {"包": 1}, {"新词汇": 1}, {"标": 1}, {"含": 1}, {"题": 1}], "doc_len": 6}
-# TOKENIZE accepts ik_mode + stopword_table + quantifier_table together
-CREATE TABLE my_stopwords (word varchar(100) primary key)
-ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
-CREATE TABLE my_quantifiers (word varchar(100) primary key)
-ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
-ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_stopwords;
-ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_quantifiers;
-SELECT TOKENIZE('这是非常重要的信息', 'ik',
-'[{"output":"all"},{"additional_args":[{"ik_mode":"max_word"},{"dict_table":"ai_ik_test.my_dict"},{"stopword_table":"ai_ik_test.my_stopwords"},{"quantifier_table":"ai_ik_test.my_quantifiers"}]}]') AS toks;
-toks
-{"tokens": [{"要": 1}, {"息": 1}, {"常": 1}, {"重": 1}, {"这": 1}, {"信": 1}, {"是": 1}, {"的": 1}, {"非": 1}], "doc_len": 9}
 DROP DATABASE ai_ik_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/r/load_file.result
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/r/load_file.result
@@ -11,14 +11,5 @@ Hello from load_file!
 SELECT length(load_file('lf_loc', 'ai_lf_hello.txt')) AS content_len;
 content_len
 22
-# the Document AI pipeline: load a file and split it into chunk rows.
-# load_file returns a binary BLOB, which ai_split_document rejects, so CONVERT it first.
-SELECT chunk_id, chunk_offset, chunk_length, chunk_text
-FROM AI_SPLIT_DOCUMENT(CONVERT(load_file('lf_loc','ai_lf_doc.txt') USING utf8mb4),
-'{"type":"text","by":"sentence","max":1}');
-chunk_id	chunk_offset	chunk_length	chunk_text
-0	0	24	Document AI splits text.
-1	25	21	It chunks long files.
-2	47	25	Each chunk becomes a row.
 DROP LOCATION lf_loc;
 DROP DATABASE ai_lf_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/t/ik_custom_dict.test
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/t/ik_custom_dict.test
@@ -34,19 +34,4 @@ ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_dict;
 INSERT INTO articles (title) VALUES ('包含新词汇的标题');
 SELECT id, title FROM articles WHERE MATCH(title) AGAINST('新词汇' IN BOOLEAN MODE) ORDER BY id;
 
---echo # TOKENIZE preview: an UNQUALIFIED dict_table resolves against the current database.
---echo # 数据库 / 介绍 / 使用指南 break into single chars; the dictionary words stay whole.
-SELECT id, TOKENIZE(title, 'ik', '[{"output":"all"},{"additional_args":[{"dict_table":"my_dict"}]}]') AS toks
-FROM articles ORDER BY id;
-
---echo # TOKENIZE accepts ik_mode + stopword_table + quantifier_table together
-CREATE TABLE my_stopwords (word varchar(100) primary key)
-  ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
-CREATE TABLE my_quantifiers (word varchar(100) primary key)
-  ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
-ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_stopwords;
-ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_quantifiers;
-SELECT TOKENIZE('这是非常重要的信息', 'ik',
-  '[{"output":"all"},{"additional_args":[{"ik_mode":"max_word"},{"dict_table":"ai_ik_test.my_dict"},{"stopword_table":"ai_ik_test.my_stopwords"},{"quantifier_table":"ai_ik_test.my_quantifiers"}]}]') AS toks;
-
 DROP DATABASE ai_ik_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/t/load_file.test
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/t/load_file.test
@@ -10,9 +10,6 @@ USE ai_lf_test;
 --write_file $MYSQL_TMP_DIR/ai_lf_hello.txt
 Hello from load_file!
 EOF
---write_file $MYSQL_TMP_DIR/ai_lf_doc.txt
-Document AI splits text. It chunks long files. Each chunk becomes a row.
-EOF
 
 # a LOCATION is the privileged directory load_file reads from (local file:// only in seekdb).
 # hide the absolute scratch path from the recorded result so the test is portable.
@@ -25,13 +22,6 @@ SELECT load_file('lf_loc', 'ai_lf_hello.txt') AS content;
 --echo # byte length
 SELECT length(load_file('lf_loc', 'ai_lf_hello.txt')) AS content_len;
 
---echo # the Document AI pipeline: load a file and split it into chunk rows.
---echo # load_file returns a binary BLOB, which ai_split_document rejects, so CONVERT it first.
-SELECT chunk_id, chunk_offset, chunk_length, chunk_text
-FROM AI_SPLIT_DOCUMENT(CONVERT(load_file('lf_loc','ai_lf_doc.txt') USING utf8mb4),
-                       '{"type":"text","by":"sentence","max":1}');
-
 DROP LOCATION lf_loc;
 DROP DATABASE ai_lf_test;
 --remove_file $MYSQL_TMP_DIR/ai_lf_hello.txt
---remove_file $MYSQL_TMP_DIR/ai_lf_doc.txt


### PR DESCRIPTION
load_file no longer runs the load_file -> AI_SPLIT_DOCUMENT integration query (ai_split_document has its own case), so its ai_lf_doc.txt fixture goes too.

ik_custom_dict drops the two TOKENIZE previews and the stopword/quantifier tables they created; the case keeps the dictionary-driven MATCH coverage.

Both .result files are updated to match, and all three ai_funcs cases pass.

<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
