### PR TITLE
feat: support custom dictionaries for IK parser

### DIFF
--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -2882,6 +2882,8 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_FULLTEXT_DICT = 4920,
+  T_REFRESH_FULLTEXT_DICT = 4921,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/plugin/interface/ob_plugin_ftparser_intf.h
+++ b/src/plugin/interface/ob_plugin_ftparser_intf.h
@@ -77,7 +77,13 @@ public:
   };
 
   ObFTIKParam(Mode mode = Mode::SMART)
-      : mode_(mode), main_dict_(""), quan_dict_(""), stopword_dict_("")
+      : mode_(mode),
+        main_dict_(""),
+        quan_dict_(""),
+        stopword_dict_(""),
+        main_dict_id_(common::OB_INVALID_ID),
+        quan_dict_id_(common::OB_INVALID_ID),
+        stopword_dict_id_(common::OB_INVALID_ID)
   {
   }
 
@@ -86,6 +92,9 @@ public:
   common::ObString main_dict_;
   common::ObString quan_dict_;
   common::ObString stopword_dict_;
+  uint64_t main_dict_id_;
+  uint64_t quan_dict_id_;
+  uint64_t stopword_dict_id_;
 };
 
 /**
@@ -103,7 +112,8 @@ public:
       : ObFTParserParamExport(),
         ngram_token_size_(NGRAM_TOKEN_SIZE),
         min_ngram_size_(NGRAM_TOKEN_SIZE),
-        max_ngram_size_(NGRAM_TOKEN_SIZE)
+        max_ngram_size_(NGRAM_TOKEN_SIZE),
+        tenant_id_(common::OB_INVALID_TENANT_ID)
   {
   }
   virtual ~ObFTParserParam() { reset(); }
@@ -112,7 +122,11 @@ public:
   {
     ObFTParserParamExport::reset();
     allocator_ = nullptr;
+    ik_param_ = ObFTIKParam();
     ngram_token_size_ = NGRAM_TOKEN_SIZE;
+    min_ngram_size_ = NGRAM_TOKEN_SIZE;
+    max_ngram_size_ = NGRAM_TOKEN_SIZE;
+    tenant_id_ = common::OB_INVALID_TENANT_ID;
   }
 
   INHERIT_TO_STRING_KV("base", ObFTParserParamExport, KP_(allocator), K_(ngram_token_size));
@@ -125,6 +139,7 @@ public:
   int64_t ngram_token_size_;
   int64_t min_ngram_size_;
   int64_t max_ngram_size_;
+  uint64_t tenant_id_;
 };
 
 class ObITokenIterator

--- a/src/rootserver/ob_ddl_operator.cpp
+++ b/src/rootserver/ob_ddl_operator.cpp
@@ -2374,6 +2374,11 @@ int ObDDLOperator::alter_table_create_index(const ObTableSchema &new_table_schem
         }
       }
     }
+    if (OB_SUCC(ret) && index_schema.is_fts_index_aux()
+        && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+               index_schema, trans))) {
+      LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(index_schema));
+    }
   }
   return ret;
 }
@@ -4212,7 +4217,13 @@ int ObDDLOperator::drop_table(
 {
   int ret = OB_SUCCESS;
   bool tmp = false;
-  if (OB_FAIL(ObDependencyDDLHelper::modify_dep_obj_status(trans, table_schema.get_table_id(),
+  if (!is_drop_db && table_schema.is_fulltext_dict()
+      && OB_FAIL(ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+             table_schema.get_table_id(), trans))) {
+    if (OB_OP_NOT_ALLOW != ret) {
+      LOG_WARN("fail to check dictionary table dependencies", K(ret), K(table_schema));
+    }
+  } else if (OB_FAIL(ObDependencyDDLHelper::modify_dep_obj_status(trans, table_schema.get_table_id(),
                                                       *this, schema_service_))) {
     LOG_WARN("failed to modify obj status", K(ret));
   } else if (OB_FAIL(drop_table_for_not_dropped_schema(
@@ -4227,6 +4238,13 @@ int ObDDLOperator::drop_table(
                       ObObjectType::VIEW))) {
     LOG_WARN("failed to delete_schema_object_dependency", K(ret), K(1UL),
     K(table_schema.get_table_id()));
+  } else if (table_schema.is_fts_index_aux()
+             && OB_FAIL(ObDependencyInfo::delete_schema_object_dependency(
+                    trans,
+                    table_schema.get_table_id(),
+                    table_schema.get_schema_version(),
+                    ObObjectType::INDEX))) {
+    LOG_WARN("fail to delete fulltext dictionary dependencies", K(ret), K(table_schema));
   }
 
   if (OB_FAIL(ret)) {
@@ -4434,6 +4452,12 @@ int ObDDLOperator::drop_table_to_recyclebin(const ObTableSchema &table_schema,
   } else if (OB_UNLIKELY(table_schema.get_table_type() == MATERIALIZED_VIEW_LOG)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("materialized view log should not come to recyclebin", KR(ret));
+  } else if (table_schema.is_fulltext_dict()
+             && OB_FAIL(ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+                    table_schema.get_table_id(), trans))) {
+    if (OB_OP_NOT_ALLOW != ret) {
+      LOG_WARN("fail to check dictionary table dependencies", K(ret), K(table_schema));
+    }
   } else if (OB_ISNULL(schema_service_impl)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_ERROR("schema_service_impl must not null", K(ret));

--- a/src/rootserver/ob_ddl_service.cpp
+++ b/src/rootserver/ob_ddl_service.cpp
@@ -2029,6 +2029,10 @@ int ObDDLService::create_tables_in_trans(const bool if_not_exist,
                                                      0 == i ? &tmp_ddl_stmt_str : NULL,
                                                      i == table_schemas.count() - 1))) {
           LOG_WARN("failed to create table schema, ", K(ret));
+        } else if (table_schema.is_fts_index_aux()
+                   && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+                          table_schema, trans))) {
+          LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(table_schema));
         } else if (OB_FAIL(ddl_operator.insert_temp_table_info(trans, table_schema))) {
           LOG_WARN("failed to insert_temp_table_info!", K(ret));
         } else if (table_schema.is_view_table() && dep_infos != nullptr && 0 == i) {

--- a/src/rootserver/parallel_ddl/ob_create_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_create_table_helper.cpp
@@ -1142,6 +1142,15 @@ int ObCreateTableHelper::operate_schemas_() {
   } else if (OB_FAIL(inner_create_table_(&arg_.ddl_stmt_str_,
                                          replace_mock_fk_parent_table_id_))) {
     LOG_WARN("fail create table", KR(ret));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < new_tables_.count(); ++i) {
+      const ObTableSchema &table_schema = new_tables_.at(i);
+      if (table_schema.is_fts_index_aux()
+          && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+                 table_schema, get_trans_()))) {
+        LOG_WARN("fail to record fulltext dictionary dependencies", KR(ret), K(table_schema));
+      }
+    }
   }
   return ret;
 }

--- a/src/rootserver/parallel_ddl/ob_drop_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_drop_table_helper.cpp
@@ -22,7 +22,9 @@
 #include "rootserver/ob_tablet_drop.h"
 #include "share/ob_autoincrement_service.h"
 #include "share/ob_rpc_struct.h"
+#include "share/schema/ob_dependency_info.h"
 #include "share/schema/ob_table_sql_service.h"
+#include "sql/resolver/ddl/ob_fts_index_builder_util.h"
 #include "storage/tablelock/ob_lock_inner_connection_util.h"
 
 using namespace oceanbase::rootserver;
@@ -176,6 +178,12 @@ int ObDropTableHelper::check_legitimacy_()
         ret = OB_NOT_SUPPORTED;
         LOG_WARN("drop table required by materialized view is not supported", KR(ret));
         LOG_USER_ERROR(OB_NOT_SUPPORTED, "drop table required by materialized view is");
+      } else if (table_schema->is_fulltext_dict()
+                 && OB_FAIL(oceanbase::share::ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+                        table_schema->get_table_id(), get_trans_()))) {
+        if (OB_OP_NOT_ALLOW != ret) {
+          LOG_WARN("fail to check dictionary table dependencies", KR(ret), KPC(table_schema));
+        }
       }
     }
   }
@@ -1411,6 +1419,13 @@ int ObDropTableHelper::drop_table_(const ObTableSchema &table_schema, const ObSt
       LOG_WARN("fail to sync version for cascade tables", KR(ret));
     } else if (OB_FAIL(sync_version_for_cascade_mock_fk_parent_table_(table_schema.get_depend_mock_fk_parent_table_ids()))) {
       LOG_WARN("fail to sync version for cascade mock fk parent table", KR(ret));
+    } else if (table_schema.is_fts_index_aux()
+               && OB_FAIL(ObDependencyInfo::delete_schema_object_dependency(
+                      get_trans_(),
+                      table_schema.get_table_id(),
+                      table_schema.get_schema_version(),
+                      ObObjectType::INDEX))) {
+      LOG_WARN("fail to delete fulltext dictionary dependencies", KR(ret), K(table_schema));
     }
 
     if (OB_SUCC(ret)) {

--- a/src/rootserver/parallel_ddl/ob_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_table_helper.cpp
@@ -647,6 +647,9 @@ int ObTableHelper::inner_generate_table_schema_(const ObCreateTableArg &arg, ObT
     ret = OB_NOT_SUPPORTED;
     LOG_WARN("not user tenant, create duplicate table not supported", KR(ret));
     LOG_USER_ERROR(OB_NOT_SUPPORTED, "not user tenant, create duplicate table");
+  } else if (OB_FAIL(ObFtsIndexBuilderUtil::check_fulltext_dict_schema(
+                         new_table, arg.index_arg_list_.count()))) {
+    LOG_WARN("fulltext dictionary table schema is invalid", KR(ret), K(new_table));
   }
 
   if (FALSE_IT(new_table.set_table_id(mock_table_id))) {

--- a/src/share/schema/ob_schema_struct.h
+++ b/src/share/schema/ob_schema_struct.h
@@ -185,6 +185,9 @@ static const uint64_t OB_MIN_ID  = 0;//used for lower_bound
 #define EXTERNAL_TABLE_AUTO_REFRESH_FLAG_OFFSET 2
 #define EXTERNAL_TABLE_AUTO_REFRESH_FLAG_BITS 2
 
+// Identifies a user table whose rows are used as a full-text dictionary.
+#define FULLTEXT_DICT_FLAG (INT64_C(1) << 4)
+
 // schema array size
 static const int64_t SCHEMA_SMALL_MALLOC_BLOCK_SIZE = 64;
 static const int64_t SCHEMA_MALLOC_BLOCK_SIZE = 128;

--- a/src/share/schema/ob_table_schema.h
+++ b/src/share/schema/ob_table_schema.h
@@ -1413,6 +1413,7 @@ public:
   int set_external_properties(const common::ObString &format) { return deep_copy_str(format, external_properties_); }
   void set_external_table_auto_refresh(const int64_t flag) { table_flags_ |= (flag << EXTERNAL_TABLE_AUTO_REFRESH_FLAG_OFFSET); }
   inline void set_user_specified_partition_for_external_table() { table_flags_ |= EXTERNAL_TABLE_USER_SPECIFIED_PARTITION_FLAG; }
+  inline void set_fulltext_dict() { table_flags_ |= FULLTEXT_DICT_FLAG; }
   template<typename ColumnType>
   int add_column(const ColumnType &column);
   int delete_column(const common::ObString &column_name);
@@ -1581,6 +1582,7 @@ public:
   inline ObNameGeneratedType get_name_generated_type() const { return name_generated_type_; }
   bool is_sys_generated_name(bool check_unknown) const;
   inline bool is_user_specified_partition_for_external_table() const { return (table_flags_ & EXTERNAL_TABLE_USER_SPECIFIED_PARTITION_FLAG) != 0; }
+  inline bool is_fulltext_dict() const { return (table_flags_ & FULLTEXT_DICT_FLAG) != 0; }
   inline bool is_index_visible() const
   {
     return 0 == (index_attributes_set_ & ((uint64_t)(1) << INDEX_VISIBILITY));

--- a/src/sql/engine/cmd/ob_alter_system_executor.cpp
+++ b/src/sql/engine/cmd/ob_alter_system_executor.cpp
@@ -35,6 +35,12 @@
 #include "sql/engine/cmd/ob_timezone_importer.h"
 #include "sql/engine/cmd/ob_srs_importer.h"
 #include "share/ob_internal_table_change_notifier.h"
+#include "share/schema/ob_schema_getter_guard.h"
+#include "share/schema/ob_multi_version_schema_service.h"
+#include "storage/fts/ob_fts_plugin_helper.h"
+#include "storage/fts/dict/ob_ft_cache_container.h"
+#include "storage/fts/dict/ob_ft_dict_def.h"
+#include "storage/fts/dict/ob_ft_dict_hub.h"
 
 namespace oceanbase
 {
@@ -471,6 +477,64 @@ int ObRefreshMemStatExecutor::execute(ObExecContext &ctx, ObRefreshMemStatStmt &
   } else if (OB_FAIL(GCTX.root_service_->admin_refresh_memory_stat(
                          stmt.get_rpc_arg()))) {
     LOG_WARN("refresh memory stat failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+  }
+  return ret;
+}
+
+int ObRefreshFulltextDictExecutor::execute(ObExecContext &ctx,
+                                           ObRefreshFulltextDictStmt &stmt)
+{
+  int ret = OB_SUCCESS;
+  ObSQLSessionInfo *session = ctx.get_my_session();
+  share::schema::ObSchemaGetterGuard schema_guard;
+  const share::schema::ObTableSchema *table_schema = nullptr;
+  uint64_t table_id = OB_INVALID_ID;
+  storage::ObFTDictHub *dict_hub = nullptr;
+  ObArenaAllocator allocator("FTDictRefresh");
+  ObSqlString full_table_name;
+  if (OB_ISNULL(session) || OB_ISNULL(GCTX.schema_service_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("session or schema service is not initialized", K(ret), KP(session));
+  } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+    LOG_WARN("fail to get schema guard", K(ret));
+  } else if (OB_FAIL(schema_guard.get_table_id(
+                         stmt.get_database_name(),
+                         stmt.get_table_name(),
+                         false,
+                         share::schema::ObSchemaGetterGuard::ALL_NON_HIDDEN_TYPES,
+                         table_id))) {
+    LOG_WARN("fail to resolve dictionary table", K(ret), K(stmt));
+  } else if (OB_INVALID_ID == table_id) {
+    ret = OB_ERR_UNKNOWN_TABLE;
+    LOG_USER_ERROR(OB_ERR_UNKNOWN_TABLE,
+                   stmt.get_table_name().length(), stmt.get_table_name().ptr(),
+                   stmt.get_database_name().length(), stmt.get_database_name().ptr());
+  } else if (OB_FAIL(schema_guard.get_table_schema(table_id, table_schema))) {
+    LOG_WARN("fail to get dictionary table schema", K(ret), K(table_id));
+  } else if (OB_ISNULL(table_schema) || !table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "refreshing a non-fulltext-dictionary table is");
+  } else if (OB_FAIL(full_table_name.append_fmt("%.*s.%.*s",
+                                                stmt.get_database_name().length(),
+                                                stmt.get_database_name().ptr(),
+                                                stmt.get_table_name().length(),
+                                                stmt.get_table_name().ptr()))) {
+    LOG_WARN("fail to construct dictionary table name", K(ret));
+  } else if (OB_FAIL(storage::ObFTParsePluginData::instance().get_dict_hub(dict_hub))) {
+    LOG_WARN("fail to get fulltext dictionary hub", K(ret));
+  } else {
+    storage::ObFTDictDesc desc(common::OB_SERVER_TENANT_ID,
+                               table_id,
+                               full_table_name.string(),
+                               storage::ObFTDictType::DICT_IK_MAIN,
+                               ObCharsetType::CHARSET_UTF8MB4,
+                               ObCollationType::CS_TYPE_UTF8MB4_BIN,
+                               false,
+                               true);
+    storage::ObFTCacheRangeContainer container(allocator);
+    if (OB_FAIL(dict_hub->refresh(desc, container))) {
+      LOG_WARN("fail to refresh fulltext dictionary", K(ret), K(desc));
+    }
   }
   return ret;
 }

--- a/src/sql/engine/cmd/ob_alter_system_executor.h
+++ b/src/sql/engine/cmd/ob_alter_system_executor.h
@@ -56,6 +56,8 @@ DEF_SIMPLE_EXECUTOR(ObAdminMerge);
 
 DEF_SIMPLE_EXECUTOR(ObRefreshMemStat);
 
+DEF_SIMPLE_EXECUTOR(ObRefreshFulltextDict);
+
 DEF_SIMPLE_EXECUTOR(ObWashMemFragmentation);
 
 DEF_SIMPLE_EXECUTOR(ObRefreshIOCalibraiton);

--- a/src/sql/engine/expr/ob_expr_tokenize.cpp
+++ b/src/sql/engine/expr/ob_expr_tokenize.cpp
@@ -28,6 +28,7 @@
 #include "object/ob_object.h"
 #include "plugin/sys/ob_plugin_helper.h"
 #include "sql/resolver/ddl/ob_fts_index_builder_util.h"
+#include "sql/session/ob_sql_session_info.h"
 #include "share/ob_json_access_utils.h"
 #include "storage/fts/dict/ob_gen_dic_loader.h"
 #include "storage/fts/ob_fts_parser_property.h"
@@ -144,7 +145,9 @@ ObExprTokenize::TokenizeParam ::TokenizeParam()
 {
 }
 
-int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj)
+int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj,
+                                                    const ObString &database_name,
+                                                    const uint64_t tenant_id)
 {
   int ret = OB_SUCCESS;
   ObString str;
@@ -195,7 +198,8 @@ int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj)
       LOG_USER_ERROR(OB_INVALID_ARGUMENT, "parser arguments");
     } else {
       ObString json_str;
-      if (OB_FAIL(ObFTParserJsonProps::tokenize_array_to_props_json(allocator_, val, json_str))) {
+      if (OB_FAIL(ObFTParserJsonProps::tokenize_array_to_props_json(
+                      allocator_, val, database_name, tenant_id, json_str))) {
         LOG_WARN("Fail to tokenize array to props json", K(ret));
         ObSqlString message;
         message.append_fmt("format in %s form", ADDITIONAL_ARGS_STR);
@@ -227,6 +231,10 @@ int ObExprTokenize::parse_param(const ObExpr &expr,
   ObEvalCtx::TempAllocGuard tmp_alloc_g(ctx);
   
   MultimodeAlloctor temp_allocator(tmp_alloc_g.get_allocator(), expr.type_, ret);
+  ObSQLSessionInfo *session = ctx.exec_ctx_.get_my_session();
+  const uint64_t tenant_id = common::OB_SERVER_TENANT_ID;
+  const ObString database_name = OB_ISNULL(session)
+      ? ObString() : session->get_database_name();
 
   if (OB_UNLIKELY(expr.arg_cnt_ < 1 || expr.arg_cnt_ > 3)) {
     ret = OB_INVALID_ARGUMENT;
@@ -235,7 +243,8 @@ int ObExprTokenize::parse_param(const ObExpr &expr,
     LOG_WARN("Fail to parse fulltext.", K(ret));
   } else if (OB_FAIL(parse_parser_name(expr, ctx, param))) {
     LOG_WARN("Fail to parse parser params.", K(ret));
-  } else if (OB_FAIL(parse_parser_properties(expr, ctx, temp_allocator, param))) {
+  } else if (OB_FAIL(parse_parser_properties(
+                         expr, database_name, tenant_id, ctx, temp_allocator, param))) {
     LOG_WARN("Fail to parse parser params.", K(ret));
   } else if (OB_FAIL(param.reform_parser_properties(param.properties_))) {
     LOG_WARN("Fail to reform parser params.", K(ret));
@@ -378,6 +387,8 @@ int ObExprTokenize::parse_parser_name(const ObExpr &expr, ObEvalCtx &ctx, Tokeni
 }
 
 int ObExprTokenize::parse_parser_properties(const ObExpr &expr,
+                                            const ObString &database_name,
+                                            const uint64_t tenant_id,
                                             ObEvalCtx &ctx,
                                             MultimodeAlloctor &mm_alloc,
                                             TokenizeParam &param)
@@ -404,7 +415,7 @@ int ObExprTokenize::parse_parser_properties(const ObExpr &expr,
           } else if (ObJsonNodeType::J_OBJECT != (node->json_type())) {
             ret = OB_INVALID_ARGUMENT;
             LOG_WARN("Argument of json array invalid", K(ret));
-          } else if (OB_FAIL(param.parse_json_param(node))) {
+          } else if (OB_FAIL(param.parse_json_param(node, database_name, tenant_id))) {
             LOG_WARN("Failed to parse json object", K(ret));
           }
         } // for

--- a/src/sql/engine/expr/ob_expr_tokenize.h
+++ b/src/sql/engine/expr/ob_expr_tokenize.h
@@ -60,7 +60,9 @@ private:
   public:
     TokenizeParam();
 
-    int parse_json_param(const ObIJsonBase *obj);
+    int parse_json_param(const ObIJsonBase *obj,
+                         const ObString &database_name,
+                         const uint64_t tenant_id);
 
     // check and reform parser properties to standard format
     int reform_parser_properties(const ObString &properties);
@@ -89,6 +91,8 @@ private:
   static int parse_fulltext(const ObExpr &expr, ObEvalCtx &ctx, TokenizeParam &param);
   static int parse_parser_name(const ObExpr &expr, ObEvalCtx &ctx, TokenizeParam &param);
   static int parse_parser_properties(const ObExpr &expr,
+                                     const ObString &database_name,
+                                     const uint64_t tenant_id,
                                      ObEvalCtx &ctx,
                                      MultimodeAlloctor &mm_alloc,
                                      TokenizeParam &param);

--- a/src/sql/executor/ob_cmd_executor.cpp
+++ b/src/sql/executor/ob_cmd_executor.cpp
@@ -515,6 +515,10 @@ int ObCmdExecutor::execute(ObExecContext &ctx, ObICmd &cmd)
         DEFINE_EXECUTE_CMD(ObRefreshMemStatStmt, ObRefreshMemStatExecutor);
         break;
       }
+      case stmt::T_REFRESH_FULLTEXT_DICT: {
+        DEFINE_EXECUTE_CMD(ObRefreshFulltextDictStmt, ObRefreshFulltextDictExecutor);
+        break;
+      }
       case stmt::T_WASH_MEMORY_FRAGMENTATION: {
         DEFINE_EXECUTE_CMD(ObWashMemFragmentationStmt, ObWashMemFragmentationExecutor);
         break;

--- a/src/sql/parser/non_reserved_keywords_mysql_mode.c
+++ b/src/sql/parser/non_reserved_keywords_mysql_mode.c
@@ -250,6 +250,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"deterministic", DETERMINISTIC},
   {"dense_rank", DENSE_RANK},
   {"diagnostics", DIAGNOSTICS},
+  {"dict", DICT},
   {"dict_table", DICT_TABLE},
   {"diff", DIFF},
   {"disallow", DISALLOW},
@@ -1162,6 +1163,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"INCONSISTENT", INCONSISTENT},
   {"INDIVIDUAL", INDIVIDUAL},
   {"hybrid_search", HYBRID_SEARCH},
+  {"fulltext_dict", FULLTEXT_DICT},
 };
 
 /** https://dev.mysql.com/doc/refman/5.7/en/sql-syntax-prepared-statements.html

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -2881,6 +2881,8 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_FULLTEXT_DICT = 4920,
+  T_REFRESH_FULLTEXT_DICT = 4921,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -292,7 +292,7 @@ END_P SET_VAR DELIMITER
         CTXCAT CTX_ID CUBE CURDATE CURRENT STACKED CURTIME CURSOR_NAME CUME_DIST CYCLE CALC_PARTITION_ID CONNECT
 
         DAG DATA DATAFILE DATA_DISK_SIZE DATA_SOURCE DATA_TABLE_ID DATE DATE_ADD DATE_SUB DATETIME DAY DEALLOCATE DECRYPT
-        DEFAULT_AUTH DEFAULT_LOB_INROW_THRESHOLD DEFINER DELAY DELAY_KEY_WRITE DEPTH DES_KEY_FILE DENSE_RANK DESCRIPTION DESTINATION DIAGNOSTICS DICT_TABLE
+        DEFAULT_AUTH DEFAULT_LOB_INROW_THRESHOLD DEFINER DELAY DELAY_KEY_WRITE DEPTH DES_KEY_FILE DENSE_RANK DESCRIPTION DESTINATION DIAGNOSTICS DICT DICT_TABLE
         DIFF DIRECTORY DISABLE DISALLOW DISCARD DISK DISKGROUP DO DOT DUMP DUMPFILE DUPLICATE DUPLICATE_SCOPE DUPLICATE_READ_CONSISTENCY DYNAMIC
         DATABASE_ID DEFAULT_TABLEGROUP DISCONNECT DEMAND DELETE_INSERT DYNAMIC_PARTITION_POLICY
 
@@ -302,7 +302,7 @@ END_P SET_VAR DELIMITER
 
         FAIL FAILOVER FAST FAULTS FILE_BLOCK_SIZE FIELDS FILEX FINAL_COUNT FIRST FIRST_VALUE FIXED FLUSH FOLLOWER FORMAT
         FOUND FORK FREEZE FREQUENCY FUNCTION FOLLOWING FLASHBACK FULL FRAGMENTATION FROZEN FILE_ID FILTER
-        FIELD_OPTIONALLY_ENCLOSED_BY FIELD_DELIMITER FIELD_ENCLOSED_BY FILE_EXTENSION
+        FIELD_OPTIONALLY_ENCLOSED_BY FIELD_DELIMITER FIELD_ENCLOSED_BY FILE_EXTENSION FULLTEXT_DICT
 
         GENERAL GEOMETRY GEOMCOLLECTION GEOMETRYCOLLECTION GET_FORMAT GLOBAL GRANTS GRANULARITY GROUP_CONCAT GROUPING GTS
         GLOBAL_NAME GLOBAL_ALIAS
@@ -471,7 +471,7 @@ END_P SET_VAR DELIMITER
 %type <node> alter_column_behavior opt_set opt_position_column
 %type <node> alter_system_stmt alter_system_set_parameter_actions alter_system_settp_actions settp_option alter_system_set_parameter_action alter_system_reset_parameter_actions alter_system_reset_parameter_action
 %type <node> opt_comment opt_as
-%type <node> column_name relation_name relation_name_list opt_relation_name function_name column_label var_name relation_name_or_string row_format_option compression_name merge_engine_types
+%type <node> column_name relation_name relation_name_list opt_relation_name function_name column_label var_name relation_name_or_string refresh_fulltext_dict_dst row_format_option compression_name merge_engine_types
 %type <node> opt_hint_list hint_option select_with_opt_hint update_with_opt_hint delete_with_opt_hint hint_list_with_end global_hint transform_hint optimize_hint
 %type <node> create_index_stmt index_name sort_column_list sort_column_key opt_index_option_list opt_fulltext_index_option_list index_option fulltext_index_option opt_sort_column_key_length opt_index_using_algorithm index_using_algorithm visibility_option opt_constraint_name constraint_name create_with_opt_hint index_expr alter_with_opt_hint
 %type <node> opt_when check_state constraint_definition
@@ -6864,6 +6864,11 @@ TABLE_MODE opt_equal_mark STRING_VALUE
   (void)($2);
   malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_MODE, 1, $3);
 }
+| FULLTEXT_DICT opt_equal_mark STRING_VALUE
+{
+  (void)($2);
+  malloc_non_terminal_node($$, result->malloc_pool_, T_FULLTEXT_DICT, 1, $3);
+}
 | DUPLICATE_SCOPE opt_equal_mark STRING_VALUE
 {
   (void)($2);
@@ -7419,6 +7424,22 @@ relation_name
 | ALL
 {
   make_name_node($$, result->malloc_pool_, "all");
+}
+;
+
+refresh_fulltext_dict_dst:
+relation_name_or_string { $$ = $1; }
+| relation_name '.' relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_RELATION_FACTOR, 2, $1, $3);
+  dup_node_string($3, $$, result->malloc_pool_);
+}
+| id_dot_id
+{
+  ParseNode *db_node = $1->children_[0];
+  ParseNode *tb_node = $1->children_[1];
+  malloc_non_terminal_node($$, result->malloc_pool_, T_RELATION_FACTOR, 2, db_node, tb_node);
+  dup_node_string(tb_node, $$, result->malloc_pool_);
 }
 ;
 
@@ -18457,6 +18478,12 @@ alter_with_opt_hint SYSTEM REFRESH IO CALIBRATION opt_storage_name opt_calibrati
   malloc_non_terminal_node($$, result->malloc_pool_, T_REFRESH_IO_CALIBRATION, 3, $6, $7, NULL);
 }
 |
+alter_with_opt_hint SYSTEM REFRESH FULLTEXT DICT refresh_fulltext_dict_dst
+{
+  (void)($1);
+  malloc_non_terminal_node($$, result->malloc_pool_, T_REFRESH_FULLTEXT_DICT, 1, $6);
+}
+|
 alter_with_opt_hint SYSTEM opt_set alter_system_set_parameter_actions
 {
   (void)($1);
@@ -22175,6 +22202,7 @@ ACCESS_INFO
 |       DESCRIPTION
 |       DEMAND
 |       DIAGNOSTICS
+|       DICT
 |       DICT_TABLE
 |       DIFF
 |       DIRECTORY
@@ -22265,6 +22293,7 @@ ACCESS_INFO
 |       FREQUENCY
 |       FUNCTION
 |       FULL %prec HIGHER_PARENS
+|       FULLTEXT_DICT
 |       GENERAL
 |       GEOMETRY
 |       GEOMCOLLECTION

--- a/src/sql/printer/ob_schema_printer.cpp
+++ b/src/sql/printer/ob_schema_printer.cpp
@@ -1516,6 +1516,12 @@ int ObSchemaPrinter::print_table_definition_table_options(const ObTableSchema &t
       SHARE_SCHEMA_LOG(WARN, "fail to print collate", K(ret), K(table_schema));
     }
   }
+  if (OB_SUCC(ret) && !strict_compat_ && !is_for_table_status && !is_index_tbl
+      && !is_no_table_options(sql_mode) && table_schema.is_fulltext_dict()) {
+    if (OB_FAIL(databuff_printf(buf, buf_len, pos, "FULLTEXT_DICT = 'Y' "))) {
+      SHARE_SCHEMA_LOG(WARN, "fail to print fulltext dictionary option", K(ret), K(table_schema));
+    }
+  }
   if (OB_SUCC(ret) && table_schema.is_fts_index()
       && !is_no_key_options(sql_mode) && !table_schema.get_parser_name_str().empty()) {
     if (OB_FAIL(ObFtsIndexSchemaPrinter::print_fts_parser_info(table_schema, strict_compat_, buf, buf_len, pos))) {

--- a/src/sql/resolver/cmd/ob_alter_system_resolver.cpp
+++ b/src/sql/resolver/cmd/ob_alter_system_resolver.cpp
@@ -1145,6 +1145,82 @@ int ObRefreshMemStatResolver::resolve(const ParseNode &parse_tree)
   return ret;
 }
 
+int ObRefreshFulltextDictResolver::resolve(const ParseNode &parse_tree)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(T_REFRESH_FULLTEXT_DICT != parse_tree.type_)
+      || OB_ISNULL(parse_tree.children_)
+      || parse_tree.num_child_ < 1
+      || OB_ISNULL(parse_tree.children_[0])) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid refresh fulltext dictionary parse tree", K(ret), K(parse_tree.type_));
+  } else {
+    ObRefreshFulltextDictStmt *stmt = create_stmt<ObRefreshFulltextDictStmt>();
+    const ParseNode *relation_node = parse_tree.children_[0];
+    ObString database_name;
+    ObString table_name;
+    if (OB_ISNULL(stmt)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else {
+      stmt_ = stmt;
+      if (T_RELATION_FACTOR == relation_node->type_) {
+        if (relation_node->num_child_ < 2
+            || OB_ISNULL(relation_node->children_[0])
+            || OB_ISNULL(relation_node->children_[1])) {
+          ret = OB_ERR_UNEXPECTED;
+        } else {
+          database_name.assign_ptr(relation_node->children_[0]->str_value_,
+                                   relation_node->children_[0]->str_len_);
+          table_name.assign_ptr(relation_node->children_[1]->str_value_,
+                                relation_node->children_[1]->str_len_);
+        }
+      } else if (T_VARCHAR == relation_node->type_ || T_CHAR == relation_node->type_) {
+        ObString full_name;
+        if (OB_FAIL(Util::resolve_string(relation_node, full_name))) {
+          LOG_WARN("fail to resolve dictionary table string", K(ret));
+        } else {
+          const char *dot = full_name.find('.');
+          if (OB_ISNULL(dot)) {
+            table_name = full_name;
+          } else {
+            database_name.assign_ptr(full_name.ptr(), static_cast<int32_t>(dot - full_name.ptr()));
+            table_name.assign_ptr(dot + 1,
+                static_cast<int32_t>(full_name.length() - (dot - full_name.ptr()) - 1));
+          }
+        }
+      } else if (T_IDENT == relation_node->type_) {
+        if (OB_FAIL(Util::resolve_relation_name(relation_node, table_name))) {
+          LOG_WARN("fail to resolve dictionary table identifier", K(ret));
+        }
+      } else {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected dictionary table node", K(ret), K(relation_node->type_));
+      }
+
+      if (OB_FAIL(ret)) {
+      } else if (database_name.empty()) {
+        if (OB_ISNULL(session_info_)) {
+          ret = OB_ERR_UNEXPECTED;
+        } else if (FALSE_IT(database_name = session_info_->get_database_name())) {
+        } else if (database_name.empty()) {
+          ret = OB_ERR_NO_DB_SELECTED;
+          LOG_USER_ERROR(OB_ERR_NO_DB_SELECTED);
+        }
+      }
+      if (OB_SUCC(ret)) {
+        if (database_name.empty() || table_name.empty() || OB_NOT_NULL(table_name.find('.'))) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name must be [database.]table");
+        } else {
+          stmt->set_database_name(database_name);
+          stmt->set_table_name(table_name);
+        }
+      }
+    }
+  }
+  return ret;
+}
+
 int ObWashMemFragmentationResolver::resolve(const ParseNode &parse_tree)
 {
   int ret = OB_SUCCESS;

--- a/src/sql/resolver/cmd/ob_alter_system_resolver.h
+++ b/src/sql/resolver/cmd/ob_alter_system_resolver.h
@@ -96,6 +96,8 @@ DEF_SIMPLE_CMD_RESOLVER(ObAdminMergeResolver);
 
 DEF_SIMPLE_CMD_RESOLVER(ObRefreshMemStatResolver);
 
+DEF_SIMPLE_CMD_RESOLVER(ObRefreshFulltextDictResolver);
+
 DEF_SIMPLE_CMD_RESOLVER(ObWashMemFragmentationResolver);
 
 DEF_SIMPLE_CMD_RESOLVER(ObRefreshIOCalibrationResolver);

--- a/src/sql/resolver/cmd/ob_alter_system_stmt.h
+++ b/src/sql/resolver/cmd/ob_alter_system_stmt.h
@@ -169,6 +169,26 @@ private:
   obcall::ObAdminRefreshMemStatArg rpc_arg_;
 };
 
+class ObRefreshFulltextDictStmt : public ObSystemCmdStmt
+{
+public:
+  ObRefreshFulltextDictStmt()
+      : ObSystemCmdStmt(stmt::T_REFRESH_FULLTEXT_DICT), database_name_(), table_name_()
+  {
+  }
+  virtual ~ObRefreshFulltextDictStmt() {}
+
+  const common::ObString &get_database_name() const { return database_name_; }
+  const common::ObString &get_table_name() const { return table_name_; }
+  void set_database_name(const common::ObString &database_name) { database_name_ = database_name; }
+  void set_table_name(const common::ObString &table_name) { table_name_ = table_name; }
+
+  TO_STRING_KV(N_STMT_TYPE, ((int)stmt_type_), K_(database_name), K_(table_name));
+private:
+  common::ObString database_name_;
+  common::ObString table_name_;
+};
+
 class ObWashMemFragmentationStmt : public ObSystemCmdStmt
 {
 public:

--- a/src/sql/resolver/ddl/ob_alter_table_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_alter_table_resolver.cpp
@@ -166,6 +166,10 @@ int ObAlterTableResolver::resolve(const ParseNode &parse_tree)
         } else if (1 == parse_tree.value_ && OB_ISNULL(index_schema_)) {
           ret = OB_ERR_UNEXPECTED;
           LOG_WARN("table schema is NULL", K(ret));
+        } else if (table_schema_->is_fulltext_dict()) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "alter fulltext dictionary table structure is");
+          LOG_WARN("alter fulltext dictionary table is not supported", K(ret), KPC(table_schema_));
         }
       }
     }

--- a/src/sql/resolver/ddl/ob_ddl_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_ddl_resolver.cpp
@@ -1602,9 +1602,13 @@ int ObDDLResolver::resolve_table_option(const ParseNode *option_node, const bool
         break;
       }
       case T_PARSER_PROPERTIES: {
-        if (OB_FAIL(ObFTParserResolverHelper::resolve_parser_properties(*option_node,
-                                                                               *allocator_,
-                                                                               parser_properties_))) {
+        if (OB_FAIL(ObFTParserResolverHelper::resolve_parser_properties(
+                database_name_,
+                *option_node,
+                common::OB_SERVER_TENANT_ID,
+                *allocator_,
+                schema_checker_,
+                parser_properties_))) {
           LOG_WARN("fail to resolve parser properties", K(ret));
         }
         break;
@@ -1732,6 +1736,29 @@ int ObDDLResolver::resolve_table_option(const ParseNode *option_node, const bool
               table_mode_.pk_exists_ = tbl_schema->get_table_mode_struct().pk_exists_;
               table_mode_.table_organization_mode_ = tbl_schema->get_table_mode_struct().table_organization_mode_;
             }
+          }
+        }
+        break;
+      }
+      case T_FULLTEXT_DICT: {
+        if (is_index_option) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "FULLTEXT_DICT in index option is");
+        } else if (OB_ISNULL(option_node->children_[0])) {
+          ret = OB_ERR_UNEXPECTED;
+          SQL_RESV_LOG(WARN, "option_node child is null", K(ret));
+        } else if (stmt::T_CREATE_TABLE != stmt_->get_stmt_type()) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "FULLTEXT_DICT outside CREATE TABLE is");
+        } else {
+          const ObString flag(static_cast<int32_t>(option_node->children_[0]->str_len_),
+                              option_node->children_[0]->str_value_);
+          if (0 != flag.case_compare("Y")) {
+            ret = OB_INVALID_ARGUMENT;
+            LOG_USER_ERROR(OB_INVALID_ARGUMENT, "FULLTEXT_DICT only accepts 'Y'");
+          } else {
+            ObCreateTableStmt *create_table_stmt = static_cast<ObCreateTableStmt *>(stmt_);
+            create_table_stmt->get_create_table_arg().schema_.set_fulltext_dict();
           }
         }
         break;
@@ -6847,6 +6874,10 @@ int ObDDLResolver::generate_global_index_schema(
     ObTableType table_type = table_schema->get_table_type();
     LOG_WARN("Not support to create index on non-normal table", K(ret), K(table_type),
              "arg", crt_idx_stmt->get_create_index_arg());
+  } else if (table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "create index on fulltext dictionary table is");
+    LOG_WARN("create index on fulltext dictionary table is not supported", K(ret), KPC(table_schema));
   } else {
     ObArray<ObColumnSchemaV2 *> gen_columns;
     ObCreateIndexArg &create_index_arg = crt_idx_stmt->get_create_index_arg();

--- a/src/sql/resolver/ddl/ob_fts_index_builder_util.cpp
+++ b/src/sql/resolver/ddl/ob_fts_index_builder_util.cpp
@@ -24,7 +24,11 @@
 #include "share/ob_server_struct.h"
 #include "rootserver/ob_root_service.h"
 #include "plugin/sys/ob_plugin_helper.h"
+#include "share/schema/ob_dependency_info.h"
 #include "share/schema/ob_schema_utils.h"  // relocated-definition owner
+#include "storage/fts/dict/ob_ft_dict_def.h"
+#include "storage/fts/ob_fts_parser_property.h"
+#include "storage/fts/ob_fts_plugin_helper.h"
 
 namespace oceanbase
 {
@@ -34,6 +38,48 @@ using namespace share::schema;
 
 namespace share
 {
+
+int ObFtsIndexBuilderUtil::check_fulltext_dict_schema(
+    const share::schema::ObTableSchema &table_schema,
+    const int64_t inline_index_count)
+{
+  int ret = OB_SUCCESS;
+  if (!table_schema.is_fulltext_dict()) {
+  } else if (table_schema.is_heap_organized_table()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "heap organization for fulltext dictionary table is");
+  } else if (inline_index_count > 0) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "inline index on fulltext dictionary table is");
+  } else if (table_schema.is_partitioned_table()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "partitioning fulltext dictionary table is");
+  } else if (1 != table_schema.get_column_count()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table must contain exactly one column");
+  } else {
+    const share::schema::ObColumnSchemaV2 *word_column = table_schema.get_column_schema("word");
+    if (OB_ISNULL(word_column)) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table must contain column 'word'");
+    } else if (!word_column->is_rowkey_column()
+               || 1 != table_schema.get_rowkey_column_num()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "column 'word' must be the only primary key column");
+    } else if (ObVarcharType != word_column->get_data_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "column 'word' must be varchar");
+    } else if (CHARSET_UTF8MB4 != word_column->get_charset_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table charset must be utf8mb4");
+    } else if (word_column->get_accuracy().get_length() < 1
+               || word_column->get_accuracy().get_length() > 500) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_USER_ERROR(OB_INVALID_ARGUMENT, "column 'word' varchar length must be in [1, 500]");
+    }
+  }
+  return ret;
+}
 namespace
 {
 bool get_function_args(const ObString &expr_string,
@@ -2199,6 +2245,122 @@ int ObFtsIndexBuilderUtil::try_load_and_lock_dictionary_tables(
           LOG_WARN("fail to lock all dictionaries", K(ret), K(1UL), K(dic_loader_handle));
         }
       }
+    }
+  }
+  return ret;
+}
+
+namespace
+{
+typedef int (storage::ObFTParserJsonProps::*DictTableIdGetter)(uint64_t &) const;
+
+int append_fts_dict_dependency(const storage::ObFTParserJsonProps &properties,
+                               const ObTableSchema &index_schema,
+                               const storage::ObFTDictType dict_type,
+                               DictTableIdGetter getter,
+                               ObIArray<ObDependencyInfo> &dependencies)
+{
+  int ret = OB_SUCCESS;
+  uint64_t dict_table_id = OB_INVALID_ID;
+  if (OB_FAIL((properties.*getter)(dict_table_id))) {
+    if (OB_SEARCH_NOT_FOUND == ret) {
+      ret = OB_SUCCESS;
+    } else {
+      LOG_WARN("fail to get dictionary table id from parser properties", K(ret), K(dict_type));
+    }
+  } else if (is_inner_table(dict_table_id)) {
+    // Built-in dictionaries are immutable inner tables and need no dependency row.
+  } else {
+    ObDependencyInfo dependency;
+    dependency.set_dep_obj_type(ObObjectType::INDEX);
+    dependency.set_ref_obj_id(dict_table_id);
+    dependency.set_ref_obj_type(ObObjectType::TABLE);
+    dependency.set_property(static_cast<uint64_t>(dict_type));
+    dependency.set_order(dependencies.count());
+    if (OB_FAIL(dependencies.push_back(dependency))) {
+      LOG_WARN("fail to append dictionary table dependency", K(ret), K(dict_table_id));
+    }
+  }
+  return ret;
+}
+} // namespace
+
+int ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+    const ObTableSchema &index_schema,
+    ObMySQLTransaction &trans)
+{
+  int ret = OB_SUCCESS;
+  storage::ObFTParser parser;
+  storage::ObFTParserJsonProps properties;
+  ObArray<ObDependencyInfo> dependencies;
+  const ObString &parser_name = index_schema.get_parser_name();
+  const ObString &parser_properties = index_schema.get_parser_property_str();
+
+  if (!index_schema.is_fts_index_aux() || parser_name.empty() || parser_properties.empty()) {
+  } else if (OB_FAIL(parser.parse_from_str(parser_name.ptr(), parser_name.length()))) {
+    LOG_WARN("fail to parse fulltext parser name", K(ret), K(parser_name));
+  } else if (!parser.is_ik()) {
+  } else if (OB_FAIL(properties.init())) {
+    LOG_WARN("fail to initialize parser properties", K(ret));
+  } else if (OB_FAIL(properties.parse_from_valid_str(parser_properties))) {
+    LOG_WARN("fail to parse fulltext parser properties", K(ret), K(parser_properties));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_MAIN,
+                 &storage::ObFTParserJsonProps::config_get_dict_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append main dictionary dependency", K(ret));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_QUAN,
+                 &storage::ObFTParserJsonProps::config_get_quantifier_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append quantifier dictionary dependency", K(ret));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_STOP,
+                 &storage::ObFTParserJsonProps::config_get_stopword_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append stopword dictionary dependency", K(ret));
+  } else if (!dependencies.empty()
+             && OB_FAIL(ObDependencyInfo::insert_dependency_infos(
+                    trans,
+                    dependencies,
+                    index_schema.get_table_id(),
+                    index_schema.get_schema_version(),
+                    index_schema.get_table_id()))) {
+    LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(index_schema));
+  }
+  return ret;
+}
+
+int ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+    const uint64_t dict_table_id,
+    ObMySQLTransaction &trans)
+{
+  int ret = OB_SUCCESS;
+  ObArray<ObDependencyInfo> dependencies;
+  bool is_in_use = false;
+  if (OB_INVALID_ID == dict_table_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table id", K(ret), K(dict_table_id));
+  } else if (OB_FAIL(ObDependencyInfo::collect_dep_infos(dict_table_id, trans, dependencies))) {
+    LOG_WARN("fail to collect dictionary table dependencies", K(ret), K(dict_table_id));
+  } else {
+    for (int64_t i = 0; !is_in_use && i < dependencies.count(); ++i) {
+      const ObDependencyInfo &dependency = dependencies.at(i);
+      is_in_use = ObObjectType::INDEX == dependency.get_dep_obj_type()
+                  && ObObjectType::TABLE == dependency.get_ref_obj_type()
+                  && dict_table_id == dependency.get_ref_obj_id();
+    }
+    if (is_in_use) {
+      ret = OB_OP_NOT_ALLOW;
+      LOG_WARN("cannot drop a fulltext dictionary table in use", K(ret), K(dict_table_id));
+      LOG_USER_ERROR(OB_OP_NOT_ALLOW,
+                     "drop fulltext dictionary table that is being used by fulltext index");
     }
   }
   return ret;

--- a/src/sql/resolver/ddl/ob_fts_index_builder_util.h
+++ b/src/sql/resolver/ddl/ob_fts_index_builder_util.h
@@ -74,6 +74,9 @@ public:
   // Check if we can use rowkey instead of doc id.
   // if we want to add more types, make this one condition of them.
   static int determine_docid_type(const ObTableSchema &table_schema, ObDocIDType &doc_id_type);
+  static int check_fulltext_dict_schema(
+      const share::schema::ObTableSchema &table_schema,
+      const int64_t inline_index_count);
   static int check_need_doc_id(
       const ObTableSchema &table_schema,
       bool &need_doc_id);
@@ -154,6 +157,12 @@ public:
       bool &need_to_load_dic);
   static int try_load_and_lock_dictionary_tables(
       const ObTableSchema &index_schema,
+      ObMySQLTransaction &trans);
+  static int record_fts_dict_table_dependencies(
+      const ObTableSchema &index_schema,
+      ObMySQLTransaction &trans);
+  static int check_can_drop_dict_table(
+      const uint64_t dict_table_id,
       ObMySQLTransaction &trans);
   static int try_load_dictionary_for_all_tenants();
   static int check_supportability_for_loader_key(const ObString &parser_name,

--- a/src/sql/resolver/ddl/ob_fts_parser_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_fts_parser_resolver.cpp
@@ -16,6 +16,8 @@
 
 #include "storage/fts/ob_fts_literal.h"
 #include "storage/fts/ob_fts_parser_property.h"
+#include "lib/string/ob_sql_string.h"
+#include "sql/resolver/ob_schema_checker.h"
 #define USING_LOG_PREFIX STORAGE_FTS
 
 #include "sql/resolver/ddl/ob_fts_parser_resolver.h"
@@ -25,13 +27,88 @@ namespace oceanbase
 namespace sql
 {
 
-int ObFTParserResolverHelper::resolve_parser_properties(
-    const ParseNode &parse_tree,
+int ObFTParserResolverHelper::resolve_dict_table_name_and_id(
+    const common::ObString &index_database_name,
+    const common::ObString &table_name,
+    const uint64_t tenant_id,
+    share::schema::ObSchemaGetterGuard &schema_guard,
     common::ObIAllocator &allocator,
+    uint64_t &table_id,
+    common::ObString &full_table_name)
+{
+  int ret = OB_SUCCESS;
+  ObString database_name;
+  ObString parsed_table_name;
+  table_id = OB_INVALID_ID;
+  full_table_name.reset();
+  const char *dot = table_name.find('.');
+  if (table_name.empty() || OB_INVALID_TENANT_ID == tenant_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table argument", K(ret), K(table_name), K(tenant_id));
+  } else if (OB_NOT_NULL(dot)) {
+    database_name.assign_ptr(table_name.ptr(), static_cast<int32_t>(dot - table_name.ptr()));
+    parsed_table_name.assign_ptr(dot + 1,
+        static_cast<int32_t>(table_name.length() - (dot - table_name.ptr()) - 1));
+    if (database_name.empty() || parsed_table_name.empty()
+        || OB_NOT_NULL(parsed_table_name.find('.'))) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name must be [database.]table");
+    }
+  } else if (index_database_name.empty()) {
+    ret = OB_ERR_NO_DB_SELECTED;
+    LOG_USER_ERROR(OB_ERR_NO_DB_SELECTED);
+  } else {
+    database_name = index_database_name;
+    parsed_table_name = table_name;
+  }
+
+  const share::schema::ObTableSchema *table_schema = nullptr;
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(schema_guard.get_table_id(database_name,
+                                               parsed_table_name,
+                                               false,
+                                               share::schema::ObSchemaGetterGuard::ALL_NON_HIDDEN_TYPES,
+                                               table_id))) {
+    LOG_WARN("fail to resolve dictionary table id", K(ret), K(database_name), K(parsed_table_name));
+  } else if (OB_INVALID_ID == table_id) {
+    ret = OB_ERR_UNKNOWN_TABLE;
+    LOG_USER_ERROR(OB_ERR_UNKNOWN_TABLE,
+                   parsed_table_name.length(), parsed_table_name.ptr(),
+                   database_name.length(), database_name.ptr());
+  } else if (OB_FAIL(schema_guard.get_table_schema(table_id, table_schema))) {
+    LOG_WARN("fail to get dictionary table schema", K(ret), K(table_id));
+  } else if (OB_ISNULL(table_schema)) {
+    ret = OB_TABLE_NOT_EXIST;
+  } else if (!table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "using a non-fulltext-dictionary table as dictionary is");
+  } else {
+    const int64_t buffer_size = database_name.length() + parsed_table_name.length() + 2;
+    char *buffer = static_cast<char *>(allocator.alloc(buffer_size));
+    int64_t pos = 0;
+    if (OB_ISNULL(buffer)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else if (OB_FAIL(databuff_printf(buffer, buffer_size, pos, "%.*s.%.*s",
+                                      database_name.length(), database_name.ptr(),
+                                      parsed_table_name.length(), parsed_table_name.ptr()))) {
+      LOG_WARN("fail to construct dictionary table name", K(ret));
+    } else {
+      full_table_name.assign_ptr(buffer, static_cast<int32_t>(pos));
+    }
+  }
+  return ret;
+}
+
+int ObFTParserResolverHelper::resolve_parser_properties(
+    const common::ObString &index_database_name,
+    const ParseNode &parse_tree,
+    const uint64_t tenant_id,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker *schema_checker,
     common::ObString &parser_property)
 {
   int ret = OB_SUCCESS;
-  if (OB_UNLIKELY(parse_tree.num_child_ <= 0)) {
+  if (OB_UNLIKELY(parse_tree.num_child_ <= 0) || OB_ISNULL(schema_checker)) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument, parser properties is empty", K(ret), K(parse_tree.num_child_));
   } else {
@@ -44,7 +121,12 @@ int ObFTParserResolverHelper::resolve_parser_properties(
       if (OB_ISNULL(parse_tree.children_[i])) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("option_node child is nullptr", K(ret));
-      } else if (OB_FAIL(resolve_fts_index_parser_properties(parse_tree.children_[i], property))) {
+      } else if (OB_FAIL(resolve_fts_index_parser_properties(index_database_name,
+                                                             parse_tree.children_[i],
+                                                             tenant_id,
+                                                             property,
+                                                             allocator,
+                                                             *schema_checker))) {
         LOG_WARN("fail to resolve fts index parser properties", K(ret));
       }
     }
@@ -57,8 +139,12 @@ int ObFTParserResolverHelper::resolve_parser_properties(
 }
 
 int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
+    const common::ObString &index_database_name,
     const ParseNode *node,
-    storage::ObFTParserJsonProps &property)
+    const uint64_t tenant_id,
+    storage::ObFTParserJsonProps &property,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker &schema_checker)
 {
   int ret = OB_SUCCESS;
   if (OB_ISNULL(node) || node->num_child_ != 1 || OB_ISNULL(node->children_[0])){
@@ -115,54 +201,24 @@ int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
         break;
       }
       case T_PARSER_STOPWORD_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the stopword table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_stopword_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set stopword table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_stopword_table,
+                                   &storage::ObFTParserJsonProps::config_set_stopword_table_id);
         break;
       }
       case T_PARSER_DICT_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the dict table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_dict_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set dict table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_dict_table,
+                                   &storage::ObFTParserJsonProps::config_set_dict_table_id);
         break;
       }
       case T_PARSER_QUANTIFIER_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the quanitfier table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_quantifier_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set quantifier table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_quantifier_table,
+                                   &storage::ObFTParserJsonProps::config_set_quantifier_table_id);
         break;
       }
       case T_IK_MODE: {
@@ -230,6 +286,43 @@ int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
         ret = OB_INVALID_ARGUMENT;
         LOG_WARN("invalid fts index parser properties option", K(ret), K(node->type_));
       }
+    }
+  }
+  return ret;
+}
+
+int ObFTParserResolverHelper::resolve_table_config(
+    const common::ObString &index_database_name,
+    const ParseNode *node,
+    const uint64_t tenant_id,
+    storage::ObFTParserJsonProps &property,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker &schema_checker,
+    int (storage::ObFTParserJsonProps::*set_name)(const common::ObString &),
+    int (storage::ObFTParserJsonProps::*set_id)(const uint64_t))
+{
+  int ret = OB_SUCCESS;
+  uint64_t table_id = OB_INVALID_ID;
+  ObString full_table_name;
+  if (OB_ISNULL(node) || OB_ISNULL(node->children_) || OB_ISNULL(node->children_[0])
+      || node->children_[0]->str_len_ <= 0 || OB_ISNULL(schema_checker.get_schema_guard())) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name is empty");
+  } else {
+    const ObString table_name(static_cast<int32_t>(node->children_[0]->str_len_),
+                              node->children_[0]->str_value_);
+    if (OB_FAIL(resolve_dict_table_name_and_id(index_database_name,
+                                               table_name,
+                                               tenant_id,
+                                               *schema_checker.get_schema_guard(),
+                                               allocator,
+                                               table_id,
+                                               full_table_name))) {
+      LOG_WARN("fail to resolve dictionary table", K(ret), K(table_name));
+    } else if (OB_FAIL((property.*set_name)(full_table_name))) {
+      LOG_WARN("fail to set dictionary table name", K(ret), K(full_table_name));
+    } else if (OB_FAIL((property.*set_id)(table_id))) {
+      LOG_WARN("fail to set dictionary table id", K(ret), K(table_id));
     }
   }
   return ret;

--- a/src/sql/resolver/ddl/ob_fts_parser_resolver.h
+++ b/src/sql/resolver/ddl/ob_fts_parser_resolver.h
@@ -20,11 +20,13 @@
 #include "sql/resolver/ddl/ob_ddl_resolver.h"
 #include "storage/fts/ob_fts_parser_property.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
+#include "share/schema/ob_schema_getter_guard.h"
 
 namespace oceanbase
 {
 namespace sql
 {
+class ObSchemaChecker;
 class ObFTParserResolverHelper final
 {
 public:
@@ -32,13 +34,39 @@ public:
   ~ObFTParserResolverHelper() = default;
 
   static int resolve_parser_properties(
+      const common::ObString &index_database_name,
       const ParseNode &parse_tree,
+      const uint64_t tenant_id,
       common::ObIAllocator &allocator,
+      ObSchemaChecker *schema_checker,
       common::ObString &parser_property);
 
+  static int resolve_dict_table_name_and_id(
+      const common::ObString &index_database_name,
+      const common::ObString &table_name,
+      const uint64_t tenant_id,
+      share::schema::ObSchemaGetterGuard &schema_guard,
+      common::ObIAllocator &allocator,
+      uint64_t &table_id,
+      common::ObString &full_table_name);
+
 private:
-  static int resolve_fts_index_parser_properties(const ParseNode *node,
-                                                 storage::ObFTParserJsonProps &property);
+  static int resolve_fts_index_parser_properties(
+      const common::ObString &index_database_name,
+      const ParseNode *node,
+      const uint64_t tenant_id,
+      storage::ObFTParserJsonProps &property,
+      common::ObIAllocator &allocator,
+      ObSchemaChecker &schema_checker);
+  static int resolve_table_config(
+      const common::ObString &index_database_name,
+      const ParseNode *node,
+      const uint64_t tenant_id,
+      storage::ObFTParserJsonProps &property,
+      common::ObIAllocator &allocator,
+      ObSchemaChecker &schema_checker,
+      int (storage::ObFTParserJsonProps::*set_name)(const common::ObString &),
+      int (storage::ObFTParserJsonProps::*set_id)(const uint64_t));
 };
 
 } // end namespace sql

--- a/src/sql/resolver/ob_resolver.cpp
+++ b/src/sql/resolver/ob_resolver.cpp
@@ -365,6 +365,10 @@ int ObResolver::resolve(IsPrepared if_prepared, const ParseNode &parse_tree, ObS
         REGISTER_STMT_RESOLVER(RefreshMemStat);
         break;
       }
+      case T_REFRESH_FULLTEXT_DICT: {
+        REGISTER_STMT_RESOLVER(RefreshFulltextDict);
+        break;
+      }
       case T_WASH_MEMORY_FRAGMENTATION: {
         REGISTER_STMT_RESOLVER(WashMemFragmentation);
         break;

--- a/src/sql/resolver/ob_stmt_type.h
+++ b/src/sql/resolver/ob_stmt_type.h
@@ -347,6 +347,7 @@ OB_STMT_TYPE_DEF_UNKNOWN_AT(T_LOCATION_UTILS_LIST, no_priv_needed, 390)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_LOCATION_UTILS, no_priv_needed, 391)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_DIFF_TABLE, get_dml_stmt_need_privs, 392)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_MERGE_TABLE, get_merge_table_stmt_need_privs, 393)
+OB_STMT_TYPE_DEF_UNKNOWN_AT(T_REFRESH_FULLTEXT_DICT, get_sys_tenant_alter_system_priv, 394)
 
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_MAX, err_stmt_type_priv, 500)
 #endif

--- a/src/storage/fts/dict/ob_ft_cache.h
+++ b/src/storage/fts/dict/ob_ft_cache.h
@@ -36,10 +36,11 @@ namespace storage
 class ObDictCacheKey : public common::ObIKVCacheKey
 {
 public:
-  ObDictCacheKey(const uint64_t name,
-                 const ObFTDictType dict_type,
-                 int32_t range_id)
-      : name_(name), dict_type_(dict_type), range_id_(range_id)
+  ObDictCacheKey(const uint64_t tenant_id,
+                 const uint64_t table_id,
+                 const uint64_t generation,
+                 const int32_t range_id)
+      : tenant_id_(tenant_id), table_id_(table_id), generation_(generation), range_id_(range_id)
   {
   }
   ~ObDictCacheKey() override {}
@@ -48,14 +49,18 @@ public:
   {
     const ObDictCacheKey &other_key = reinterpret_cast<const ObDictCacheKey &>(other);
     return (&other == this)
-           || ((other_key.name_ == name_) && (other_key.dict_type_ == dict_type_));
+           || (other_key.tenant_id_ == tenant_id_
+               && other_key.table_id_ == table_id_
+               && other_key.generation_ == generation_
+               && other_key.range_id_ == range_id_);
   }
 
   uint64_t hash() const override
   {
     uint64_t hash_val = 0;
-    hash_val = murmurhash(&name_, sizeof(name_), hash_val);
-    hash_val = murmurhash(&dict_type_, sizeof(dict_type_), hash_val);
+    hash_val = murmurhash(&tenant_id_, sizeof(tenant_id_), hash_val);
+    hash_val = murmurhash(&table_id_, sizeof(table_id_), hash_val);
+    hash_val = murmurhash(&generation_, sizeof(generation_), hash_val);
     hash_val = murmurhash(&range_id_, sizeof(range_id_), hash_val);
     return hash_val;
   }
@@ -80,17 +85,18 @@ public:
       ret = OB_INVALID_ARGUMENT;
       CLOG_LOG(WARN, "invalid argument for ob dict cache", K(ret), K(buf_len), K(size()));
     } else {
-      ObDictCacheKey *new_key = new (buf) ObDictCacheKey(name_, dict_type_, range_id_);
+      ObDictCacheKey *new_key = new (buf) ObDictCacheKey(
+          tenant_id_, table_id_, generation_, range_id_);
       key = new_key;
     }
     return ret;
   }
 
-  TO_STRING_KV(K_(name), K_(dict_type), K_(range_id));
+  TO_STRING_KV(K_(tenant_id), K_(table_id), K_(generation), K_(range_id));
 private:
-  // to change to name
-  uint64_t name_; // when build dict
-  ObFTDictType dict_type_;
+  uint64_t tenant_id_;
+  uint64_t table_id_;
+  uint64_t generation_;
   int32_t range_id_;
 };
 

--- a/src/storage/fts/dict/ob_ft_cache_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_cache_dict.cpp
@@ -87,8 +87,8 @@ int ObFTCacheDict::make_and_fetch_cache_entry(const ObFTDictDesc &desc,
 {
   int ret = OB_SUCCESS;
   ObDictCache &cache = ObDictCache::get_instance();
-  uint64_t name = static_cast<uint64_t>(desc.type_);
-  const ObDictCacheKey put_key(name, desc.type_, range_id);
+  const ObDictCacheKey put_key(
+      desc.tenant_id_, desc.table_id_, desc.generation_, range_id);
   const ObDictCacheValue put_value(dat_buff);
   if (OB_FAIL(cache.put_and_fetch_dict(put_key, put_value, value, handle))) {
     LOG_WARN("Failed to put dict into kv cache", K(ret));

--- a/src/storage/fts/dict/ob_ft_dat_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_dat_dict.cpp
@@ -39,7 +39,7 @@ int ObFTDATBuilder<DATA_TYPE>::init(ObFTTrie<DATA_TYPE> &trie)
     ret = OB_INIT_TWICE;
     LOG_WARN("Builder has already inited", K(ret));
   } else {
-    size_t map_size = ObArrayHashMap::estimate_size(trie.node_num());
+    size_t map_size = ObFTArrayHashMap::estimate_size(trie.node_num());
     size_t array_size = trie.node_num() * 6; // by experience.
     size_t base_size = array_size * sizeof(int32_t);
     size_t check_size = base_size;
@@ -305,9 +305,9 @@ int ObFTDATReader<DATA_TYPE>::match_with_hit(const ObString &ft_char,
 template class ObFTDATBuilder<void>;
 template class ObFTDATReader<void>;
 
-ObArrayHashMap *ObFTDAT::get_map() { return reinterpret_cast<ObArrayHashMap *>(buff); }
+ObFTArrayHashMap *ObFTDAT::get_map() { return reinterpret_cast<ObFTArrayHashMap *>(buff); }
 
-int ObArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
+int ObFTArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
 {
   int ret = OB_ENTRY_NOT_EXIST;
   uint64_t hash = word.get_word().hash();
@@ -324,7 +324,7 @@ int ObArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
   return ret;
 }
 
-int ObArrayHashMap::insert(const ObString &key, ObFTWordCode code)
+int ObFTArrayHashMap::insert(const ObString &key, ObFTWordCode code)
 {
   int ret = OB_SUCCESS;
   uint64_t hash = key.hash();
@@ -340,7 +340,7 @@ int ObArrayHashMap::insert(const ObString &key, ObFTWordCode code)
   return ret;
 }
 
-int ObArrayHashMap::init(size_t word_num)
+int ObFTArrayHashMap::init(size_t word_num)
 {
   int ret = OB_SUCCESS;
   size_t capacity = estimate_capacity(word_num);
@@ -353,14 +353,14 @@ int ObArrayHashMap::init(size_t word_num)
   return OB_SUCCESS;
 }
 
-size_t ObArrayHashMap::estimate_size(size_t word_num)
+size_t ObFTArrayHashMap::estimate_size(size_t word_num)
 {
   size_t capacity = estimate_capacity(word_num);
   size_t size = sizeof(Header) + capacity * sizeof(Entry);
   return size;
 }
 
-size_t ObArrayHashMap::estimate_capacity(size_t word_num)
+size_t ObFTArrayHashMap::estimate_capacity(size_t word_num)
 {
   constexpr size_t MIN_CAPACITY = 101;                   // prime
   size_t capacity = MAX(word_num * 4 / 3, MIN_CAPACITY); // 75%

--- a/src/storage/fts/dict/ob_ft_dat_dict.h
+++ b/src/storage/fts/dict/ob_ft_dat_dict.h
@@ -33,10 +33,10 @@ namespace oceanbase
 {
 namespace storage
 {
-/* @class ObArrayHashMap
+/* @class ObFTArrayHashMap
  * @description: a fixed size hash map, used to store words and their code.
  */
