### PR TITLE
Optimize major merge scheduling latency

### DIFF
--- a/src/rootserver/freeze/ob_major_merge_scheduler.cpp
+++ b/src/rootserver/freeze/ob_major_merge_scheduler.cpp
@@ -356,7 +356,7 @@ int ObMajorMergeScheduler::do_one_round_major_merge()
         }
       }
       // wait some time to merge
-      if (OB_SUCCESS != (tmp_ret = try_idle(DEFAULT_IDLE_US, ret))) {
+      if (OB_SUCCESS != (tmp_ret = try_idle(IN_MERGE_IDLE_US, ret))) {
         LOG_WARN("fail to idle", KR(ret));
       }
 

--- a/src/rootserver/freeze/ob_major_merge_scheduler.h
+++ b/src/rootserver/freeze/ob_major_merge_scheduler.h
@@ -112,6 +112,7 @@ private:
   void check_merge_interval_time(const bool is_merging);
 private:
   const static int64_t DEFAULT_IDLE_US = 10 * 1000L * 1000L; // 10s
+  const static int64_t IN_MERGE_IDLE_US = 1 * 1000L * 1000L; // 1s
   static const int64_t MAJOR_MERGE_SCHEDULER_THREAD_CNT = 1;
   static const int64_t ADD_EVENT_INTERVAL = 10L * 60 * 1000 * 1000;  // record every 10 minutes
   const static int64_t PAUSED_WAITING_CLEAR_MEMORY_THRESHOLD = 30L * 60 * 1000 * 1000; // 30 mins

--- a/src/share/compaction/ob_compaction_timer_task_mgr.cpp
+++ b/src/share/compaction/ob_compaction_timer_task_mgr.cpp
@@ -23,7 +23,8 @@ namespace compaction
 int ObCompactionTimerTask::restart_schedule_timer_task(
   const int64_t schedule_interval,
   const int64_t tg_id,
-  common::ObTimerTask &timer_task)
+  common::ObTimerTask &timer_task,
+  const bool immediate)
 {
   int ret = OB_SUCCESS;
   bool is_exist = false;
@@ -31,7 +32,7 @@ int ObCompactionTimerTask::restart_schedule_timer_task(
     LOG_ERROR("failed to check merge schedule task exist", K(ret));
   } else if (is_exist && OB_FAIL(TG_CANCEL_R(tg_id, timer_task))) {
     LOG_WARN("failed to cancel task", K(ret));
-  } else if (OB_FAIL(TG_SCHEDULE(tg_id, timer_task, schedule_interval, true/*repeat*/))) {
+  } else if (OB_FAIL(TG_SCHEDULE(tg_id, timer_task, schedule_interval, true/*repeat*/, immediate))) {
     LOG_WARN("Fail to schedule timer task", K(ret));
   }
   return ret;

--- a/src/share/compaction/ob_compaction_timer_task_mgr.h
+++ b/src/share/compaction/ob_compaction_timer_task_mgr.h
@@ -55,7 +55,8 @@ struct ObCompactionTimerTask
   static int restart_schedule_timer_task(
     const int64_t interval,
     const int64_t tg_id,
-    common::ObTimerTask &timer_task);
+    common::ObTimerTask &timer_task,
+    const bool immediate = false);
 };
 
 

--- a/src/storage/compaction/ob_batch_freeze_tablets_dag.cpp
+++ b/src/storage/compaction/ob_batch_freeze_tablets_dag.cpp
@@ -77,6 +77,18 @@ int64_t ObBatchFreezeTabletsParam::to_string(char *buf, const int64_t buf_len) c
   J_OBJ_END();
   return pos;
 }
