### PR TITLE
feat: implement document ai functions

### DIFF
--- a/deps/oblib/src/lib/ob_name_def.h
+++ b/deps/oblib/src/lib/ob_name_def.h
@@ -1259,4 +1259,6 @@
 #define N_AI_RERANK                         "ai_rerank"
 #define N_AI_PROMPT                         "ai_prompt"
 #define N_CHECK_LOCATION_ACCESS "check_location_access"
+#define N_LOAD_FILE                         "load_file"
+#define N_AI_SPLIT_DOCUMENT                 "ai_split_document"
 #endif //OCEANBASE_LIB_OB_NAME_DEF_H_

--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -1057,6 +1057,8 @@ typedef enum ObItemType
   T_FUN_SYS_AI_RERANK = 2084,
   T_FUN_MD5_CNN_WS = 2085,
   T_FUN_SYS_BUCKET = 2086,
+  T_FUN_SYS_LOAD_FILE = 2087,
+  T_FUN_SYS_AI_SPLIT_DOCUMENT = 2088,
   T_MAX_OP = 3000,
 
   //pseudo column, to mark the group iterator id

--- a/src/sql/CMakeLists.txt
+++ b/src/sql/CMakeLists.txt
@@ -518,6 +518,7 @@ ob_set_subtarget(ob_sql engine_expr
   engine/expr/ob_expr_char_length.cpp
   engine/expr/ob_expr_check_catalog_access.cpp
   engine/expr/ob_expr_check_location_access.cpp
+  engine/expr/ob_expr_load_file.cpp
   engine/expr/ob_expr_cast.cpp
   engine/expr/ob_expr_coalesce.cpp
   engine/expr/ob_expr_coll_pred.cpp
@@ -660,6 +661,7 @@ ob_set_subtarget(ob_sql engine_expr
   engine/expr/ob_expr_mod.cpp
   engine/expr/ob_expr_multiset.cpp
   engine/expr/ob_expr_tokenize.cpp
+  engine/expr/ob_expr_ai_split_document.cpp
   engine/expr/ob_expr_gtid.cpp
   engine/expr/ob_expr_inner_table_option_printer.cpp
   engine/expr/ob_expr_rb_build_empty.cpp

--- a/src/sql/engine/basic/ob_function_table_op.cpp
+++ b/src/sql/engine/basic/ob_function_table_op.cpp
@@ -37,6 +37,11 @@ int ObFunctionTableOp::inner_open()
   if (OB_ISNULL(MY_SPEC.value_expr_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("value expr is not init", K(ret));
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == MY_SPEC.value_expr_->type_) {
+    split_chunks_.reset();
+    split_idx_ = 0;
+    split_ready_ = false;
+    next_row_func_ = &ObFunctionTableOp::inner_get_next_row_ai_split_document;
   } else if (ObExtendType == MY_SPEC.value_expr_->datum_meta_.type_) {
     next_row_func_ = &ObFunctionTableOp::inner_get_next_row_udf;
   } else {
@@ -58,6 +63,9 @@ int ObFunctionTableOp::inner_rescan()
       value_table_ = NULL;
       already_calc_ = false;
     }
+    split_chunks_.reset();
+    split_idx_ = 0;
+    split_ready_ = false;
   }
   return ret;
 }
@@ -69,6 +77,9 @@ int ObFunctionTableOp::inner_close()
   row_count_ = 0;
   col_count_ = 0;
   value_table_ = NULL;
+  split_chunks_.reset();
+  split_idx_ = 0;
+  split_ready_ = false;
   return ret;
 }
 