-class ObArrayHashMap final
+class ObFTArrayHashMap final
 {
 public:
   struct Entry
@@ -105,7 +105,7 @@ public:
   char buff[1] = {0};
 
 public:
-  ObArrayHashMap *get_map();
+  ObFTArrayHashMap *get_map();
 } __attribute__((packed));
 
 template <typename DataType>
@@ -150,7 +150,7 @@ private:
 private:
   common::ObIAllocator &alloc_;
   ObFTDAT *dat_;
-  ObArrayHashMap *map_;
+  ObFTArrayHashMap *map_;
 
   bool is_inited_;
   int32_t next_code_;

--- a/src/storage/fts/dict/ob_ft_dict_def.h
+++ b/src/storage/fts/dict/ob_ft_dict_def.h
@@ -64,15 +64,52 @@ public:
                const ObFTDictType type,
                const ObCharsetType charset,
                const ObCollationType coll_type)
-      : name_(name), type_(type), charset_(charset), coll_type_(coll_type)
+      : tenant_id_(1),
+        table_id_(static_cast<uint64_t>(type)),
+        table_name_(name),
+        type_(type),
+        charset_(charset),
+        coll_type_(coll_type),
+        generation_(0),
+        is_builtin_(true),
+        need_casedown_(false)
   {
   }
 