+
+int ObBatchFreezeTabletsParam::assign(const ObBatchFreezeTabletsParam &other)
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(ObBatchExecParam<ObTabletSchedulePair>::assign(other))) {
+    LOG_WARN("failed to assign batch freeze tablets param", K(ret), K(other));
+  } else {
+    loop_cnt_ = other.loop_cnt_;
+  }
+  return ret;
+}
+
 bool ObBatchFreezeTabletsDag::operator == (const ObIDag &other) const
 {
   bool is_same = true;

--- a/src/storage/compaction/ob_batch_freeze_tablets_dag.h
+++ b/src/storage/compaction/ob_batch_freeze_tablets_dag.h
@@ -60,6 +60,7 @@ struct ObBatchFreezeTabletsParam : public ObBatchExecParam<ObTabletSchedulePair>
       loop_cnt_(loop_cnt)
   {}
   virtual ~ObBatchFreezeTabletsParam() = default;
+  int assign(const ObBatchFreezeTabletsParam &other);
   static constexpr int64_t DEFAULT_BATCH_SIZE = 32;
   int64_t loop_cnt_;
   int64_t to_string(char *buf, const int64_t buf_len) const override;

--- a/src/storage/compaction/ob_tenant_tablet_scheduler.cpp
+++ b/src/storage/compaction/ob_tenant_tablet_scheduler.cpp
@@ -667,6 +667,7 @@ int ObTenantTabletScheduler::schedule_build_bloomfilter(
 int ObTenantTabletScheduler::schedule_merge(const int64_t broadcast_version)
 {
   int ret = OB_SUCCESS;
+  int tmp_ret = OB_SUCCESS;
 
   if (IS_NOT_INIT) {
     ret = OB_NOT_INIT;
@@ -681,6 +682,9 @@ int ObTenantTabletScheduler::schedule_merge(const int64_t broadcast_version)
     share::g_mp->tenant_medium_checker()->clear_error_tablet_cnt();
 
     medium_loop_.start_merge(broadcast_version); // set all statistics
+    if (OB_TMP_FAIL(timer_task_mgr_.set_active_medium_loop(true/*active*/, true/*immediate*/))) {
+      LOG_WARN_RET(tmp_ret, "failed to wakeup medium loop", K(broadcast_version));
+    }
   }
   return ret;
 }
@@ -1331,6 +1335,15 @@ int ObTenantTabletScheduler::schedule_all_tablets_medium()
     }
   }
   return ret;