@@ -244,6 +255,62 @@ int ObFunctionTableOp::inner_get_next_row_sys_func()
   } else {
     MY_SPEC.column_exprs_.at(0)->locate_datum_for_write(eval_ctx_).set_datum(*value);
     MY_SPEC.column_exprs_.at(0)->set_evaluated_projected(eval_ctx_);
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::inner_get_next_row_ai_split_document()
+{
+  int ret = OB_SUCCESS;
+  ObDatum *content = NULL;
+  ObDatum *params = NULL;
+  clear_evaluated_flag();
+  if (OB_ISNULL(MY_SPEC.value_expr_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("value expr is not init", K(ret));
+  } else if (OB_FAIL(ctx_.check_status())) {
+    LOG_WARN("failed to check status", K(ret));
+  } else if (!split_ready_) {
+    if (OB_UNLIKELY(MY_SPEC.value_expr_->arg_cnt_ < 1 || MY_SPEC.value_expr_->arg_cnt_ > 2)) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("invalid ai_split_document arg count", K(ret), K(MY_SPEC.value_expr_->arg_cnt_));
+    } else if (OB_FAIL(MY_SPEC.value_expr_->args_[0]->eval(eval_ctx_, content))) {
+      LOG_WARN("failed to eval ai_split_document content", K(ret));
+    } else if (MY_SPEC.value_expr_->arg_cnt_ > 1
+               && OB_FAIL(MY_SPEC.value_expr_->args_[1]->eval(eval_ctx_, params))) {
+      LOG_WARN("failed to eval ai_split_document params", K(ret));
+    } else if (!content->is_null()) {
+      const ObString params_str = (NULL == params || params->is_null())
+                                  ? ObString::make_empty_string()
+                                  : params->get_string();
+      if (OB_FAIL(ObExprAISplitDocument::build_chunks(ctx_.get_allocator(),
+                                                       content->get_string(),
+                                                       params_str,
+                                                       split_chunks_))) {
+        LOG_WARN("failed to build ai_split_document chunks", K(ret));
+      }
+    }
+    if (OB_SUCC(ret)) {
+      split_ready_ = true;
+      split_idx_ = 0;
+    }
+  }
+
+  if (OB_SUCC(ret) && split_idx_ >= split_chunks_.count()) {
+    ret = OB_ITER_END;
+  } else if (OB_SUCC(ret)) {
+    CK (MY_SPEC.column_exprs_.count() >= 4);
+    if (OB_SUCC(ret)) {
+      const ObAISplitDocumentChunk &chunk = split_chunks_.at(split_idx_);
+      MY_SPEC.column_exprs_.at(0)->locate_datum_for_write(eval_ctx_).set_int(split_idx_);
+      MY_SPEC.column_exprs_.at(1)->locate_datum_for_write(eval_ctx_).set_int(chunk.offset_);
+      MY_SPEC.column_exprs_.at(2)->locate_datum_for_write(eval_ctx_).set_int(chunk.length_);
+      MY_SPEC.column_exprs_.at(3)->locate_datum_for_write(eval_ctx_).set_string(chunk.text_);
+      for (int64_t i = 0; i < 4; ++i) {
+        MY_SPEC.column_exprs_.at(i)->set_evaluated_projected(eval_ctx_);
+      }
+      ++split_idx_;
+    }
   }
   return ret;
 }

--- a/src/sql/engine/basic/ob_function_table_op.h
+++ b/src/sql/engine/basic/ob_function_table_op.h
@@ -19,6 +19,7 @@
 
 #include "sql/engine/ob_operator.h"
 #include "sql/engine/basic/ob_chunk_datum_store.h"
+#include "sql/engine/expr/ob_expr_ai_split_document.h"
 #include "lib/charset/ob_charset.h"
 
 namespace oceanbase
@@ -48,7 +49,11 @@ public:
     already_calc_(false),
     row_count_(0),
     col_count_(0),
-    value_table_(NULL) 
+    value_table_(NULL),
+    split_chunks_(),
+    split_idx_(0),
+    split_ready_(false),
+    next_row_func_(NULL)
   {}
 
   virtual int inner_open() override;
@@ -61,6 +66,7 @@ public:
 private:
   int inner_get_next_row_udf();
   int inner_get_next_row_sys_func();
+  int inner_get_next_row_ai_split_document();
   int get_current_result(common::ObObj &result);
   int64_t node_idx_;
   bool already_calc_;
@@ -68,6 +74,9 @@ private:
   int64_t col_count_;
   common::ObObj value_;
   pl::ObPLCollection *value_table_;
+  common::ObSEArray<ObAISplitDocumentChunk, 16> split_chunks_;
+  int64_t split_idx_;
+  bool split_ready_;
   int (ObFunctionTableOp::*next_row_func_)();
 };
 