+  ObFTDictDesc(const uint64_t tenant_id,
+               const uint64_t table_id,
+               const ObString &table_name,
+               const ObFTDictType type,
+               const ObCharsetType charset,
+               const ObCollationType coll_type,
+               const bool is_builtin,
+               const bool need_casedown)
+      : tenant_id_(tenant_id),
+        table_id_(table_id),
+        table_name_(table_name),
+        type_(type),
+        charset_(charset),
+        coll_type_(coll_type),
+        generation_(0),
+        is_builtin_(is_builtin),
+        need_casedown_(need_casedown)
+  {
+  }
+
+  TO_STRING_KV(K_(tenant_id), K_(table_id), K_(table_name), K_(type),
+               K_(charset), K_(coll_type), K_(generation), K_(is_builtin),
+               K_(need_casedown));
+
 public:
-  ObString name_;
+  uint64_t tenant_id_;
+  uint64_t table_id_;
+  ObString table_name_;
   ObFTDictType type_;
   ObCharsetType charset_;
   ObCollationType coll_type_;
+  uint64_t generation_;
+  bool is_builtin_;
+  bool need_casedown_;
 };
 
 } //  namespace storage

--- a/src/storage/fts/dict/ob_ft_dict_hub.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_hub.cpp
@@ -45,13 +45,27 @@ int ObFTDictHub::init()
 int ObFTDictHub::destroy()
 {
   int ret = OB_SUCCESS;
+  dict_map_.destroy();
+  rw_dict_lock_.destroy();
   is_inited_ = false;
   return ret;
 }
 int ObFTDictHub::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container)
 {
+  return build_cache_internal(desc, container, false);
+}
+
+int ObFTDictHub::refresh(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container)
+{
+  return build_cache_internal(desc, container, true);
+}
+
+int ObFTDictHub::build_cache_internal(const ObFTDictDesc &desc,
+                                      ObFTCacheRangeContainer &container,
+                                      const bool force_refresh)
+{
   int ret = OB_SUCCESS;
-  ObFTDictInfoKey key(static_cast<uint64_t>(desc.type_));
+  ObFTDictInfoKey key(desc.tenant_id_, desc.table_id_);
   ObFTDictInfo info;
   container.reset();
 
@@ -61,28 +75,44 @@ int ObFTDictHub::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &
   } else {
     ObBucketHashWLockGuard guard(rw_dict_lock_, key.hash());
 
-    // try if valid with no recursive lock
-    if (OB_FAIL(get_dict_info(key, info))) {
-      if (OB_HASH_NOT_EXIST == ret) {
-        // dict not exist, make new one, by caller
-        ret = OB_ENTRY_NOT_EXIST;
+    int info_ret = get_dict_info(key, info);
+    if (OB_HASH_NOT_EXIST == info_ret) {
+      info_ret = OB_SUCCESS;
+    }
+    if (OB_SUCCESS != info_ret) {
+      ret = info_ret;
+      LOG_WARN("Failed to get dict info", K(ret), K(desc));
+    } else if (!force_refresh && info.generation_ > 0) {
+      ObFTDictDesc load_desc(desc);
+      load_desc.generation_ = info.generation_;
+      if (OB_FAIL(ObFTRangeDict::try_load_cache(
+                      load_desc, info.range_count_, container))) {
+        if (OB_ENTRY_NOT_EXIST == ret) {
+          ret = OB_SUCCESS;
+        } else {
+          LOG_WARN("Failed to load current dictionary cache", K(ret), K(load_desc));
+        }
       } else {
-        LOG_WARN("Failed to get dict info", K(ret));
-      }
-    } else if (OB_FAIL(ObFTRangeDict::try_load_cache(desc, info.range_count_, container))) {
-      if (OB_ENTRY_NOT_EXIST == ret) {
-      } else {
-        LOG_WARN("Failed to load cache", K(ret));
+        return OB_SUCCESS;
       }
     }
 
-    if (OB_FAIL(ret)) {
-      if (OB_ENTRY_NOT_EXIST == ret) {
-        if (OB_FAIL(ObFTRangeDict::build_cache_from_ik_dict(desc, container))) {
-          LOG_WARN("Failed to build cache", K(ret));
-        } else if (FALSE_IT(info.range_count_ = container.get_handles().size())) {
-        } else if (OB_FAIL(put_dict_info(key, info))) {
-          LOG_WARN("Failed to put dict info", K(ret));
+    if (OB_SUCC(ret)) {
+      ObFTDictDesc build_desc(desc);
+      build_desc.generation_ = info.generation_ + 1;
+      container.reset();
+      if (build_desc.is_builtin_) {
+        if (OB_FAIL(ObFTRangeDict::build_cache_from_ik_dict(build_desc, container))) {
+          LOG_WARN("Failed to build compiled dictionary cache", K(ret), K(build_desc));
+        }
+      } else if (OB_FAIL(ObFTRangeDict::build_cache(build_desc, container))) {
+        LOG_WARN("Failed to build custom dictionary cache", K(ret), K(build_desc));
+      }
+      if (OB_SUCC(ret)) {
+        info.generation_ = build_desc.generation_;
+        info.range_count_ = static_cast<int32_t>(container.get_handles().size());
+        if (OB_FAIL(put_dict_info(key, info))) {
+          LOG_WARN("Failed to publish dictionary cache generation", K(ret), K(build_desc));
         }
       }
     }
@@ -95,7 +125,7 @@ int ObFTDictHub::load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &c
   int ret = OB_SUCCESS;
   ObFTDictInfo info;
   container.reset();
-  ObFTDictInfoKey key(static_cast<uint64_t>(desc.type_));
+  ObFTDictInfoKey key(desc.tenant_id_, desc.table_id_);
   if (!is_inited_) {
     ret = OB_NOT_INIT;
     LOG_WARN("dict hub not init", K(ret));
@@ -112,11 +142,16 @@ int ObFTDictHub::load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &c
       }
     }
     if (OB_FAIL(ret)) {
-    } else if (OB_FAIL(ObFTRangeDict::try_load_cache(desc, info.range_count_, container))) {
+    } else {
+      ObFTDictDesc load_desc(desc);
+      load_desc.generation_ = info.generation_;
+      if (OB_FAIL(ObFTRangeDict::try_load_cache(
+                      load_desc, info.range_count_, container))) {
       if (OB_ENTRY_NOT_EXIST == ret) {
         // dict not exist, make new one, by caller
       } else {
         LOG_WARN("Failed to load cache", K(ret));
+      }
       }
     }
   }

--- a/src/storage/fts/dict/ob_ft_dict_hub.h
+++ b/src/storage/fts/dict/ob_ft_dict_hub.h
@@ -32,19 +32,12 @@ class ObFTDictInfo
 {
 public:
   ObFTDictInfo()
-      : name_(""),
-        type_(ObFTDictType::DICT_TYPE_INVALID),
-        charset_(CHARSET_INVALID),
-        version_(0),
-        range_count_(0)
+      : generation_(0), range_count_(0)
   {
   }
 
 public:
-  char name_[2048]; // for now
-  ObFTDictType type_;
-  ObCharsetType charset_;
-  int64_t version_; // in memory
+  uint64_t generation_;
   int32_t range_count_;
 };
 
@@ -52,11 +45,11 @@ struct ObFTDictInfoKey
 {
 public:
   ObFTDictInfoKey()
-      : type_(static_cast<uint64_t>(ObFTDictType::DICT_TYPE_INVALID))
+      : tenant_id_(OB_INVALID_TENANT_ID), table_id_(OB_INVALID_ID)
   {
-  } // default constructor
-  ObFTDictInfoKey(const uint64_t type)
-      : type_(type)
+  }
+  ObFTDictInfoKey(const uint64_t tenant_id, const uint64_t table_id)
+      : tenant_id_(tenant_id), table_id_(table_id)
   {
   }
   int hash(uint64_t &hash_value) const
@@ -69,27 +62,34 @@ public:
   uint64_t hash() const
   {
     uint64_t hash = 0;
-    hash = common::murmurhash(&type_, sizeof(int64_t), hash);
+    hash = common::murmurhash(&tenant_id_, sizeof(tenant_id_), hash);
+    hash = common::murmurhash(&table_id_, sizeof(table_id_), hash);
     return hash;
   }
 
   bool operator==(const ObFTDictInfoKey &other) const
   {
-    return type_ == other.type_ && true;
+    return tenant_id_ == other.tenant_id_ && table_id_ == other.table_id_;
   }
 
   int compare(const ObFTDictInfoKey &other) const
   {
     int ret = 0;
-    if (0 == ret) {
-      ret = type_ - other.type_;
+    if (tenant_id_ < other.tenant_id_) {
+      ret = -1;
+    } else if (tenant_id_ > other.tenant_id_) {
+      ret = 1;
+    } else if (table_id_ < other.table_id_) {
+      ret = -1;
+    } else if (table_id_ > other.table_id_) {
+      ret = 1;
     }
     return ret;
   }
 
 private:
-  uint64_t type_;
-  // name
+  uint64_t tenant_id_;
+  uint64_t table_id_;
 };
 
 class ObFTCacheRangeContainer;
@@ -107,7 +107,12 @@ public:
 
   int load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
 
+  int refresh(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
+
 private:
+  int build_cache_internal(const ObFTDictDesc &desc,
+                           ObFTCacheRangeContainer &container,
+                           const bool force_refresh);
   int get_dict_info(const ObFTDictInfoKey &key, ObFTDictInfo &info);
 
   int put_dict_info(const ObFTDictInfoKey &key, const ObFTDictInfo &info);

--- a/src/storage/fts/dict/ob_ft_dict_table_iter.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_table_iter.cpp
@@ -30,7 +30,7 @@ namespace oceanbase
 namespace storage
 {
 ObFTDictTableIter::ObFTDictTableIter(ObISQLClient::ReadResult &result)
-    : ObIFTDictIterator(), is_inited_(false), res_(result)
+    : ObIFTDictIterator(), is_inited_(false), iter_end_(false), res_(result)
 {
 }
 
@@ -40,6 +40,8 @@ int ObFTDictTableIter::get_key(ObString &str)
   if (!IS_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("Not inited.", K(ret));
+  } else if (iter_end_) {
+    ret = OB_ITER_END;
   } else if (OB_FAIL(res_.get_result()->get_varchar("word", str))) {
     LOG_WARN("Failed to get varchar", K(ret));
   }
@@ -58,29 +60,50 @@ int ObFTDictTableIter::next()
   if (!IS_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("Not inited.", K(ret));
+  } else if (iter_end_) {
+    ret = OB_ITER_END;
   } else if (OB_FAIL(res_.get_result()->next())) {
-    if (OB_ITER_END != ret) {
+    if (OB_ITER_END == ret) {
+      iter_end_ = true;
+    } else {
       LOG_WARN("Failed to get next row", K(ret));
     }
   }
   return ret;
 }
 
-int ObFTDictTableIter::init(const ObString &table_name)
+int ObFTDictTableIter::init(const ObFTDictDesc &desc)
 {
   int ret = OB_SUCCESS;
   common::ObMySQLProxy *sql_proxy = GCTX.sql_proxy_;
+  const char *dot = desc.table_name_.find('.');
 
   if (IS_INIT) {
     ret = OB_INIT_TWICE;
     LOG_WARN("Inited twice.", K(ret));
+  } else if (OB_ISNULL(sql_proxy) || OB_ISNULL(dot)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table descriptor", K(ret), K(desc), KP(sql_proxy));
   } else {
+    const ObString database_name(static_cast<int32_t>(dot - desc.table_name_.ptr()),
+                                 desc.table_name_.ptr());
+    const ObString table_name(static_cast<int32_t>(
+                                  desc.table_name_.length() - (dot - desc.table_name_.ptr()) - 1),
+                              dot + 1);
     SMART_VAR(ObSqlString, sql_string)
     {
-      if (OB_FAIL(sql_string.append("SELECT word FROM oceanbase."))) {
-        LOG_WARN("Failed to append sql", K(ret));
-      } else if (OB_FAIL(sql_string.append(table_name))) {
-        LOG_WARN("Failed to append sql", K(ret));
+      if (desc.need_casedown_) {
+        if (OB_FAIL(sql_string.append_fmt("SELECT DISTINCT LOWER(word) AS word FROM `%.*s`.`%.*s`",
+                                         database_name.length(), database_name.ptr(),
+                                         table_name.length(), table_name.ptr()))) {
+          LOG_WARN("Failed to append lowercase dictionary sql", K(ret));
+        }
+      } else if (OB_FAIL(sql_string.append_fmt("SELECT word FROM `%.*s`.`%.*s`",
+                                              database_name.length(), database_name.ptr(),
+                                              table_name.length(), table_name.ptr()))) {
+        LOG_WARN("Failed to append dictionary sql", K(ret));
+      }
+      if (OB_FAIL(ret)) {
       } else if (OB_FAIL(sql_string.append(" ORDER BY word"))) {
         LOG_WARN("Failed to append sql", K(ret));
       } else if (OB_FAIL(sql_proxy->read(res_, sql_string.ptr()))) {
@@ -94,10 +117,12 @@ int ObFTDictTableIter::init(const ObString &table_name)
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("Failed to get result", K(ret));
     } else if (OB_FAIL(res_.get_result()->next())) {
-      if (OB_ITER_END != ret) {
-        LOG_WARN("Failed to get next row", K(ret));
-      } else {
+      if (OB_ITER_END == ret) {
+        ret = OB_SUCCESS;
+        iter_end_ = true;
         is_inited_ = true;
+      } else {
+        LOG_WARN("Failed to get next row", K(ret));
       }
     } else {
       is_inited_ = true;
@@ -111,6 +136,7 @@ void ObFTDictTableIter::reset()
 {
   res_.close();
   is_inited_ = false;
+  iter_end_ = false;
 }
 
 } //  namespace storage

--- a/src/storage/fts/dict/ob_ft_dict_table_iter.h
+++ b/src/storage/fts/dict/ob_ft_dict_table_iter.h
@@ -19,6 +19,7 @@
 
 #include "common/mysqlclient/ob_isql_client.h"
 #include "storage/fts/dict/ob_ft_dict_iterator.h"
+#include "storage/fts/dict/ob_ft_dict_def.h"
 
 namespace oceanbase
 {
@@ -37,13 +38,14 @@ public:
   int next() override;
 
 public:
-  int init(const ObString &table_name);
+  int init(const ObFTDictDesc &desc);
 
 private:
   void reset();
 
 private:
   bool is_inited_;
+  bool iter_end_;
   ObISQLClient::ReadResult &res_;
 };
 

--- a/src/storage/fts/dict/ob_ft_range_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_range_dict.cpp
@@ -465,35 +465,19 @@ int ObFTRangeDict::build_dict_from_cache(const ObFTCacheRangeContainer &range_co
 int ObFTRangeDict::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &range_container)
 {
   int ret = OB_SUCCESS;
-
-  ObString table_name;
-  switch (desc.type_) {
-  case ObFTDictType::DICT_IK_MAIN: {
-    table_name = ObString(share::OB_FT_DICT_IK_UTF8_TNAME);
-  } break;
-  case ObFTDictType::DICT_IK_QUAN: {
-    table_name = ObString(share::OB_FT_QUANTIFIER_IK_UTF8_TNAME);
-  } break;
-  case ObFTDictType::DICT_IK_STOP: {
-    table_name = ObString(share::OB_FT_STOPWORD_IK_UTF8_TNAME);
-  } break;
-  default:
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("Not supported dict type.", K(ret));
-  }
-
-  if (OB_SUCC(ret)) {
-    SMART_VAR(ObISQLClient::ReadResult, result)
-    {
-      ObFTDictTableIter iter_table(result);
-      if (OB_FAIL(iter_table.init(table_name))) {
-        LOG_WARN("Failed to init iterator.", K(ret));
-      } else if (OB_FAIL(ObFTRangeDict::build_ranges(desc, iter_table, range_container))) {
-        LOG_WARN("Failed to build ranges.", K(ret));
-      }
+  SMART_VAR(ObISQLClient::ReadResult, result)
+  {
+    ObFTDictTableIter iter_table(result);
+    if (desc.is_builtin_) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("built-in dictionary must use compiled data", K(ret), K(desc));
+    } else if (OB_FAIL(iter_table.init(desc))) {
+      LOG_WARN("Failed to init dictionary table iterator", K(ret), K(desc));
+    } else if (OB_FAIL(ObFTRangeDict::build_ranges_concurrently_thread_pool(
+                           desc, iter_table, range_container))) {
+      LOG_WARN("Failed to build dictionary table ranges", K(ret), K(desc));
     }
   }
-
   return ret;
 }
 
@@ -502,10 +486,8 @@ int ObFTRangeDict::try_load_cache(const ObFTDictDesc &desc,
                                   ObFTCacheRangeContainer &range_container)
 {
   int ret = OB_SUCCESS;
-  uint64_t name = static_cast<uint64_t>(desc.type_);
-
   for (int64_t i = 0; OB_SUCC(ret) && i < range_count; ++i) {
-    ObDictCacheKey key(name, desc.type_, i);
+    ObDictCacheKey key(desc.tenant_id_, desc.table_id_, desc.generation_, i);
     ObFTCacheRangeHandle *info = nullptr;
     if (OB_FAIL(range_container.fetch_info_for_dict(info))) {
       LOG_WARN("Failed to fetch info for dict.", K(ret));

--- a/src/storage/fts/ob_fts_literal.h
+++ b/src/storage/fts/ob_fts_literal.h
@@ -18,6 +18,7 @@
 #define _OCEANBASE_STORAGE_FTS_OB_FTS_LITERAL_H_
 
 #include <cstdint>
+#include "share/inner_table/ob_inner_table_schema_constants.h"
 namespace oceanbase
 {
 namespace storage
@@ -36,7 +37,12 @@ public:
   static constexpr const char *CONFIG_NAME_NGRAM_TOKEN_SIZE = "ngram_token_size";
   static constexpr const char *CONFIG_NAME_STOPWORD_TABLE = "stopword_table";
   static constexpr const char *CONFIG_NAME_DICT_TABLE = "dict_table";
-  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE = "quanitfier_table";
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE = "quantifier_table";
+  // Compatibility for parser properties written before the spelling was fixed.
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE_LEGACY = "quanitfier_table";
+  static constexpr const char *CONFIG_NAME_STOPWORD_TABLE_ID = "stopword_table_id";
+  static constexpr const char *CONFIG_NAME_DICT_TABLE_ID = "dict_table_id";
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE_ID = "quantifier_table_id";
   static constexpr const char *CONFIG_NAME_IK_MODE = "ik_mode";
   static constexpr const char *CONFIG_NAME_MIN_NGRAM_SIZE = "min_ngram_size";
   static constexpr const char *CONFIG_NAME_MAX_NGRAM_SIZE = "max_ngram_size";

--- a/src/storage/fts/ob_fts_parser_property.cpp
+++ b/src/storage/fts/ob_fts_parser_property.cpp
@@ -27,6 +27,9 @@
 #include "lib/utility/ob_print_utils.h"
 #include "storage/fts/ob_fts_literal.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
+#include "share/ob_server_struct.h"
+#include "share/schema/ob_multi_version_schema_service.h"
+#include "sql/resolver/ddl/ob_fts_parser_resolver.h"
 
 #define USING_LOG_PREFIX STORAGE_FTS
 
@@ -203,6 +206,42 @@ int ObFTParserJsonProps::config_set_quantifier_table(const ObString &str)
   }
 
   return ret;
+}
+
+int ObFTParserJsonProps::config_set_table_id(const char *config_name, const uint64_t table_id)
+{
+  int ret = OB_SUCCESS;
+  ObJsonUint *table_id_node = nullptr;
+  if (!IS_INIT) {
+    ret = OB_NOT_INIT;
+  } else if (OB_ISNULL(config_name) || OB_INVALID_ID == table_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table id", K(ret), KP(config_name), K(table_id));
+  } else if (OB_ISNULL(table_id_node = OB_NEWx(ObJsonUint, &allocator_, table_id))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("fail to allocate dictionary table id node", K(ret), K(table_id));
+  } else if (OB_FAIL(root_->object_add(ObString(config_name), table_id_node))) {
+    LOG_WARN("fail to add dictionary table id", K(ret), KCSTRING(config_name), K(table_id));
+  }
+  if (OB_FAIL(ret)) {
+    OB_DELETEx(ObJsonUint, &allocator_, table_id_node);
+  }
+  return ret;
+}
+
+int ObFTParserJsonProps::config_set_stopword_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_set_dict_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_set_quantifier_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID, table_id);
 }
 
 int ObFTParserJsonProps::config_set_ik_mode(const ObString &ik_mode)
@@ -458,20 +497,67 @@ int ObFTParserJsonProps::config_get_quantifier_table(ObString &str) const
     if (OB_FAIL(
             root_->get_object_value(ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE), value))) {
       if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = root_->get_object_value(
+            ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_LEGACY), value);
+        if (OB_FAIL(ret) && OB_SEARCH_NOT_FOUND != ret) {
+          LOG_WARN("Fail to get legacy quanitfier_table", K(ret));
+        }
       } else {
         LOG_WARN("Fail to get quantifier_table", K(ret));
       }
-    } else if (OB_ISNULL(value)) {
+    }
+    if (OB_SUCC(ret) && OB_ISNULL(value)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("value is null", K(ret));
-    } else if (value->json_type() != ObJsonNodeType::J_STRING) {
+    } else if (OB_SUCC(ret) && value->json_type() != ObJsonNodeType::J_STRING) {
+      ret = OB_INVALID_ARGUMENT;
       LOG_WARN("value is not string", K(ret));
-    } else {
+    } else if (OB_SUCC(ret)) {
       ObJsonString *json_str = static_cast<ObJsonString *>(value);
       str = json_str->get_str();
     }
   }
   return ret;
+}
+
+int ObFTParserJsonProps::config_get_table_id(const char *config_name, uint64_t &table_id) const
+{
+  int ret = OB_SUCCESS;
+  ObIJsonBase *value = nullptr;
+  if (!IS_INIT) {
+    ret = OB_NOT_INIT;
+  } else if (OB_ISNULL(config_name)) {
+    ret = OB_INVALID_ARGUMENT;
+  } else if (OB_FAIL(root_->get_object_value(ObString(config_name), value))) {
+    if (OB_SEARCH_NOT_FOUND != ret) {
+      LOG_WARN("fail to get dictionary table id", K(ret), KCSTRING(config_name));
+    }
+  } else if (OB_ISNULL(value)) {
+    ret = OB_ERR_UNEXPECTED;
+  } else if (ObJsonNodeType::J_UINT == value->json_type()) {
+    table_id = value->get_uint();
+  } else if (ObJsonNodeType::J_INT == value->json_type() && value->get_int() >= 0) {
+    table_id = static_cast<uint64_t>(value->get_int());
+  } else {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("dictionary table id is not an unsigned integer", K(ret), KCSTRING(config_name));
+  }
+  return ret;
+}
+
+int ObFTParserJsonProps::config_get_stopword_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_get_dict_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_get_quantifier_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID, table_id);
 }
 
 int ObFTParserJsonProps::config_get_ik_mode(ObString &ik_mode) const
@@ -629,7 +715,11 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
   static const char *supported[] = {
       ObFTSLiteral::CONFIG_NAME_DICT_TABLE,
       ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE,
+      ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_LEGACY,
       ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE,
+      ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID,
+      ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID,
+      ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID,
       ObFTSLiteral::CONFIG_NAME_IK_MODE,
   };
 
@@ -658,6 +748,16 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
       // check dict table valid
     }
 
+    uint64_t table_id = OB_INVALID_ID;
+    if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_dict_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_dict_table_id(share::OB_FT_DICT_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default dictionary table id", K(ret));
+        }
+      }
+    }
+
     if (OB_FAIL(ret)) {
       // do nothing
     } else if (OB_FAIL(config_get_quantifier_table(table_name))) {
@@ -672,16 +772,34 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
     }
 
     if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_quantifier_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_quantifier_table_id(share::OB_FT_QUANTIFIER_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default quantifier table id", K(ret));
+        }
+      }
+    }
+
+    if (OB_FAIL(ret)) {
       // do nothing
-    } else if (OB_FAIL(config_get_quantifier_table(table_name))) {
+    } else if (OB_FAIL(config_get_stopword_table(table_name))) {
       if (OB_SEARCH_NOT_FOUND == ret) {
         if (OB_FAIL(
-                config_set_quantifier_table(ObFTSLiteral::FT_DEFAULT_IK_QUANTIFIER_UTF8_TABLE))) {
-          LOG_WARN("Failed to set default quantifier table", K(ret));
+                config_set_stopword_table(ObFTSLiteral::FT_DEFAULT_IK_STOPWORD_UTF8_TABLE))) {
+          LOG_WARN("Failed to set default stopword table", K(ret));
         }
       }
     } else {
-      // check quantifier table valid
+      // check stopword table valid
+    }
+
+    if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_stopword_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_stopword_table_id(share::OB_FT_STOPWORD_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default stopword table id", K(ret));
+        }
+      }
     }
 
     if (OB_FAIL(ret)) {
@@ -1138,6 +1256,54 @@ int ObFTParserJsonProps::show_parser_properties(const ObFTParserJsonProps &prope
       }
     }
 