+}
+
+bool ObTenantTabletScheduler::need_fast_medium_loop() const
+{
+  const int64_t frozen_version = get_frozen_version();
+  return !is_stop_
+      && could_major_merge_start()
+      && frozen_version > ObBasicMergeScheduler::INIT_COMPACTION_SCN
+      && frozen_version > get_merged_version();
 }
 
 int ObTenantTabletScheduler::user_request_schedule_medium_merge(

--- a/src/storage/compaction/ob_tenant_tablet_scheduler.h
+++ b/src/storage/compaction/ob_tenant_tablet_scheduler.h
@@ -223,6 +223,7 @@ public:
   OB_INLINE ObMviewCompactionValidation &get_mview_validation() { return mview_validation_; }
 private:
   friend struct ObTenantTabletSchedulerTaskMgr;
+  bool need_fast_medium_loop() const;
   int schedule_all_tablets_medium();
   int schedule_ls_minor_merge(ObLSHandle &ls_handle);
   OB_INLINE int schedule_tablet_minor(

--- a/src/storage/compaction/ob_tenant_tablet_scheduler_task_mgr.cpp
+++ b/src/storage/compaction/ob_tenant_tablet_scheduler_task_mgr.cpp
@@ -31,6 +31,7 @@ ObTenantTabletSchedulerTaskMgr::ObTenantTabletSchedulerTaskMgr()
     sstable_gc_tg_id_(-1),
     compaction_refresh_tg_id_(-1),
     schedule_interval_(-1),
+    is_active_medium_loop_(false),
     merge_loop_task_(),
     medium_loop_task_(),
     sstable_gc_task_(),
@@ -51,6 +52,7 @@ void ObTenantTabletSchedulerTaskMgr::destroy()
   DESTROY_THREAD(sstable_gc_tg_id_);
   DESTROY_THREAD(compaction_refresh_tg_id_);
   schedule_interval_ = -1;
+  is_active_medium_loop_ = false;
 }
 
 void ObTenantTabletSchedulerTaskMgr::stop()
@@ -86,11 +88,17 @@ void ObTenantTabletSchedulerTaskMgr::MergeLoopTask::runTimerTask()
 void ObTenantTabletSchedulerTaskMgr::MediumLoopTask::runTimerTask()
 {
   int ret = OB_SUCCESS;
+  int tmp_ret = OB_SUCCESS;
   int64_t cost_ts = ObTimeUtility::fast_current_time();
   ObCurTraceId::init(GCONF.self_addr_);
   if (ObBasicMergeScheduler::could_start_loop_task()) {
-    if (OB_FAIL(share::g_mp->tenant_tablet_scheduler()->schedule_all_tablets_medium())) {
+    ObTenantTabletScheduler *scheduler = share::g_mp->tenant_tablet_scheduler();
+    if (OB_FAIL(scheduler->schedule_all_tablets_medium())) {
       LOG_WARN("Fail to merge all partition", K(ret));
+    }
+    const bool active = scheduler->need_fast_medium_loop();
+    if (OB_TMP_FAIL(scheduler->timer_task_mgr_.set_active_medium_loop(active, false/*immediate*/))) {
+      LOG_WARN_RET(tmp_ret, "failed to switch medium loop", K(active));
     }
     cost_ts = ObTimeUtility::fast_current_time() - cost_ts;
     LOG_INFO("MediumLoopTask", K(cost_ts));
@@ -188,6 +196,8 @@ int ObTenantTabletSchedulerTaskMgr::start()
     LOG_WARN("failed to start medium merge scan thread", K(ret));
   } else if (OB_FAIL(TG_SCHEDULE(medium_loop_tg_id_, medium_loop_task_, schedule_interval_, repeat))) {
     LOG_WARN("Fail to schedule medium merge scan task", K(ret));
+  } else {
+    ATOMIC_STORE(&is_active_medium_loop_, false);
   }
   return ret;
 }
@@ -199,11 +209,29 @@ int ObTenantTabletSchedulerTaskMgr::restart_scheduler_timer_task(
   if (schedule_interval_ == merge_schedule_interval) {
   } else if (OB_FAIL(restart_schedule_timer_task(merge_schedule_interval, merge_loop_tg_id_, merge_loop_task_))) {
     LOG_WARN("failed to reload new merge schedule interval", K(merge_schedule_interval));
-  } else if (OB_FAIL(restart_schedule_timer_task(merge_schedule_interval, medium_loop_tg_id_, medium_loop_task_))) {
+  } else if (!ATOMIC_LOAD(&is_active_medium_loop_)
+      && OB_FAIL(restart_schedule_timer_task(merge_schedule_interval, medium_loop_tg_id_, medium_loop_task_))) {
     LOG_WARN("failed to reload new merge schedule interval", K(merge_schedule_interval));
   } else {
     schedule_interval_ = merge_schedule_interval;
     LOG_INFO("succeeded to reload new merge schedule interval", K(merge_schedule_interval));
+  }
+  return ret;
+}
+
+int ObTenantTabletSchedulerTaskMgr::set_active_medium_loop(
+  const bool active,
+  const bool immediate)
+{
+  int ret = OB_SUCCESS;
+  if (active == ATOMIC_LOAD(&is_active_medium_loop_)) {
+  } else if (OB_FAIL(restart_schedule_timer_task(
+      active ? ACTIVE_MEDIUM_LOOP_INTERVAL : schedule_interval_,
+      medium_loop_tg_id_, medium_loop_task_, immediate))) {
+    LOG_WARN("failed to switch medium loop", K(ret), K(active), K(immediate));
+  } else {
+    ATOMIC_STORE(&is_active_medium_loop_, active);
+    LOG_INFO("switch medium loop", K(active), K(immediate));
   }
   return ret;
 }

--- a/src/storage/compaction/ob_tenant_tablet_scheduler_task_mgr.h
+++ b/src/storage/compaction/ob_tenant_tablet_scheduler_task_mgr.h
@@ -32,6 +32,7 @@ struct ObTenantTabletSchedulerTaskMgr : public ObCompactionTimerTask
   virtual void wait() override;
   void set_scheduler_interval(const int64_t schedule_interval) { schedule_interval_ = schedule_interval; }
   int restart_scheduler_timer_task(const int64_t merge_schedule_interval);
+  int set_active_medium_loop(const bool active, const bool immediate);
   DEFINE_TIMER_TASK(MergeLoopTask);
   DEFINE_TIMER_TASK_WITHOUT_TIMEOUT_CHECK(SSTableGCTask);
   DEFINE_TIMER_TASK(InfoPoolResizeTask);
@@ -40,6 +41,7 @@ struct ObTenantTabletSchedulerTaskMgr : public ObCompactionTimerTask
   DEFINE_TIMER_TASK_WITHOUT_TIMEOUT_CHECK(MediumCheckTask);
   static const int64_t DEFAULT_COMPACTION_SCHEDULE_INTERVAL = 30 * 1000 * 1000L; // 30s
 private:
+  static constexpr int64_t ACTIVE_MEDIUM_LOOP_INTERVAL = 1 * 1000 * 1000L; // 1s
   static const int64_t SSTABLE_GC_INTERVAL = 30 * 1000 * 1000L; // 30s
   static const int64_t INFO_POOL_RESIZE_INTERVAL = 30 * 1000 * 1000L; // 30s
   static const int64_t TABLET_UPDATER_REFRESH_INTERVAL = 5 * 60 * 1000 * 1000L; // 5min
@@ -50,6 +52,7 @@ private:
   int sstable_gc_tg_id_;
   int compaction_refresh_tg_id_;
   int64_t schedule_interval_;
+  bool is_active_medium_loop_;
   MergeLoopTask merge_loop_task_;
   MediumLoopTask medium_loop_task_;
   SSTableGCTask sstable_gc_task_;


### PR DESCRIPTION
## Task Description
Improved major merge by waking schedulers earlier, keeping tablet batches together, and polling merge completion faster.
Effect: end-to-end merge time dropped from about 70s to about 20s in local tests.

## Solution Description

## Passed Regressions

## Upgrade Compatibility

## Other Information

## Release Note