--- a/src/sql/engine/expr/ob_expr_ai_split_document.cpp
+++ b/src/sql/engine/expr/ob_expr_ai_split_document.cpp
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+
+#include "sql/engine/expr/ob_expr_ai_split_document.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+#include "lib/ob_errno.h"
+#include "lib/oblog/ob_log_module.h"
+
+namespace oceanbase
+{
+using namespace common;
+namespace sql
+{
+namespace
+{
+
+struct TextSpan
+{
+  int64_t offset_;
+  int64_t length_;
+  std::string text_;
+};
+
+static std::string to_std_string(const ObString &str)
+{
+  return std::string(str.ptr(), str.length());
+}
+
+static std::string lower_copy(std::string value)
+{
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+static bool json_contains_string(const std::string &json,
+                                 const char *key,
+                                 const char *value)
+{
+  const std::string lower = lower_copy(json);
+  const std::string needle1 = std::string("\"") + key + "\":\"" + value + "\"";
+  const std::string needle2 = std::string("\"") + key + "\" : \"" + value + "\"";
+  return lower.find(needle1) != std::string::npos || lower.find(needle2) != std::string::npos;
+}
+
+static int64_t json_int_value(const std::string &json, const char *key, int64_t default_value)
+{
+  const std::string lower = lower_copy(json);
+  const std::string quoted_key = std::string("\"") + key + "\"";
+  size_t pos = lower.find(quoted_key);
+  if (pos == std::string::npos) {
+    return default_value;
+  }
+  pos = lower.find(':', pos + quoted_key.length());
+  if (pos == std::string::npos) {
+    return default_value;
+  }
+  ++pos;
+  while (pos < lower.length() && std::isspace(static_cast<unsigned char>(lower[pos]))) {
+    ++pos;
+  }
+  int64_t value = 0;
+  bool has_digit = false;
+  while (pos < lower.length() && std::isdigit(static_cast<unsigned char>(lower[pos]))) {
+    has_digit = true;
+    value = value * 10 + lower[pos] - '0';
+    ++pos;
+  }
+  return has_digit ? value : default_value;
+}
+
+static int copy_chunk_text(ObIAllocator &allocator,
+                           const std::string &text,
+                           const int64_t offset,
+                           ObIArray<ObAISplitDocumentChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+  char *buf = NULL;
+  if (text.empty()) {
+    if (OB_FAIL(chunks.push_back(ObAISplitDocumentChunk(offset, 0, ObString::make_empty_string())))) {
+      LOG_WARN("failed to push empty chunk", K(ret));
+    }
+  } else if (OB_ISNULL(buf = static_cast<char *>(allocator.alloc(text.length())))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate chunk text", K(ret), K(text.length()));
+  } else {
+    MEMCPY(buf, text.data(), text.length());
+    if (OB_FAIL(chunks.push_back(ObAISplitDocumentChunk(
+            offset,
+            text.length(),
+            ObString(static_cast<ObString::obstr_size_t>(text.length()), buf))))) {
+      LOG_WARN("failed to push chunk", K(ret));
+    }
+  }
+  return ret;
+}
+
+static std::vector<TextSpan> split_sentences(const std::string &content)
+{
+  std::vector<TextSpan> spans;
+  size_t pos = 0;
+  while (pos < content.length()) {
+    while (pos < content.length() && std::isspace(static_cast<unsigned char>(content[pos]))) {
+      ++pos;
+    }
+    if (pos >= content.length()) {
+      break;
+    }
+    const size_t start = pos;
+    while (pos < content.length()
+           && content[pos] != '.'
+           && content[pos] != '!'
+           && content[pos] != '?') {
+      ++pos;
+    }
+    if (pos < content.length()) {
+      ++pos;
+    }
+    const size_t end = pos;
+    if (end > start) {
+      spans.push_back(TextSpan{static_cast<int64_t>(start),
+                               static_cast<int64_t>(end - start),
+                               content.substr(start, end - start)});
+    }
+  }
+  return spans;
+}
+
+static std::vector<TextSpan> split_words(const std::string &content)
+{
+  std::vector<TextSpan> spans;
+  size_t pos = 0;
+  while (pos < content.length()) {
+    while (pos < content.length() && std::isspace(static_cast<unsigned char>(content[pos]))) {
+      ++pos;
+    }
+    if (pos >= content.length()) {
+      break;
+    }
+    const size_t start = pos;
+    while (pos < content.length() && !std::isspace(static_cast<unsigned char>(content[pos]))) {
+      ++pos;
+    }
+    spans.push_back(TextSpan{static_cast<int64_t>(start),
+                             static_cast<int64_t>(pos - start),
+                             content.substr(start, pos - start)});
+  }
+  return spans;
+}
+
+static int build_window_chunks(ObIAllocator &allocator,
+                               const std::vector<TextSpan> &units,
+                               const int64_t max_units,
+                               const int64_t overlap,
+                               const bool by_word,
+                               const std::string &prefix,
+                               ObIArray<ObAISplitDocumentChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+  const int64_t safe_max = std::max<int64_t>(1, max_units);
+  const int64_t safe_overlap = std::max<int64_t>(0, std::min<int64_t>(overlap, safe_max - 1));
+  const int64_t step = std::max<int64_t>(1, safe_max - safe_overlap);
+  for (int64_t start = 0; OB_SUCC(ret) && start < static_cast<int64_t>(units.size()); start += step) {
+    const int64_t end = std::min<int64_t>(start + safe_max, units.size());
+    std::string text = prefix;
+    for (int64_t i = start; i < end; ++i) {
+      if (i > start) {
+        text.append(by_word ? " " : " ");
+      }
+      text.append(units[i].text_);
+    }
+    const int64_t offset = units[start].offset_;
+    if (OB_FAIL(copy_chunk_text(allocator, text, offset, chunks))) {
+      LOG_WARN("failed to copy chunk text", K(ret));
+    }
+    if (end >= static_cast<int64_t>(units.size())) {
+      break;
+    }
+  }
+  return ret;
+}
+
+static int build_markdown_sentence_chunks(ObIAllocator &allocator,
+                                          const std::string &content,
+                                          const int64_t max_units,
+                                          const int64_t overlap,
+                                          ObIArray<ObAISplitDocumentChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+  size_t line_start = 0;
+  std::string heading;
+  std::string section_text;
+  int64_t section_offset = 0;
+  auto flush_section = [&]() -> int {
+    int tmp_ret = OB_SUCCESS;
+    if (!section_text.empty()) {
+      std::vector<TextSpan> sentences = split_sentences(section_text);
+      for (size_t i = 0; i < sentences.size(); ++i) {
+        sentences[i].offset_ += section_offset;
+      }
+      const std::string prefix = heading.empty() ? std::string() : heading + "\n";
+      tmp_ret = build_window_chunks(allocator, sentences, max_units, overlap, false, prefix, chunks);
+    }
+    section_text.clear();
+    return tmp_ret;
+  };
+
+  while (OB_SUCC(ret) && line_start <= content.length()) {
+    size_t line_end = content.find('\n', line_start);
+    if (line_end == std::string::npos) {
+      line_end = content.length();
+    }
+    const std::string line = content.substr(line_start, line_end - line_start);
+    if (!line.empty() && line[0] == '#') {
+      if (OB_FAIL(flush_section())) {
+        LOG_WARN("failed to flush markdown section", K(ret));
+      } else {
+        heading = line;
+        section_offset = static_cast<int64_t>(line_end < content.length() ? line_end + 1 : line_end);
+      }
+    } else {
+      if (section_text.empty()) {
+        section_offset = static_cast<int64_t>(line_start);
+      } else {
+        section_text.append("\n");
+      }
+      section_text.append(line);
+    }
+    if (line_end >= content.length()) {
+      break;
+    }
+    line_start = line_end + 1;
+  }
+  if (OB_SUCC(ret) && OB_FAIL(flush_section())) {
+    LOG_WARN("failed to flush last markdown section", K(ret));
+  }
+  return ret;
+}
+
+} // namespace
+
+ObExprAISplitDocument::ObExprAISplitDocument(ObIAllocator &alloc)
+  : ObStringExprOperator(alloc, T_FUN_SYS_AI_SPLIT_DOCUMENT, N_AI_SPLIT_DOCUMENT,
+                         MORE_THAN_ZERO, NOT_VALID_FOR_GENERATED_COL)
+{
+}
+
+ObExprAISplitDocument::~ObExprAISplitDocument()
+{
+}
+
+int ObExprAISplitDocument::calc_result_typeN(ObExprResType &type,
+                                             ObExprResType *types,
+                                             int64_t param_num,
+                                             ObExprTypeCtx &type_ctx) const
+{
+  int ret = OB_SUCCESS;
+  UNUSED(type_ctx);
+  if (OB_UNLIKELY(param_num < 1 || param_num > 2)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid ai_split_document argument count", K(ret), K(param_num));
+  } else {
+    type.set_varchar();
+    type.set_collation_type(ObCharset::get_system_collation());
+    type.set_length(OB_MAX_VARCHAR_LENGTH);
+    for (int64_t i = 0; i < param_num; ++i) {
+      types[i].set_calc_type(ObVarcharType);
+      types[i].set_calc_collation_type(ObCharset::get_system_collation());
+    }
+  }
+  return ret;
+}
+
+int ObExprAISplitDocument::eval_ai_split_document(const ObExpr &expr,
+                                                  ObEvalCtx &ctx,
+                                                  ObDatum &expr_datum)
+{
+  UNUSED(expr);
+  UNUSED(ctx);
+  expr_datum.set_null();
+  return OB_SUCCESS;
+}
+
+int ObExprAISplitDocument::build_chunks(ObIAllocator &allocator,
+                                        const ObString &content,
+                                        const ObString &params,
+                                        ObIArray<ObAISplitDocumentChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+  const std::string content_str = to_std_string(content);
+  const std::string params_str = to_std_string(params);
+  const bool is_text = json_contains_string(params_str, "type", "text");
+  const bool by_sentence = json_contains_string(params_str, "by", "sentence");
+  const int64_t max_units = json_int_value(params_str, "max", 256);
+  const int64_t overlap = json_int_value(params_str, "overlap", 0);
+
+  if (!is_text && by_sentence) {
+    if (OB_FAIL(build_markdown_sentence_chunks(allocator, content_str, max_units, overlap, chunks))) {
+      LOG_WARN("failed to split markdown document", K(ret));
+    }
+  } else if (by_sentence) {
+    std::vector<TextSpan> sentences = split_sentences(content_str);
+    if (OB_FAIL(build_window_chunks(allocator, sentences, max_units, overlap, false,
+                                    std::string(), chunks))) {
+      LOG_WARN("failed to split text sentences", K(ret));
+    }
+  } else {
+    std::vector<TextSpan> words = split_words(content_str);
+    if (OB_FAIL(build_window_chunks(allocator, words, max_units, overlap, true,
+                                    std::string(), chunks))) {
+      LOG_WARN("failed to split text words", K(ret));
+    }
+  }
+  return ret;
+}
+
+int ObExprAISplitDocument::cg_expr(ObExprCGCtx &op_cg_ctx,
+                                   const ObRawExpr &raw_expr,
+                                   ObExpr &rt_expr) const
+{
+  UNUSED(op_cg_ctx);
+  UNUSED(raw_expr);
+  rt_expr.eval_func_ = ObExprAISplitDocument::eval_ai_split_document;
+  return OB_SUCCESS;
+}
+
+}
+}

--- a/src/sql/engine/expr/ob_expr_ai_split_document.h
+++ b/src/sql/engine/expr/ob_expr_ai_split_document.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_AI_SPLIT_DOCUMENT_H_
+#define OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_AI_SPLIT_DOCUMENT_H_
+
+#include "lib/container/ob_se_array.h"
+#include "lib/string/ob_string.h"
+#include "sql/engine/expr/ob_expr_operator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+struct ObAISplitDocumentChunk
+{
+  ObAISplitDocumentChunk() : offset_(0), length_(0), text_() {}
+  ObAISplitDocumentChunk(int64_t offset, int64_t length, const common::ObString &text)
+      : offset_(offset), length_(length), text_(text) {}
+  int64_t offset_;
+  int64_t length_;
+  common::ObString text_;
+};
+
+class ObExprAISplitDocument : public ObStringExprOperator
+{
+public:
+  explicit ObExprAISplitDocument(common::ObIAllocator &alloc);
+  virtual ~ObExprAISplitDocument();
+  virtual int calc_result_typeN(ObExprResType &type,
+                                ObExprResType *types,
+                                int64_t param_num,
+                                common::ObExprTypeCtx &type_ctx) const override;
+  static int eval_ai_split_document(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum);
+  static int build_chunks(common::ObIAllocator &allocator,
+                          const common::ObString &content,
+                          const common::ObString &params,
+                          common::ObIArray<ObAISplitDocumentChunk> &chunks);
+  virtual int cg_expr(ObExprCGCtx &op_cg_ctx,
+                      const ObRawExpr &raw_expr,
+                      ObExpr &rt_expr) const override;
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObExprAISplitDocument);
+};
+
+}
+}
+
+#endif