+    ObString dict_table;
+    if (FAILEDx(properties.config_get_dict_table(dict_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get dict table", K(ret));
+      }
+    } else {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_DICT_TABLE,
+                                  dict_table.length(), dict_table.ptr()))) {
+        LOG_WARN("fail to print dict table", K(ret), K(dict_table));
+      }
+    }
+
+    ObString stopword_table;
+    if (OB_SUCC(ret) && FAILEDx(properties.config_get_stopword_table(stopword_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get stopword table", K(ret));
+      }
+    } else if (OB_SUCC(ret)) {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE,
+                                  stopword_table.length(), stopword_table.ptr()))) {
+        LOG_WARN("fail to print stopword table", K(ret), K(stopword_table));
+      }
+    }
+
+    ObString quantifier_table;
+    if (OB_SUCC(ret) && FAILEDx(properties.config_get_quantifier_table(quantifier_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get quantifier table", K(ret));
+      }
+    } else if (OB_SUCC(ret)) {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE,
+                                  quantifier_table.length(), quantifier_table.ptr()))) {
+        LOG_WARN("fail to print quantifier table", K(ret), K(quantifier_table));
+      }
+    }
+
     if (FAILEDx(databuff_printf(buf, buf_len, pos, ") "))) {
       LOG_WARN("fail to printf parser properties", K(ret), K(buf_len), K(pos), K(properties));
     }
