### PR TITLE
[seekdb][observer] Fix sanity startup crash in pre-main THP init

### DIFF
--- a/src/observer/main.cpp
+++ b/src/observer/main.cpp
@@ -395,11 +395,6 @@ static void disable_hugepage_for_self_text()
   fclose(maps);
 }
 
-__attribute__((constructor(101)))
-static void early_disable_hugepage_for_observer()
-{
-  disable_hugepage_for_self_text();
-}
 #endif
 
 using namespace oceanbase::obsys;
@@ -409,6 +404,8 @@ using namespace oceanbase::common;
 using namespace oceanbase::observer;
 using namespace oceanbase::share;
 using namespace oceanbase::omt;
+
+namespace oceanbase { namespace share { void ob_init_create_func(); } }
 
 #define MPRINT(format, ...) fprintf(stderr, format "\n", ##__VA_ARGS__)
 #define MPRINTx(format, ...)                                                   \
@@ -861,6 +858,9 @@ static const char *get_arg_value(int argc, char *argv[], const char *name)
 
 int main(int argc, char *argv[])
 {
+#if defined(__linux__)
+  disable_hugepage_for_self_text();
+#endif
 #ifdef _WIN32
   ::oceanbase::common::g_ob_log_main_entered = true;
 #endif


### PR DESCRIPTION
## Task Description
Fix a crash in seekdb sanity builds where the process fails during startup with a Segmentation fault before entering `main`. The crash occurs because the early Transparent Huge Pages (THP) text mapping initialization runs from a constructor before the sanity libc interposition layer is fully ready.

## Solution Description
Move the call to disable THP text mapping from the early constructor path to the beginning of the observer's `main` function. This preserves the required THP-related behavior before normal observer startup begins, while preventing reentry into the sanity-instrumented libc wrappers before `main` is reached.

## Passed Regressions
- `./build.sh release --init --ob-make seekdb`
- `build_release/src/observer/seekdb --version`
- Release idle startup A/B check: `THP_enabled=0`, `FilePmdMapped=0`, `RssFile` stable with no meaningful regression
- `./build.sh sanity --init --ob-make seekdb`
- `build_sanity/src/observer/seekdb --version`
- Sanity idle startup on port 40110: process stayed alive, `THP_enabled=0`, `FilePmdMapped=0`, `AnonHugePages=0`

## Upgrade Compatibility
No impact on storage format, schema, protocol, or upgrade compatibility. The change only adjusts the timing of when the process-local THP text mapping disable logic is invoked during startup.

## Other Information
This MR contains one commit: `3528f109b5a fix pre-main THP initialization reentry`.
Untracked local files `2` and `issue.txxt` are not included in this MR.
Related internal link: DIMA-2026071000117337332

## Release Note
Fixed a startup crash in seekdb sanity builds related to early Transparent Huge Pages (THP) initialization.