--- a/src/sql/engine/expr/ob_expr_eval_functions.cpp
+++ b/src/sql/engine/expr/ob_expr_eval_functions.cpp
@@ -388,6 +388,8 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
 #include "ob_expr_vector_similarity.h"
 #include "ob_expr_check_location_access.h"
+#include "ob_expr_load_file.h"
+#include "ob_expr_ai_split_document.h"
 
 namespace oceanbase
 {
@@ -1341,6 +1343,8 @@ static ObExpr::EvalFunc g_expr_eval_functions[] = {
   ObExprVectorCosineSimilarity::calc_cosine_similarity,                /* 872 */
   ObExprVectorIPSimilarity::calc_ip_similarity,                        /* 873 */
   ObExprVectorSimilarity::calc_similarity,                             /* 874 */
+  ObExprLoadFile::eval_load_file,                                      /* 875 */
+  ObExprAISplitDocument::eval_ai_split_document,                       /* 876 */
 };
 
 static ObExpr::EvalBatchFunc g_expr_eval_batch_functions[] = {

--- a/src/sql/engine/expr/ob_expr_load_file.cpp
+++ b/src/sql/engine/expr/ob_expr_load_file.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+
+#include "sql/engine/expr/ob_expr_load_file.h"
+
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include "lib/ob_errno.h"
+#include "lib/oblog/ob_log_module.h"
+#include "share/schema/ob_location_schema_struct.h"
+#include "share/schema/ob_schema_getter_guard.h"
+#include "sql/engine/ob_exec_context.h"
+
+namespace oceanbase
+{
+using namespace common;
+using namespace share::schema;
+namespace sql
+{
+
+ObExprLoadFile::ObExprLoadFile(ObIAllocator &alloc)
+  : ObStringExprOperator(alloc, T_FUN_SYS_LOAD_FILE, N_LOAD_FILE, 2,
+                         NOT_VALID_FOR_GENERATED_COL, NOT_ROW_DIMENSION)
+{
+}
+
+ObExprLoadFile::~ObExprLoadFile()
+{
+}
+
+int ObExprLoadFile::calc_result_type2(ObExprResType &type,
+                                      ObExprResType &type1,
+                                      ObExprResType &type2,
+                                      ObExprTypeCtx &type_ctx) const
+{
+  int ret = OB_SUCCESS;
+  UNUSED(type_ctx);
+  type.set_blob();
+  type.set_collation_type(CS_TYPE_BINARY);
+  type.set_accuracy(ObAccuracy::DDL_DEFAULT_ACCURACY[ObLongTextType]);
+  type1.set_calc_type(ObVarcharType);
+  type1.set_calc_collation_type(ObCharset::get_system_collation());
+  type2.set_calc_type(ObVarcharType);
+  type2.set_calc_collation_type(ObCharset::get_system_collation());
+  return ret;
+}
+
+int ObExprLoadFile::eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum)
+{
+  int ret = OB_SUCCESS;
+  ObDatum *location_name = NULL;
+  ObDatum *file_name = NULL;
+  ObSchemaGetterGuard schema_guard;
+  const ObLocationSchema *location_schema = NULL;
+
+  if (OB_UNLIKELY(expr.arg_cnt_ != 2)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid load_file argument count", K(ret), K(expr.arg_cnt_));
+  } else if (OB_FAIL(expr.args_[0]->eval(ctx, location_name))
+             || OB_FAIL(expr.args_[1]->eval(ctx, file_name))) {
+    LOG_WARN("failed to eval load_file arguments", K(ret));
+  } else if (location_name->is_null() || file_name->is_null()) {
+    expr_datum.set_null();
+  } else if (OB_ISNULL(GCTX.schema_service_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("schema service is null", K(ret));
+  } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+    LOG_WARN("failed to get schema guard", K(ret));
+  } else if (OB_FAIL(schema_guard.get_location_schema_by_name(location_name->get_string(),
+                                                              location_schema))) {
+    LOG_WARN("failed to get location schema", K(ret), K(location_name->get_string()));
+  } else if (OB_ISNULL(location_schema)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("location schema is null", K(ret));
+  } else {
+    const ObString url = location_schema->get_location_url_str();
+    const ObString name = file_name->get_string();
+    const char *file_prefix = "file://";
+    const int64_t file_prefix_len = 7;
+    if (url.length() < file_prefix_len
+        || 0 != STRNCASECMP(url.ptr(), file_prefix, file_prefix_len)) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "load_file only supports file:// location");
+    } else {
+      std::string path(url.ptr() + file_prefix_len, url.length() - file_prefix_len);
+      if (!path.empty() && path[path.length() - 1] != '/' && path[path.length() - 1] != '\\') {
+        path.append("/");
+      }
+      path.append(name.ptr(), name.length());
+
+      std::ifstream input(path.c_str(), std::ios::in | std::ios::binary);
+      if (!input.good()) {
+        ret = OB_IO_ERROR;
+        LOG_WARN("failed to open load_file path", K(ret), K(path.c_str()));
+      } else {
+        std::string content((std::istreambuf_iterator<char>(input)),
+                            std::istreambuf_iterator<char>());
+        char *buf = NULL;
+        if (content.empty()) {
+          expr_datum.set_string("");
+        } else if (OB_ISNULL(buf = expr.get_str_res_mem(ctx, content.length()))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          LOG_WARN("failed to allocate load_file result", K(ret), K(content.length()));
+        } else {
+          MEMCPY(buf, content.data(), content.length());
+          expr_datum.set_string(buf, static_cast<ObString::obstr_size_t>(content.length()));
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::cg_expr(ObExprCGCtx &op_cg_ctx,
+                            const ObRawExpr &raw_expr,
+                            ObExpr &rt_expr) const
+{
+  UNUSED(op_cg_ctx);
+  UNUSED(raw_expr);
+  rt_expr.eval_func_ = ObExprLoadFile::eval_load_file;
+  return OB_SUCCESS;
+}
+
+}
+}

--- a/src/sql/engine/expr/ob_expr_load_file.h
+++ b/src/sql/engine/expr/ob_expr_load_file.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_H_
+#define OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_H_
+
+#include "sql/engine/expr/ob_expr_operator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+class ObExprLoadFile : public ObStringExprOperator
+{
+public:
+  explicit ObExprLoadFile(common::ObIAllocator &alloc);
+  virtual ~ObExprLoadFile();
+  virtual int calc_result_type2(ObExprResType &type,
+                                ObExprResType &type1,
+                                ObExprResType &type2,
+                                common::ObExprTypeCtx &type_ctx) const override;
+  static int eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum);
+  virtual int cg_expr(ObExprCGCtx &op_cg_ctx,
+                      const ObRawExpr &raw_expr,
+                      ObExpr &rt_expr) const override;
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObExprLoadFile);
+};
+
+}
+}
+
+#endif