@@ -1148,7 +1314,9 @@ int ObFTParserJsonProps::show_parser_properties(const ObFTParserJsonProps &prope
 
 #undef __FT_PARSER_PROPERTY_SHOW_COMMA
 
-int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser, const ObString &json_str)
+int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser,
+                                                const ObString &json_str,
+                                                ObIAllocator &allocator)
 {
   int ret = OB_SUCCESS;
   ObFTParserJsonProps props;
@@ -1158,12 +1326,55 @@ int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser, const 
     LOG_WARN("fail to parse from json str", K(ret), K(json_str));
   } else {
     if (parser.is_ik()) {
-      // set dict tables and copy dict name
-      dict_table_ = ObString(ObFTSLiteral::CONFIG_NAME_DICT_TABLE);
-      stopword_table_ = ObString(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE);
-      quantifier_table_ = ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE);
+      ObString table_name;
+      if (OB_FAIL(props.config_get_dict_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_DICT_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, dict_table_))) {
+        LOG_WARN("fail to copy dictionary table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret) && OB_FAIL(props.config_get_dict_table_id(dict_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          dict_table_id_ = share::OB_FT_DICT_IK_UTF8_TID;
+        }
+      }
+
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_stopword_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_STOPWORD_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, stopword_table_))) {
+        LOG_WARN("fail to copy stopword table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret) && OB_FAIL(props.config_get_stopword_table_id(stopword_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          stopword_table_id_ = share::OB_FT_STOPWORD_IK_UTF8_TID;
+        }
+      }
+
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_quantifier_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_QUANTIFIER_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, quantifier_table_))) {
+        LOG_WARN("fail to copy quantifier table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret)
+                 && OB_FAIL(props.config_get_quantifier_table_id(quantifier_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          quantifier_table_id_ = share::OB_FT_QUANTIFIER_IK_UTF8_TID;
+        }
+      }
+
       ObString ik_smart;
-      if (OB_FAIL(props.config_get_ik_mode(ik_smart))) {
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_ik_mode(ik_smart))) {
         if (OB_SEARCH_NOT_FOUND == ret) {
           // from old version, ik_mode is not set, so use default value
           ik_mode_smart_ = true;
@@ -1227,6 +1438,9 @@ ObFTParserProperty::ObFTParserProperty()
       stopword_table_(),
       dict_table_(),
       quantifier_table_(),
+      stopword_table_id_(share::OB_FT_STOPWORD_IK_UTF8_TID),
+      dict_table_id_(share::OB_FT_DICT_IK_UTF8_TID),
+      quantifier_table_id_(share::OB_FT_QUANTIFIER_IK_UTF8_TID),
       min_ngram_token_size_(ObFTSLiteral::FT_DEFAULT_MIN_NGRAM_SIZE),
       max_ngram_token_size_(ObFTSLiteral::FT_DEFAULT_MAX_NGRAM_SIZE)
 {
@@ -1236,10 +1450,22 @@ int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
                                                       ObIJsonBase *array,
                                                       ObString &json_str)
 {
+  return tokenize_array_to_props_json(
+      allocator, array, ObString(), OB_INVALID_TENANT_ID, json_str);
+}
+
+int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
+                                                      ObIJsonBase *array,
+                                                      const ObString &database_name,
+                                                      const uint64_t tenant_id,
+                                                      ObString &json_str)
+{
   int ret = OB_SUCCESS;
 
   ObArenaAllocator alloc;
   ObJsonObject properties_root(&alloc);
+  share::schema::ObSchemaGetterGuard schema_guard;
+  bool schema_guard_loaded = false;
 
   if (OB_ISNULL(array)) {
     ret = OB_INVALID_ARGUMENT;
@@ -1257,8 +1483,60 @@ int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
         ret = OB_INVALID_ARGUMENT;
       } else if (OB_FAIL(array_value_item->get_object_value(0, config_name, config_value))) {
         LOG_WARN("Fail to get object value", K(ret));
-      } else if (OB_FAIL(properties_root.object_add(config_name, config_value))) {
-        LOG_WARN("Fail to add object value", K(ret));
+      } else {
+        const bool is_dict_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_DICT_TABLE);
+        const bool is_stopword_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE);
+        const bool is_quantifier_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE);
+        if (!is_dict_table && !is_stopword_table && !is_quantifier_table) {
+          if (OB_FAIL(properties_root.object_add(config_name, config_value))) {
+            LOG_WARN("Fail to add object value", K(ret));
+          }
+        } else if (ObJsonNodeType::J_STRING != config_value->json_type()
+                   || OB_INVALID_TENANT_ID == tenant_id) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table config requires a valid string and tenant");
+        } else {
+          if (!schema_guard_loaded) {
+            if (OB_ISNULL(GCTX.schema_service_)) {
+              ret = OB_NOT_INIT;
+            } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+              LOG_WARN("fail to get schema guard for TOKENIZE", K(ret));
+            } else {
+              schema_guard_loaded = true;
+            }
+          }
+          uint64_t table_id = OB_INVALID_ID;
+          ObString full_table_name;
+          const ObString input_table_name(config_value->get_data_length(), config_value->get_data());
+          if (OB_FAIL(ret)) {
+          } else if (OB_FAIL(sql::ObFTParserResolverHelper::resolve_dict_table_name_and_id(
+                                 database_name,
+                                 input_table_name,
+                                 tenant_id,
+                                 schema_guard,
+                                 alloc,
+                                 table_id,
+                                 full_table_name))) {
+            LOG_WARN("fail to resolve TOKENIZE dictionary table", K(ret), K(input_table_name));
+          } else {
+            ObJsonString *table_name_node = OB_NEWx(ObJsonString, &alloc, full_table_name);
+            ObJsonUint *table_id_node = OB_NEWx(ObJsonUint, &alloc, table_id);
+            const char *id_config_name = is_dict_table
+                ? ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID
+                : (is_stopword_table ? ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID
+                                     : ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID);
+            if (OB_ISNULL(table_name_node) || OB_ISNULL(table_id_node)) {
+              ret = OB_ALLOCATE_MEMORY_FAILED;
+            } else if (OB_FAIL(properties_root.object_add(config_name, table_name_node))) {
+              LOG_WARN("fail to add TOKENIZE dictionary table name", K(ret));
+            } else if (OB_FAIL(properties_root.object_add(ObString(id_config_name), table_id_node))) {
+              LOG_WARN("fail to add TOKENIZE dictionary table id", K(ret));
+            }
+          }
+        }
       }
     }
     ObJsonBuffer j_buf(&allocator);