--- a/src/sql/engine/expr/ob_expr_operator_factory.cpp
+++ b/src/sql/engine/expr/ob_expr_operator_factory.cpp
@@ -442,6 +442,8 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
 #include "sql/engine/expr/ob_expr_vector_similarity.h"
 #include "sql/engine/expr/ob_expr_check_location_access.h"
+#include "sql/engine/expr/ob_expr_load_file.h"
+#include "sql/engine/expr/ob_expr_ai_split_document.h"
 
 
 #include "sql/engine/expr/ob_expr_lock_func.h"
@@ -1148,6 +1150,8 @@ void ObExprOperatorFactory::register_expr_operators()
     REG_OP(ObExprAIRerank);
     REG_OP(ObExprAIPrompt);
     REG_OP(ObExprCheckLocationAccess);
+    REG_OP(ObExprLoadFile);
+    REG_OP(ObExprAISplitDocument);
   }();
 }
 
@@ -1332,4 +1336,3 @@ void ObExprOperatorFactory::get_function_alias_name(const ObString &origin_name,
 
 } //end sql
 } //end oceanbase
-

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -1057,6 +1057,8 @@ typedef enum ObItemType
   T_FUN_SYS_AI_RERANK = 2084,
   T_FUN_MD5_CNN_WS = 2085,
   T_FUN_SYS_BUCKET = 2086,
+  T_FUN_SYS_LOAD_FILE = 2087,
+  T_FUN_SYS_AI_SPLIT_DOCUMENT = 2088,
   T_MAX_OP = 3000,
 
   //pseudo column, to mark the group iterator id

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -13389,6 +13389,45 @@ relation_factor %prec LOWER_PARENS
   merge_nodes($$, result, T_INDEX_HINT_LIST, $7);
   malloc_non_terminal_node($$, result->malloc_pool_, T_ALIAS, 6, $1, $6, $$, $2, $3, $5);
 }
+| function_name '(' opt_expr_as_list ')' %prec LOWER_PARENS
+{
+  ParseNode *params = NULL;
+  ParseNode *func = NULL;
+  if (NULL != $3) {
+    merge_nodes(params, result, T_EXPR_LIST, $3);
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 2, $1, params);
+  } else {
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 1, $1);
+  }
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, func, NULL);
+  store_pl_ref_object_symbol(func, result, REF_FUNC);
+}
+| function_name '(' opt_expr_as_list ')' relation_name
+{
+  ParseNode *params = NULL;
+  ParseNode *func = NULL;
+  if (NULL != $3) {
+    merge_nodes(params, result, T_EXPR_LIST, $3);
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 2, $1, params);
+  } else {
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 1, $1);
+  }
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, func, $5);
+  store_pl_ref_object_symbol(func, result, REF_FUNC);
+}
+| function_name '(' opt_expr_as_list ')' AS relation_name
+{
+  ParseNode *params = NULL;
+  ParseNode *func = NULL;
+  if (NULL != $3) {
+    merge_nodes(params, result, T_EXPR_LIST, $3);
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 2, $1, params);
+  } else {
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 1, $1);
+  }
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, func, $6);
+  store_pl_ref_object_symbol(func, result, REF_FUNC);
+}
 | TABLE '(' simple_expr ')' %prec LOWER_PARENS
 {
   malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, $3, NULL);