--- a/src/storage/fts/ob_fts_parser_property.h
+++ b/src/storage/fts/ob_fts_parser_property.h
@@ -51,6 +51,9 @@ public:
   int config_set_stopword_table(const ObString &str);
   int config_set_dict_table(const ObString &str);
   int config_set_quantifier_table(const ObString &str);
+  int config_set_stopword_table_id(const uint64_t table_id);
+  int config_set_dict_table_id(const uint64_t table_id);
+  int config_set_quantifier_table_id(const uint64_t table_id);
   int config_set_ik_mode(const ObString &ik_mode);
   int config_set_min_ngram_token_size(const int64_t size);
   int config_set_max_ngram_token_size(const int64_t size);
@@ -61,6 +64,9 @@ public:
   int config_get_stopword_table(ObString &str) const;
   int config_get_dict_table(ObString &str) const;
   int config_get_quantifier_table(ObString &str) const;
+  int config_get_stopword_table_id(uint64_t &table_id) const;
+  int config_get_dict_table_id(uint64_t &table_id) const;
+  int config_get_quantifier_table_id(uint64_t &table_id) const;
   int config_get_ik_mode(ObString &ik_mode) const;
   int config_get_min_ngram_token_size(int64_t &size) const;
   int config_get_max_ngram_token_size(int64_t &size) const;
@@ -108,6 +114,11 @@ public:
   static int tokenize_array_to_props_json(ObIAllocator &allocator,
                                           ObIJsonBase *array,
                                           ObString &json_str);
+  static int tokenize_array_to_props_json(ObIAllocator &allocator,
+                                          ObIJsonBase *array,
+                                          const ObString &database_name,
+                                          const uint64_t tenant_id,
+                                          ObString &json_str);
 
   static int show_parser_properties(const ObFTParserJsonProps &properties,
                                     char *buf,
@@ -117,6 +128,8 @@ public:
   TO_STRING_KV(K_(is_inited));
 
 private:
+  int config_set_table_id(const char *config_name, const uint64_t table_id);
+  int config_get_table_id(const char *config_name, uint64_t &table_id) const;
   int ik_rebuild_props_for_ddl(bool log_to_user);
   int ngram_rebuild_props_for_ddl(bool log_to_user);
   int space_rebuild_props_for_ddl(bool log_to_user);
@@ -137,7 +150,9 @@ struct ObFTParserProperty final
 public:
   ObFTParserProperty();
   ~ObFTParserProperty() = default;
-  int parse_for_parser_helper(const ObFTParser &parser, const ObString &json_str);
+  int parse_for_parser_helper(const ObFTParser &parser,
+                              const ObString &json_str,
+                              common::ObIAllocator &allocator);
 
   bool is_equal(const ObFTParserProperty &other) const
   {
@@ -145,6 +160,9 @@ public:
            && ngram_token_size_ == other.ngram_token_size_ && ik_mode_smart_ == other.ik_mode_smart_
            && stopword_table_ == other.stopword_table_ && dict_table_ == other.dict_table_
            && quantifier_table_ == other.quantifier_table_
+           && stopword_table_id_ == other.stopword_table_id_
+           && dict_table_id_ == other.dict_table_id_
+           && quantifier_table_id_ == other.quantifier_table_id_
            && min_ngram_token_size_ == other.min_ngram_token_size_
            && max_ngram_token_size_ == other.max_ngram_token_size_;
   }
@@ -155,6 +173,9 @@ public:
                K_(stopword_table),
                K_(dict_table),
                K_(quantifier_table),
+               K_(stopword_table_id),
+               K_(dict_table_id),
+               K_(quantifier_table_id),
                K_(min_ngram_token_size),
                K_(max_ngram_token_size),
                K_(ik_mode_smart));
@@ -167,6 +188,9 @@ public:
   common::ObString stopword_table_;
   common::ObString dict_table_;
   common::ObString quantifier_table_;
+  uint64_t stopword_table_id_;
+  uint64_t dict_table_id_;
+  uint64_t quantifier_table_id_;
   int64_t min_ngram_token_size_;
   int64_t max_ngram_token_size_;
 };