--- a/src/sql/resolver/dml/ob_dml_resolver.cpp
+++ b/src/sql/resolver/dml/ob_dml_resolver.cpp
@@ -9226,13 +9226,40 @@ int ObDMLResolver::resolve_function_table_column_item_sys_func(const TableItem &
   ObRawExpr *table_expr = NULL;
   ColumnItem *col_item = NULL;
   ObDMLStmt *stmt = get_stmt();
-  const ObUserDefinedType *user_type = NULL;
 
   CK (OB_NOT_NULL(stmt));
   CK (OB_LIKELY(table_item.is_function_table()));
   CK (OB_NOT_NULL(table_expr = table_item.function_table_expr_));
   OZ (table_expr->deduce_type(session_info_));
   if (OB_FAIL(ret)) { // do nothing ...
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == table_expr->get_expr_type()) {
+    common::ObObjMeta int_meta;
+    common::ObObjMeta text_meta;
+    ObAccuracy int_accuracy = ObAccuracy::DDL_DEFAULT_ACCURACY[ObIntType];
+    ObAccuracy text_accuracy = ObAccuracy::DDL_DEFAULT_ACCURACY[ObVarcharType];
+    const ObString column_names[] = {
+      ObString("chunk_id"),
+      ObString("chunk_offset"),
+      ObString("chunk_length"),
+      ObString("chunk_text")
+    };
+    int_meta.set_int();
+    text_meta.set_varchar();
+    text_meta.set_collation_type(ObCharset::get_system_collation());
+    text_accuracy.set_length(OB_MAX_VARCHAR_LENGTH);
+    for (int64_t i = 0; OB_SUCC(ret) && i < 4; ++i) {
+      col_item = stmt->get_column_item(table_item.table_id_, column_names[i]);
+      if (NULL == col_item) {
+        OZ (resolve_function_table_column_item(table_item,
+                                               i < 3 ? int_meta : text_meta,
+                                               i < 3 ? int_accuracy : text_accuracy,
+                                               column_names[i],
+                                               OB_APP_MIN_COLUMN_ID + i,
+                                               col_item));
+      }
+      CK (OB_NOT_NULL(col_item));
+      OZ (col_items.push_back(*col_item));
+    }
   } else if (!ObResolverUtils::is_expr_can_be_used_in_table_function(*table_expr)) {
     ret = OB_NOT_SUPPORTED;
     LOG_USER_ERROR(OB_NOT_SUPPORTED, "access rows from a non-nested table item");
@@ -9246,8 +9273,10 @@ int ObDMLResolver::resolve_function_table_column_item_sys_func(const TableItem &
                                            OB_APP_MIN_COLUMN_ID,
                                            col_item));
   }
-  CK (OB_NOT_NULL(col_item));
-  OZ (col_items.push_back(*col_item));
+  if (OB_SUCC(ret) && T_FUN_SYS_AI_SPLIT_DOCUMENT != table_expr->get_expr_type()) {
+    CK (OB_NOT_NULL(col_item));
+    OZ (col_items.push_back(*col_item));
+  }
   return ret;
 }
 