--- a/src/storage/fts/ob_fts_plugin_helper.cpp
+++ b/src/storage/fts/ob_fts_plugin_helper.cpp
@@ -24,6 +24,7 @@
 #include "plugin/interface/ob_plugin_ftparser_intf.h"
 #include "plugin/sys/ob_plugin_helper.h"
 #include "share/ob_force_print_log.h"
+#include "share/rc/ob_tenant_base.h"
 #include "storage/fts/dict/ob_ft_dict_hub.h"
 #include "storage/fts/ob_fts_parser_property.h"
 #include "storage/fts/ob_fts_stop_word.h"
@@ -255,8 +256,15 @@ int ObFTParseHelper::segment(
     param.ngram_token_size_ = property.ngram_token_size_;
     param.ik_param_.mode_
         = (property.ik_mode_smart_ ? ObFTIKParam::Mode::SMART : ObFTIKParam::Mode::MAX_WORD);
+    param.ik_param_.main_dict_ = property.dict_table_;
+    param.ik_param_.quan_dict_ = property.quantifier_table_;
+    param.ik_param_.stopword_dict_ = property.stopword_table_;
+    param.ik_param_.main_dict_id_ = property.dict_table_id_;
+    param.ik_param_.quan_dict_id_ = property.quantifier_table_id_;
+    param.ik_param_.stopword_dict_id_ = property.stopword_table_id_;
     param.min_ngram_size_ = property.min_ngram_token_size_;
     param.max_ngram_size_ = property.max_ngram_token_size_;
+    param.tenant_id_ = common::OB_SERVER_TENANT_ID;
 
     if (OB_FAIL(parser_desc->segment(&param, iter))) {
       LOG_WARN("fail to segment", K(ret), K(param));
@@ -319,7 +327,8 @@ int ObFTParseHelper::init(
     LOG_WARN("invalid argument", K(ret), KP(allocator), K(plugin_name));
   } else if (OB_FAIL(parser_name_.parse_from_str(plugin_name.ptr(), plugin_name.length()))) {
     LOG_WARN("fail to parse name from cstring", K(ret), K(plugin_name));
-  } else if (OB_FAIL(parser_property_.parse_for_parser_helper(parser_name_, plugin_properties))) {
+  } else if (OB_FAIL(parser_property_.parse_for_parser_helper(
+                         parser_name_, plugin_properties, *allocator))) {
     LOG_WARN("fail to parse parser property from cstring", K(ret), K(plugin_properties), K(parser_name_));
   } else if (OB_FAIL(ObPluginHelper::find_ftparser(parser_name_.get_parser_name().str(),
                                                    parser_desc_, plugin_param_))) {
@@ -409,12 +418,14 @@ int ObFTParseHelper::check_is_the_same(
   if (is_inited_) {
     storage::ObFTParser parser_name;
     ObFTParserProperty parser_property;
+    ObArenaAllocator property_allocator("FTPropCmp");
     if (OB_UNLIKELY(plugin_name.empty())) {
       ret = OB_INVALID_ARGUMENT;
       LOG_WARN("invalid argument", K(ret), K(plugin_name));
     } else if (OB_FAIL(parser_name.parse_from_str(plugin_name.ptr(), plugin_name.length()))) {
       LOG_WARN("fail to parse name from cstring", K(ret), K(plugin_name));
-    } else if (OB_FAIL(parser_property.parse_for_parser_helper(parser_name, plugin_properties))) {
+    } else if (OB_FAIL(parser_property.parse_for_parser_helper(
+                           parser_name, plugin_properties, property_allocator))) {
       LOG_WARN("fail to parse parser property from cstring", K(ret), K(plugin_properties), K(parser_name_));
     } else if (parser_name == parser_name_ && parser_property.is_equal(parser_property_)) {
       is_same = true;

--- a/src/storage/fts/ob_ik_ft_parser.cpp
+++ b/src/storage/fts/ob_ik_ft_parser.cpp
@@ -29,6 +29,7 @@
 #include "storage/fts/dict/ob_ft_dict_def.h"
 #include "storage/fts/dict/ob_ft_dict_hub.h"
 #include "storage/fts/dict/ob_ft_range_dict.h"
+#include "share/inner_table/ob_inner_table_schema_constants.h"
 #include "storage/fts/ik/ob_ik_arbitrator.h"
 #include "storage/fts/ik/ob_ik_cjk_processor.h"
 #include "storage/fts/ik/ob_ik_letter_processor.h"
@@ -103,11 +104,10 @@ int ObIKFTParser::get_next_token(const char *&word,
         }
       } else {
         bool is_stop = false;
-        // if (!OB_ISNULL(dict_stop_)
-        //     && OB_FAIL(dict_stop_->match(ObString(len, output_word + offset), is_stop))) {
-        //   LOG_WARN("Failed to match stopwords", K(ret));
-        // } else
-        if (!is_stop) {
+        if (!OB_ISNULL(dict_stop_)
+            && OB_FAIL(dict_stop_->match(ObString(len, output_word + offset), is_stop))) {
+          LOG_WARN("Failed to match stopwords", K(ret));
+        } else if (!is_stop) {
           word = output_word + offset;
           word_len = len;
           char_cnt = cnt;
@@ -277,21 +277,56 @@ int ObIKFTParser::init_dict(const plugin::ObFTParserParam &param)
     LOG_WARN("Dict hub is not inited", K(ret));
   }
 
-  ObFTRangeDict *dict = nullptr;
-  ObFTDictDesc main_dict_desc("main_dict",
+  const ObCharsetType charset = ObCharsetType::CHARSET_UTF8MB4;
+  const ObCollationType collation = ObCollationType::CS_TYPE_UTF8MB4_BIN;
+  const bool need_casedown = true;
+  const uint64_t tenant_id = OB_INVALID_TENANT_ID == param.tenant_id_
+                                 ? common::OB_SERVER_TENANT_ID
+                                 : param.tenant_id_;
+  const uint64_t main_dict_id = OB_INVALID_ID == param.ik_param_.main_dict_id_
+                                    ? share::OB_FT_DICT_IK_UTF8_TID
+                                    : param.ik_param_.main_dict_id_;
+  const uint64_t quan_dict_id = OB_INVALID_ID == param.ik_param_.quan_dict_id_
+                                    ? share::OB_FT_QUANTIFIER_IK_UTF8_TID
+                                    : param.ik_param_.quan_dict_id_;
+  const uint64_t stopword_dict_id = OB_INVALID_ID == param.ik_param_.stopword_dict_id_
+                                        ? share::OB_FT_STOPWORD_IK_UTF8_TID
+                                        : param.ik_param_.stopword_dict_id_;
+  const ObString main_dict_name = param.ik_param_.main_dict_.empty()
+                                      ? ObString(share::OB_FT_DICT_IK_UTF8_TNAME)
+                                      : param.ik_param_.main_dict_;
+  const ObString quan_dict_name = param.ik_param_.quan_dict_.empty()
+                                      ? ObString(share::OB_FT_QUANTIFIER_IK_UTF8_TNAME)
+                                      : param.ik_param_.quan_dict_;
+  const ObString stopword_dict_name = param.ik_param_.stopword_dict_.empty()
+                                          ? ObString(share::OB_FT_STOPWORD_IK_UTF8_TNAME)
+                                          : param.ik_param_.stopword_dict_;
+  ObFTDictDesc main_dict_desc(tenant_id,
+                              main_dict_id,
+                              main_dict_name,
                               ObFTDictType::DICT_IK_MAIN,
-                              ObCharsetType::CHARSET_UTF8MB4,
-                              ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                              charset,
+                              collation,
+                              main_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                              need_casedown);
 
-  ObFTDictDesc quan_dict_desc("quan_dict",
+  ObFTDictDesc quan_dict_desc(tenant_id,
+                              quan_dict_id,
+                              quan_dict_name,
                               ObFTDictType::DICT_IK_QUAN,
-                              ObCharsetType::CHARSET_UTF8MB4,
-                              ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                              charset,
+                              collation,
+                              quan_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                              need_casedown);
 
-  ObFTDictDesc stopword_dict_desc("stopword",
+  ObFTDictDesc stopword_dict_desc(tenant_id,
+                                  stopword_dict_id,
+                                  stopword_dict_name,
                                   ObFTDictType::DICT_IK_STOP,
-                                  ObCharsetType::CHARSET_UTF8MB4,
-                                  ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                                  charset,
+                                  collation,
+                                  stopword_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                                  need_casedown);
 
   if (should_read_newest_table()) {
     // clear dict cache, always false now

--- a/unittest/storage/fts/test_ft_parser.cpp
+++ b/unittest/storage/fts/test_ft_parser.cpp
@@ -194,7 +194,7 @@ TEST_F(FTParserTest, test_cache)
   dat.mem_block_size_ = sizeof(ObFTDAT);
   ObFTDAT *ptr = &dat;
 
-  ObDictCacheKey key(1, ObFTDictType::DICT_IK_MAIN, 0);
+  ObDictCacheKey key(1, 500001, 1, 0);
   ObDictCacheValue value(ptr);
   ret = cache.put(key, value);
   ASSERT_EQ(OB_SUCCESS, ret);
@@ -205,6 +205,23 @@ TEST_F(FTParserTest, test_cache)
 
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(new_value->dat_block_->mem_block_size_, dat.mem_block_size_);
+}
+
+TEST(FTDictCacheKeyTest, distinguishes_table_generation_and_range)
+{
+  ObDictCacheKey base(1, 500001, 1, 0);
+  ObDictCacheKey same(1, 500001, 1, 0);
+  ObDictCacheKey another_tenant(2, 500001, 1, 0);
+  ObDictCacheKey another_table(1, 500002, 1, 0);
+  ObDictCacheKey another_generation(1, 500001, 2, 0);
+  ObDictCacheKey another_range(1, 500001, 1, 1);
+
+  ASSERT_TRUE(base == same);
+  ASSERT_FALSE(base == another_tenant);
+  ASSERT_FALSE(base == another_table);
+  ASSERT_FALSE(base == another_generation);
+  ASSERT_FALSE(base == another_range);
+  ASSERT_EQ(base.hash(), same.hash());
 }
 
 TEST_F(FTParserTest, test_trie)
@@ -328,8 +345,8 @@ TEST_F(FTParserTest, test_trie)
     }
 
     ObArenaAllocator allocator(ObModIds::TEST);
-    size_t size = ObArrayHashMap::estimate_size(words.size());
-    ObArrayHashMap *map = static_cast<ObArrayHashMap *>(allocator.alloc(size));
+    size_t size = ObFTArrayHashMap::estimate_size(words.size());
+    ObFTArrayHashMap *map = static_cast<ObFTArrayHashMap *>(allocator.alloc(size));
     map->init(words.size());
     for (int i = 0; i < words.size(); i++) {
       ObString str(words[i].size(), words[i].data());

--- a/unittest/storage/test_fts_property.cpp
+++ b/unittest/storage/test_fts_property.cpp
@@ -23,6 +23,7 @@
 #include "storage/fts/ob_fts_plugin_helper.h"
 
 #include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
 
 #define USING_LOG_PREFIX STORAGE_FTS
@@ -122,6 +123,9 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   static const ObString K_TEST_DICT_TABLE = "a_dict_table_name";
   static const ObString K_TEST_STOPWORD_TABLE = "a_stopword_table_name";
   static const ObString K_TEST_QUANTIFIER_TABLE = "a_quantifier_table_name";
+  static const uint64_t K_TEST_DICT_TABLE_ID = 500001;
+  static const uint64_t K_TEST_STOPWORD_TABLE_ID = 500002;
+  static const uint64_t K_TEST_QUANTIFIER_TABLE_ID = 500003;
 
   ret = json_props.init();
   ASSERT_EQ(OB_SUCCESS, ret);
@@ -142,6 +146,15 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   ASSERT_EQ(OB_SUCCESS, ret);
 
   ret = json_props.config_set_quantifier_table(K_TEST_QUANTIFIER_TABLE);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_dict_table_id(K_TEST_DICT_TABLE_ID);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_stopword_table_id(K_TEST_STOPWORD_TABLE_ID);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_quantifier_table_id(K_TEST_QUANTIFIER_TABLE_ID);
   ASSERT_EQ(OB_SUCCESS, ret);
 
   ObArenaAllocator allocator;
@@ -190,6 +203,21 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   ret = json_props.config_get_quantifier_table(quantifier_table);
   ASSERT_EQ(ret, OB_SUCCESS);
   ASSERT_EQ(quantifier_table, K_TEST_QUANTIFIER_TABLE);
+
+  uint64_t dict_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_dict_table_id(dict_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_DICT_TABLE_ID, dict_table_id);
+
+  uint64_t stopword_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_stopword_table_id(stopword_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_STOPWORD_TABLE_ID, stopword_table_id);
+
+  uint64_t quantifier_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_quantifier_table_id(quantifier_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_QUANTIFIER_TABLE_ID, quantifier_table_id);
 }
 
 TEST_F(TestFTParserJsonProperty, test_parse_from_string)
@@ -564,12 +592,14 @@ TEST_F(TestFTParserProperty, test_parse_for_ddl)
     ObString new_json;
     ret = json_props.to_format_json(tmp_alloc, new_json);
 
-    char output[] = R"(PARSER_PROPERTIES=(ik_mode="smart") )";
-    char output_buf[128];
+    char output_buf[512];
     int64_t pos = 0;
-    ret = json_props.show_parser_properties(json_props, output_buf, 128, pos);
+    ret = json_props.show_parser_properties(json_props, output_buf, sizeof(output_buf), pos);
     ASSERT_EQ(OB_SUCCESS, ret);
-    ASSERT_EQ(ObString(output), ObString(output_buf));
+    ASSERT_NE(nullptr, strstr(output_buf, "ik_mode=\"smart\""));
+    ASSERT_NE(nullptr, strstr(output_buf, "dict_table="));
+    ASSERT_NE(nullptr, strstr(output_buf, "stopword_table="));
+    ASSERT_NE(nullptr, strstr(output_buf, "quantifier_table="));
   }
   {
     int ret = OB_SUCCESS;


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

The IK parser only supports built-in dictionaries and cannot load or dynamically refresh user-defined dictionary tables.

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

- Add the `FULLTEXT_DICT` table option and dictionary schema validation.
- Add `ALTER SYSTEM REFRESH FULLTEXT DICT`.
- Persist dictionary table names and IDs in parser properties.
- Load custom main, quantifier, and stopword dictionaries.
- Isolate dictionary caches by context, table, generation, and range.
- Add dictionary dependency and drop protection.
- Support custom dictionaries in `TOKENIZE()`.
- Preserve compatibility with existing IK parser properties and callers.

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

- Debug observer build passed.
- `test_fts_property`: 4/4 passed.
- `test_ft_parser`: 8/8 passed.
- Official `ai_funcs/ik_custom_dict.test`: passed with output `ok`.
- `git diff --check`: passed.

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

Existing IK parser configurations continue to use the built-in dictionaries. The historical `quanitfier_table` property spelling remains read-compatible.

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