--- a/src/sql/resolver/ob_resolver_utils.cpp
+++ b/src/sql/resolver/ob_resolver_utils.cpp
@@ -89,73 +89,83 @@ int ObResolverUtils::get_all_function_table_column_names(const TableItem &table_
   ObRawExpr *table_expr = NULL;
   ObPLPackageGuard *package_guard = nullptr;
   const ObUserDefinedType *user_type = NULL;
-  ObExecContext *exec_ctx = params.session_info_->get_cur_exec_ctx();
-  CK (OB_NOT_NULL(exec_ctx));
-  OZ (exec_ctx->get_package_guard(package_guard));
-  CK (OB_NOT_NULL(package_guard));
   CK (OB_LIKELY(table_item.is_function_table()));
   CK (OB_NOT_NULL(table_expr = table_item.function_table_expr_));
-  CK (table_expr->get_udt_id() != OB_INVALID_ID);
-
-  CK (OB_NOT_NULL(params.schema_checker_));
-  OZ (ObResolverUtils::get_user_type(
-    params.allocator_, params.session_info_, params.sql_proxy_,
-    params.schema_checker_->get_schema_guard(),
-    *package_guard,
-    table_expr->get_udt_id(), user_type));
-  CK (OB_NOT_NULL(user_type));
-  if (OB_SUCC(ret) && !user_type->is_collection_type()) {
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("function table get udf with return type not table type",
-             K(ret), K(user_type->is_collection_type()));
-    LOG_USER_ERROR(OB_NOT_SUPPORTED, "user define type is not collation type in function table");
-  }
-  const ObCollectionType *coll_type = NULL;
-  CK (OB_NOT_NULL(coll_type = static_cast<const ObCollectionType*>(user_type)));
-  if (OB_SUCC(ret)
-      && !coll_type->get_element_type().is_obj_type()
-      && !coll_type->get_element_type().is_record_type()
-      && !coll_type->get_element_type().is_collection_type()
-      && !(coll_type->get_element_type().is_opaque_type()
-            && coll_type->get_element_type().get_user_type_id() == T_OBJ_XML)) {
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("not suppoert type in table function", K(ret), KPC(coll_type));
-    ObString err;
-    err.write(coll_type->get_name().ptr(), coll_type->get_name().length());
-    err.write(" collation type in table function\0", sizeof(" collation type in table function\0"));
-    LOG_USER_ERROR(OB_NOT_SUPPORTED, err.ptr());
-  }
-  if (OB_SUCC(ret) && (coll_type->get_element_type().is_obj_type()
-                      || coll_type->get_element_type().is_opaque_type()
-                      || coll_type->get_element_type().is_collection_type())) {
+  if (OB_FAIL(ret)) {
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == table_expr->get_expr_type()) {
+    OZ (column_names.push_back(ObString("chunk_id")));
+    OZ (column_names.push_back(ObString("chunk_offset")));
+    OZ (column_names.push_back(ObString("chunk_length")));
+    OZ (column_names.push_back(ObString("chunk_text")));
+  } else if (!table_expr->get_result_type().is_ext()) {
     OZ (column_names.push_back(ObString("COLUMN_VALUE")));
-  }
-  if (OB_SUCC(ret) && coll_type->get_element_type().is_record_type()) {
-    const ObRecordType *record_type = NULL;
-    const ObUserDefinedType *user_type = NULL;
+  } else {
+    ObExecContext *exec_ctx = params.session_info_->get_cur_exec_ctx();
+    CK (OB_NOT_NULL(exec_ctx));
+    OZ (exec_ctx->get_package_guard(package_guard));
+    CK (OB_NOT_NULL(package_guard));
+    CK (table_expr->get_udt_id() != OB_INVALID_ID);
+
     CK (OB_NOT_NULL(params.schema_checker_));
     OZ (ObResolverUtils::get_user_type(
       params.allocator_, params.session_info_, params.sql_proxy_,
       params.schema_checker_->get_schema_guard(),
       *package_guard,
-      coll_type->get_element_type().get_user_type_id(), user_type));
+      table_expr->get_udt_id(), user_type));
     CK (OB_NOT_NULL(user_type));
-    CK (user_type->is_record_type());
-    CK (OB_NOT_NULL(record_type = static_cast<const ObRecordType *>(user_type)));
-    for (int64_t i = 0; OB_SUCC(ret) && i < record_type->get_member_count(); ++i) {
-      ObString name;
-      const ObString *member_name = record_type->get_record_member_name(i);
-      CK (OB_NOT_NULL(member_name));
+    if (OB_SUCC(ret) && !user_type->is_collection_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_WARN("function table get udf with return type not table type",
+              K(ret), K(user_type->is_collection_type()));
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "user define type is not collation type in function table");
+    }
+    const ObCollectionType *coll_type = NULL;
+    CK (OB_NOT_NULL(coll_type = static_cast<const ObCollectionType*>(user_type)));
+    if (OB_SUCC(ret)
+        && !coll_type->get_element_type().is_obj_type()
+        && !coll_type->get_element_type().is_record_type()
+        && !coll_type->get_element_type().is_collection_type()
+        && !(coll_type->get_element_type().is_opaque_type()
+              && coll_type->get_element_type().get_user_type_id() == T_OBJ_XML)) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_WARN("not suppoert type in table function", K(ret), KPC(coll_type));
+      ObString err;
+      err.write(coll_type->get_name().ptr(), coll_type->get_name().length());
+      err.write(" collation type in table function\0", sizeof(" collation type in table function\0"));
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, err.ptr());
+    }
+    if (OB_SUCC(ret) && (coll_type->get_element_type().is_obj_type()
+                        || coll_type->get_element_type().is_opaque_type()
+                        || coll_type->get_element_type().is_collection_type())) {
+      OZ (column_names.push_back(ObString("COLUMN_VALUE")));
+    }
+    if (OB_SUCC(ret) && coll_type->get_element_type().is_record_type()) {
+      const ObRecordType *record_type = NULL;
+      const ObUserDefinedType *record_user_type = NULL;
+      CK (OB_NOT_NULL(params.schema_checker_));
+      OZ (ObResolverUtils::get_user_type(
+        params.allocator_, params.session_info_, params.sql_proxy_,
+        params.schema_checker_->get_schema_guard(),
+        *package_guard,
+        coll_type->get_element_type().get_user_type_id(), record_user_type));
+      CK (OB_NOT_NULL(record_user_type));
+      CK (record_user_type->is_record_type());
+      CK (OB_NOT_NULL(record_type = static_cast<const ObRecordType *>(record_user_type)));
+      for (int64_t i = 0; OB_SUCC(ret) && i < record_type->get_member_count(); ++i) {
+        ObString name;
+        const ObString *member_name = record_type->get_record_member_name(i);
+        CK (OB_NOT_NULL(member_name));
 
-      if (OB_FAIL(ret)) {
-        // do nothing
-      } else if (PL_TYPE_PACKAGE == user_type->get_type_from()) {
-        OZ (ob_write_string(*params.allocator_, *member_name, name));
-      } else {
-        name = *member_name;
+        if (OB_FAIL(ret)) {
+          // do nothing
+        } else if (PL_TYPE_PACKAGE == record_user_type->get_type_from()) {
+          OZ (ob_write_string(*params.allocator_, *member_name, name));
+        } else {
+          name = *member_name;
+        }
+
+        OZ (column_names.push_back(name));
       }
-
-      OZ (column_names.push_back(name));
     }
   }
   return ret;


### PR DESCRIPTION
## Summary

Implement Document AI functions for the CCF/OceanBase training task.

- Add LOAD_FILE(location_name, file_name) to read local files from file:// LOCATION objects and return BLOB data.
- Add AI_SPLIT_DOCUMENT(content, parameters) as a table function.
- Support text/markdown document splitting by word or sentence with max and overlap parameters.
- Expose AI_SPLIT_DOCUMENT output columns:
  - chunk_id
  - chunk_offset
  - chunk_length
  - chunk_text

## Tests

- Not run locally. This Windows environment does not have a full seekdb build/mysqltest runtime.
- Target mysqltest cases:
  - tools/deploy/mysql_test/test_suite/ai_funcs/t/load_file.test
  - tools/deploy/mysql_test/test_suite/ai_funcs/t/ai_split_document.test