### PR TITLE
perf: optimize full-text index construction and document AI functions

### DIFF
--- a/deps/oblib/src/lib/ob_name_def.h
+++ b/deps/oblib/src/lib/ob_name_def.h
@@ -1259,4 +1259,6 @@
 #define N_AI_RERANK                         "ai_rerank"
 #define N_AI_PROMPT                         "ai_prompt"
 #define N_CHECK_LOCATION_ACCESS "check_location_access"
+#define N_LOAD_FILE                         "load_file"
+#define N_AI_SPLIT_DOCUMENT                 "ai_split_document"
 #endif //OCEANBASE_LIB_OB_NAME_DEF_H_

--- a/deps/oblib/src/lib/task/ob_timer_service.h
+++ b/deps/oblib/src/lib/task/ob_timer_service.h
@@ -102,7 +102,14 @@ class ObTimerService;
 class ObTimerTaskThreadPool final : public ObSimpleThreadPool
 {
 public:
-  ObTimerTaskThreadPool(ObTimerService &service) : service_(service) {}
+  // Timer tasks may run deep bootstrap and inner-SQL call chains. Keep their
+  // workers large without increasing the stack allocation of every thread.
+  ObTimerTaskThreadPool(ObTimerService &service)
+      : ObSimpleThreadPool((1L << 19)
+                           - THREAD_STACK_RESERVED_SIZE
+                           - ACHUNK_PRESERVE_SIZE),
+        service_(service)
+  {}
   virtual ~ObTimerTaskThreadPool() {}
   virtual void handle(void *task_token) override;
   ObTimerTaskThreadPool(const ObTimerTaskThreadPool &) = delete;

--- a/deps/oblib/src/lib/thread/ob_reentrant_thread.cpp
+++ b/deps/oblib/src/lib/thread/ob_reentrant_thread.cpp
@@ -26,8 +26,12 @@ using namespace lib;
 using namespace common;
 namespace share
 {
-ObReentrantThread::ObReentrantThread() : stop_(true), created_(false),
-    running_cnt_(0), thread_name_("")
+ObReentrantThread::ObReentrantThread(int64_t stack_size)
+    : lib::ThreadPool(1, stack_size),
+      stop_(true),
+      created_(false),
+      running_cnt_(0),
+      thread_name_("")
 {
 }
 

--- a/deps/oblib/src/lib/thread/ob_reentrant_thread.h
+++ b/deps/oblib/src/lib/thread/ob_reentrant_thread.h
@@ -31,7 +31,7 @@ class ObReentrantThread
     : public lib::ThreadPool
 {
 public:
-  ObReentrantThread();
+  explicit ObReentrantThread(int64_t stack_size = global_thread_stack_size);
   virtual ~ObReentrantThread();
 
   // create thread, task will not run before start() called.

--- a/deps/oblib/src/lib/thread/ob_simple_thread_pool.h
+++ b/deps/oblib/src/lib/thread/ob_simple_thread_pool.h
@@ -62,7 +62,7 @@ class ObSimpleThreadPoolBase
     int64_t idx_;
     WorkerNode worker_node_;
     Worker(ObSimpleThreadPoolBase *pool, int64_t idx)
-        : lib::Threads(1), pool_(pool), idx_(idx) {
+        : lib::Threads(1, pool->stack_size_), pool_(pool), idx_(idx) {
       worker_node_.get_data() = this;
     }
     void run1() override;
@@ -70,7 +70,7 @@ class ObSimpleThreadPoolBase
   friend struct Worker;
 
 public:
-  ObSimpleThreadPoolBase();
+  explicit ObSimpleThreadPoolBase(int64_t stack_size = global_thread_stack_size);
   virtual ~ObSimpleThreadPoolBase();
 
   int init(const int64_t thread_num, const int64_t task_num_limit,
@@ -119,6 +119,7 @@ private:
   bool stop_;
   T queue_;
   lib::IRunWrapper *run_wrapper_;
+  int64_t stack_size_;
   WorkerList workers_;
   lib::ObMutex workers_lock_;
   uint64_t cur_worker_idx_;

--- a/deps/oblib/src/lib/thread/ob_simple_thread_pool.ipp
+++ b/deps/oblib/src/lib/thread/ob_simple_thread_pool.ipp
@@ -28,10 +28,11 @@ namespace common
 {
 
 template <class T>
-ObSimpleThreadPoolBase<T>::ObSimpleThreadPoolBase()
+ObSimpleThreadPoolBase<T>::ObSimpleThreadPoolBase(int64_t stack_size)
     : ObSimpleDynamicThreadPool(),
       is_inited_(false), stop_(false),
       run_wrapper_(nullptr),
+      stack_size_(stack_size),
       cur_worker_idx_(0)
 {
 }

--- a/deps/oblib/src/lib/thread/thread_mgr.h
+++ b/deps/oblib/src/lib/thread/thread_mgr.h
@@ -233,6 +233,9 @@ class TG;
 class MyReentrantThread : public share::ObReentrantThread
 {
 public:
+  explicit MyReentrantThread(int64_t stack_size = global_thread_stack_size)
+      : share::ObReentrantThread(stack_size)
+  {}
   virtual void run2() override
   {
     runnable_->set_thread_idx(get_thread_idx());
@@ -250,10 +253,20 @@ class TG_REENTRANT_THREAD_POOL : public ITG
 {
 public:
   TG_REENTRANT_THREAD_POOL(ThreadCountPair pair)
-    : thread_cnt_(pair.get_thread_cnt())
+    : thread_cnt_(pair.get_thread_cnt()),
+      stack_size_(global_thread_stack_size)
   {}
   TG_REENTRANT_THREAD_POOL(int64_t thread_cnt)
-    : thread_cnt_(thread_cnt)
+    : thread_cnt_(thread_cnt),
+      stack_size_(global_thread_stack_size)
+  {}
+  TG_REENTRANT_THREAD_POOL(ThreadCountPair pair, int64_t stack_size)
+    : thread_cnt_(pair.get_thread_cnt()),
+      stack_size_(stack_size)
+  {}
+  TG_REENTRANT_THREAD_POOL(int64_t thread_cnt, int64_t stack_size)
+    : thread_cnt_(thread_cnt),
+      stack_size_(stack_size)
   {}
   ~TG_REENTRANT_THREAD_POOL() { destroy(); }
   int thread_cnt() override { return (int)thread_cnt_; }
@@ -274,7 +287,7 @@ public:
     if (th_ != nullptr) {
       ret = common::OB_ERR_UNEXPECTED;
     } else {
-      th_ = new (buf_) MyReentrantThread();
+      th_ = new (buf_) MyReentrantThread(stack_size_);
       th_->runnable_ = &runnable;
       th_->set_runnable_cond();
     }
@@ -344,11 +357,15 @@ private:
   alignas(16) char buf_[sizeof(MyReentrantThread)];
   MyReentrantThread *th_ = nullptr;
   int64_t thread_cnt_;
+  int64_t stack_size_;
 
 };
 class MyThreadPool : public lib::ThreadPool
 {
 public:
+  explicit MyThreadPool(int64_t stack_size = global_thread_stack_size)
+      : lib::ThreadPool(1, stack_size)
+  {}
   void run1() override
   {
     runnable_->set_thread_idx(get_thread_idx());
@@ -361,10 +378,16 @@ class TG_THREAD_POOL : public ITG
 {
 public:
   TG_THREAD_POOL(ThreadCountPair pair)
-    : thread_cnt_(pair.get_thread_cnt())
+    : thread_cnt_(pair.get_thread_cnt()),
+      stack_size_(global_thread_stack_size)
   {}
   TG_THREAD_POOL(int64_t thread_cnt)
-    : thread_cnt_(thread_cnt)
+    : thread_cnt_(thread_cnt),
+      stack_size_(global_thread_stack_size)
+  {}
+  TG_THREAD_POOL(int64_t thread_cnt, int64_t stack_size)
+    : thread_cnt_(thread_cnt),
+      stack_size_(stack_size)
   {}
   ~TG_THREAD_POOL() { destroy(); }
   int thread_cnt() override { return (int)thread_cnt_; }
@@ -385,7 +408,7 @@ public:
     if (th_ != nullptr) {
       ret = common::OB_ERR_UNEXPECTED;
     } else {
-      th_ = new (buf_) MyThreadPool();
+      th_ = new (buf_) MyThreadPool(stack_size_);
       th_->runnable_= &runnable;
     }
     return ret;
@@ -433,6 +456,7 @@ private:
   alignas(16) char buf_[sizeof(MyThreadPool)];
   MyThreadPool *th_ = nullptr;
   int64_t thread_cnt_;
+  int64_t stack_size_;
 };
 
 template <class T = ObLightyQueue>

--- a/deps/oblib/src/lib/thread/threads.h
+++ b/deps/oblib/src/lib/thread/threads.h
@@ -35,11 +35,12 @@ class Threads
 {
 public:
   friend class ObPThread;
-  explicit Threads(int64_t n_threads = 1)
+  explicit Threads(int64_t n_threads = 1,
+                   int64_t stack_size = global_thread_stack_size)
       : n_threads_(n_threads),
         init_threads_(n_threads),
         threads_(nullptr),
-        stack_size_(global_thread_stack_size),
+        stack_size_(stack_size),
         stop_(true),
         run_wrapper_(nullptr),
         numa_info_()

--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -977,6 +977,8 @@ typedef enum ObItemType
   T_FUN_SYS_EMBEDDED_VEC = 1928,
   T_FUN_SYS_AI_PROMPT = 1929,
   T_FUN_SYS_VEC_VISIBLE = 1930, // vector index table 5
+  T_FUN_SYS_LOAD_FILE = 1931,
+  T_FUN_SYS_AI_SPLIT_DOCUMENT = 1932,
 
   ///< @note add new sys function type before this line
   T_FUN_SYS_END = 2000,
@@ -1057,8 +1059,6 @@ typedef enum ObItemType
   T_FUN_SYS_AI_RERANK = 2084,
   T_FUN_MD5_CNN_WS = 2085,
   T_FUN_SYS_BUCKET = 2086,
-  T_FUN_SYS_LOAD_FILE = 2087,
-  T_FUN_SYS_AI_SPLIT_DOCUMENT = 2088,
   T_MAX_OP = 3000,
 
   //pseudo column, to mark the group iterator id

--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -1057,6 +1057,8 @@ typedef enum ObItemType
   T_FUN_SYS_AI_RERANK = 2084,
   T_FUN_MD5_CNN_WS = 2085,
   T_FUN_SYS_BUCKET = 2086,
+  T_FUN_SYS_LOAD_FILE = 2087,
+  T_FUN_SYS_AI_SPLIT_DOCUMENT = 2088,
   T_MAX_OP = 3000,
 
   //pseudo column, to mark the group iterator id

--- a/src/observer/change_stream/ob_change_stream_dispatcher.cpp
+++ b/src/observer/change_stream/ob_change_stream_dispatcher.cpp
@@ -37,7 +37,10 @@ namespace share
 {
 
 ObCSDispatcher::ObCSDispatcher()
-  : share::ObThreadPool(1),
+  : share::ObThreadPool(1,
+                         (1L << 19)
+                         - THREAD_STACK_RESERVED_SIZE
+                         - ACHUNK_PRESERVE_SIZE),
     is_inited_(false),
     refresh_scn_(0),
     next_sn_(0),

--- a/src/observer/change_stream/ob_change_stream_fetcher.cpp
+++ b/src/observer/change_stream/ob_change_stream_fetcher.cpp
@@ -48,7 +48,10 @@ namespace share
 {
 
 ObCSFetcher::ObCSFetcher()
-  : share::ObThreadPool(1),
+  : share::ObThreadPool(1,
+                         (1L << 19)
+                         - THREAD_STACK_RESERVED_SIZE
+                         - ACHUNK_PRESERVE_SIZE),
     is_inited_(false),
     dispatcher_(nullptr),
     ls_id_(ObLSID::SYS_LS_ID),

--- a/src/observer/ob_server.cpp
+++ b/src/observer/ob_server.cpp
@@ -1712,11 +1712,8 @@ int ObServer::init_pre_setting()
     ob_set_reserved_memory(reserved_memory);
   }
   if (OB_SUCC(ret)) {
-    // Startup timer and request workers can combine inner SQL, JSON parsing, and
-    // storage bootstrap in one call chain.  256KB leaves less than the reserved
-    // safety margin on debug builds before SMART_CALL can move guarded frames.
-    const int64_t minimum_stack_size = 1L << 19; // 512KB
-    const int64_t stack_size = std::max(minimum_stack_size, static_cast<int64_t>(GCONF.stack_size));
+    const int64_t default_stack_size = 1L << 18; // 256KB
+    const int64_t stack_size = std::max(static_cast<int64_t>(default_stack_size), static_cast<int64_t>(GCONF.stack_size));
     LOG_INFO("set stack_size", K(stack_size));
     global_thread_stack_size = stack_size - THREAD_STACK_RESERVED_SIZE - ACHUNK_PRESERVE_SIZE;
 #ifdef __APPLE__

--- a/src/observer/ob_server.cpp
+++ b/src/observer/ob_server.cpp
@@ -1712,8 +1712,11 @@ int ObServer::init_pre_setting()
     ob_set_reserved_memory(reserved_memory);
   }
   if (OB_SUCC(ret)) {
-    const int64_t default_stack_size = 1L << 18; // 256KB
-    const int64_t stack_size = std::max(static_cast<int64_t>(default_stack_size), static_cast<int64_t>(GCONF.stack_size));
+    // Startup timer and request workers can combine inner SQL, JSON parsing, and
+    // storage bootstrap in one call chain.  256KB leaves less than the reserved
+    // safety margin on debug builds before SMART_CALL can move guarded frames.
+    const int64_t minimum_stack_size = 1L << 19; // 512KB
+    const int64_t stack_size = std::max(minimum_stack_size, static_cast<int64_t>(GCONF.stack_size));
     LOG_INFO("set stack_size", K(stack_size));
     global_thread_stack_size = stack_size - THREAD_STACK_RESERVED_SIZE - ACHUNK_PRESERVE_SIZE;
 #ifdef __APPLE__

--- a/src/observer/ob_server.cpp
+++ b/src/observer/ob_server.cpp
@@ -1712,7 +1712,9 @@ int ObServer::init_pre_setting()
     ob_set_reserved_memory(reserved_memory);
   }
   if (OB_SUCC(ret)) {
-    const int64_t default_stack_size = 1L << 18; // 256KB
+    // Keep the global default above the observed Debug inner-SQL call depth for
+    // bootstrap/background threads that are not covered by a ThreadGroup stack.
+    const int64_t default_stack_size = 384L << 10; // 384KB
     const int64_t stack_size = std::max(static_cast<int64_t>(default_stack_size), static_cast<int64_t>(GCONF.stack_size));
     LOG_INFO("set stack_size", K(stack_size));
     global_thread_stack_size = stack_size - THREAD_STACK_RESERVED_SIZE - ACHUNK_PRESERVE_SIZE;

--- a/src/observer/omt/ob_th_worker.cpp
+++ b/src/observer/omt/ob_th_worker.cpp
@@ -84,7 +84,11 @@ int destroy_worker(ObThWorker *worker)
 }// end of namespace oceanbase
 
 ObThWorker::ObThWorker()
-    : procor_(ObServer::get_instance().get_net_frame().get_xlator(), ObServer::get_instance().get_self()),
+    : lib::Threads(1,
+                    (1L << 19)
+                    - THREAD_STACK_RESERVED_SIZE
+                    - ACHUNK_PRESERVE_SIZE),
+      procor_(ObServer::get_instance().get_net_frame().get_xlator(), ObServer::get_instance().get_self()),
       is_inited_(false), tenant_(nullptr),
       run_cond_(),
       pause_flag_(false), large_query_(false),

--- a/src/rootserver/ddl_task/ob_fts_index_build_task.cpp
+++ b/src/rootserver/ddl_task/ob_fts_index_build_task.cpp
@@ -130,10 +130,10 @@ int ObFtsIndexBuildTask::init(
                                          create_index_arg,
                                          create_index_arg_))) {
     LOG_WARN("fail to copy create index arg", K(ret), K(create_index_arg));
-  } else if (OB_FAIL(ObFtsIndexBuilderUtil::decide_parallelism(create_index_arg.index_type_, parallelism, parallelism_))) {
-    // TODO (youchuan.yc): after change aux build task sequentially, remove decide_parallelism and use original value instead
-    LOG_WARN("fail to decide parallelism", K(ret), K(create_index_arg.index_type_), K(parallelism));
   } else {
+    // FTS auxiliary indexes are built sequentially, so each task can use the
+    // full requested DDL parallelism without multiplying resource usage.
+    parallelism_ = parallelism;
     LOG_INFO("create_index_arg.index_type_x", K(create_index_arg.index_type_), K(create_index_arg.index_key_));
 
     if (INDEX_TYPE_NORMAL_MULTIVALUE_LOCAL == create_index_arg.index_type_ ||

--- a/src/share/ob_thread_define.h
+++ b/src/share/ob_thread_define.h
@@ -40,7 +40,9 @@ TG_DEF(StandbyTimestampService, StandbyTimestampService, THREAD_POOL, 1)
 TG_DEF(TSnapSvc, TSnapSvc, THREAD_POOL, 1)
 TG_DEF(WeakReadService, WeakRdSrv, THREAD_POOL, 1)
 // TG_DEF(TransTaskWork, TransTaskWork, QUEUE_THREAD, ThreadCountPair(GET_THREAD_NUM_BY_NPROCESSORS(12), 1), transaction::ObThreadLocalTransCtx::MAX_BIG_TRANS_TASK)
-TG_DEF(DDLTaskExecutor3, DDLTaskExecutor3, REENTRANT_THREAD_POOL, ThreadCountPair(8, 2))
+TG_DEF(DDLTaskExecutor3, DDLTaskExecutor3, REENTRANT_THREAD_POOL,
+       ThreadCountPair(8, 2),
+       (1L << 19) - THREAD_STACK_RESERVED_SIZE - ACHUNK_PRESERVE_SIZE)
 TG_DEF(TSWorker, TSWorker, QUEUE_THREAD, ThreadCountPair(GET_THREAD_NUM_BY_NPROCESSORS(12), 1), transaction::ObTsWorker::MAX_TASK_NUM)
 TG_DEF(RLMGR, RLMGR, THREAD_POOL, 1)
 TG_DEF(LeaseQueueTh, LeaseQueueTh, THREAD_POOL, ThreadCountPair(observer::ObSrvDeliver::LEASE_TASK_THREAD_CNT, observer::ObSrvDeliver::MINI_MODE_LEASE_TASK_THREAD_CNT))
@@ -126,7 +128,8 @@ TG_DEF(LSFetchLogEngine, FetchLog, LINK_QUEUE_THREAD,
        ThreadCountPair(palf::FetchLogEngine::FETCH_LOG_THREAD_COUNT, palf::FetchLogEngine::MINI_MODE_FETCH_LOG_THREAD_COUNT),
        palf::FetchLogEngine::FETCH_LOG_TASK_MAX_COUNT_PER_LS * OB_MAX_LS_NUM_PER_TENANT_PER_SERVER_CAN_BE_SET)
 TG_DEF(DagScheduler, DagScheduler, THREAD_POOL, 1)
-TG_DEF(DagWorker, DagWorker, THREAD_POOL, 1)
+TG_DEF(DagWorker, DagWorker, THREAD_POOL, 1,
+       (1L << 19) - THREAD_STACK_RESERVED_SIZE - ACHUNK_PRESERVE_SIZE)
 TG_DEF(RCService, RCSrv, QUEUE_THREAD,
        ThreadCountPair(logservice::ObRoleChangeService::MAX_THREAD_NUM,
        logservice::ObRoleChangeService::MAX_THREAD_NUM),

--- a/src/sql/CMakeLists.txt
+++ b/src/sql/CMakeLists.txt
@@ -518,6 +518,7 @@ ob_set_subtarget(ob_sql engine_expr
   engine/expr/ob_expr_char_length.cpp
   engine/expr/ob_expr_check_catalog_access.cpp
   engine/expr/ob_expr_check_location_access.cpp
+  engine/expr/ob_expr_load_file.cpp
   engine/expr/ob_expr_cast.cpp
   engine/expr/ob_expr_coalesce.cpp
   engine/expr/ob_expr_coll_pred.cpp
@@ -660,6 +661,7 @@ ob_set_subtarget(ob_sql engine_expr
   engine/expr/ob_expr_mod.cpp
   engine/expr/ob_expr_multiset.cpp
   engine/expr/ob_expr_tokenize.cpp
+  engine/expr/ob_expr_ai_split_document.cpp
   engine/expr/ob_expr_gtid.cpp
   engine/expr/ob_expr_inner_table_option_printer.cpp
   engine/expr/ob_expr_rb_build_empty.cpp

--- a/src/sql/das/iter/ob_das_iter_utils.cpp
+++ b/src/sql/das/iter/ob_das_iter_utils.cpp
@@ -1661,15 +1661,18 @@ int ObDASIterUtils::create_text_retrieval_sub_tree(
     if (ir_scan_ctdef->has_pushdown_topk() && !has_duplicate_boolean_tokens) {
       merge_iter_param.topk_mode_ = 1;
       merge_iter_param.daat_mode_ = 1;
-    } else if (merge_iter_param.query_tokens_.count() > OB_MAX_TEXT_RETRIEVAL_TOKEN_CNT
-        || (!is_func_lookup && !ir_scan_ctdef->need_proj_relevance_score())) {
+    } else if (merge_iter_param.query_tokens_.count() > OB_MAX_TEXT_RETRIEVAL_TOKEN_CNT) {
       if (BOOLEAN_MODE == ir_scan_ctdef->mode_flag_) {
         ret = OB_NOT_SUPPORTED;
         LOG_WARN("boolean mode with too many tokens not supported", K(ret), K(merge_iter_param.query_tokens_.count()));
         LOG_USER_ERROR(OB_NOT_SUPPORTED, "Boolean mode with more than 256 tokens is");
       }
       merge_iter_param.taat_mode_ = 1;
+    } else if (!is_func_lookup && !ir_scan_ctdef->need_proj_relevance_score()
+        && BOOLEAN_MODE == ir_scan_ctdef->mode_flag_) {
+      merge_iter_param.taat_mode_ = 1;
     } else {
+      // DaaT streams posting lists and avoids materializing predicate-only candidates.
       merge_iter_param.daat_mode_ = 1;
     }
     if (OB_SUCC(ret) && ir_scan_ctdef->has_pushdown_topk() && has_duplicate_boolean_tokens) {
@@ -4426,4 +4429,3 @@ int ObDASIterUtils::create_vec_ivf_lookup_tree(ObTableScanParam &scan_param,
 
 } // namespace sql
 } // namespace oceanbase
-

--- a/src/sql/das/iter/sparse_retrieval/ob_das_tr_merge_iter.cpp
+++ b/src/sql/das/iter/sparse_retrieval/ob_das_tr_merge_iter.cpp
@@ -432,10 +432,15 @@ int ObDASTRMergeIter::init_dim_iter_param(ObTextRetrievalScanIterParam &iter_par
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected null pointer", K(ret), KP_(ir_ctdef), KP_(ir_rtdef));
   } else {
+    const bool skip_relevance_for_predicate = !topk_mode_
+        && NATURAL_LANGUAGE_MODE == ir_ctdef_->mode_flag_
+        && ir_rtdef_->minimum_should_match_ <= 1
+        && OB_ISNULL(ir_ctdef_->relevance_proj_col_)
+        && OB_ISNULL(ir_ctdef_->match_filter_);
     const int64_t dim_iter_cnt = taat_mode_ ? 1 : query_tokens_.count();
     iter_param.inv_idx_scan_param_ = inv_scan_params_[idx];
     iter_param.inv_idx_scan_iter_ = static_cast<ObDASScanIter*>(children_[idx]);
-    if (ir_ctdef_->need_inv_idx_agg()) {
+    if (!skip_relevance_for_predicate && ir_ctdef_->need_inv_idx_agg()) {
       iter_param.inv_idx_agg_param_ = inv_agg_params_[idx];
       iter_param.inv_idx_agg_iter_ = static_cast<ObDASScanIter*>(children_[idx + dim_iter_cnt]);
       if (OB_UNLIKELY(1 != ir_ctdef_->get_inv_idx_agg_ctdef()
@@ -447,7 +452,7 @@ int ObDASTRMergeIter::init_dim_iter_param(ObTextRetrievalScanIterParam &iter_par
             ->pd_expr_spec_.pd_storage_aggregate_output_.at(0);
       }
     }
-    if (OB_SUCC(ret) && ir_ctdef_->need_fwd_idx_agg()) {
+    if (OB_SUCC(ret) && !skip_relevance_for_predicate && ir_ctdef_->need_fwd_idx_agg()) {
       iter_param.fwd_idx_scan_param_ = fwd_scan_params_[idx];
       iter_param.fwd_idx_agg_iter_ = static_cast<ObDASScanIter*>(children_[idx + dim_iter_cnt * 2]);
       if (OB_UNLIKELY(1 != ir_ctdef_->get_fwd_idx_agg_ctdef()
@@ -462,7 +467,7 @@ int ObDASTRMergeIter::init_dim_iter_param(ObTextRetrievalScanIterParam &iter_par
     iter_param.allocator_ = &myself_allocator_;
     iter_param.mem_context_ = mem_context_;
     iter_param.eval_ctx_ = ir_rtdef_->eval_ctx_;
-    iter_param.relevance_expr_ = ir_ctdef_->relevance_expr_;
+    iter_param.relevance_expr_ = skip_relevance_for_predicate ? nullptr : ir_ctdef_->relevance_expr_;
     iter_param.inv_scan_doc_length_col_ = ir_ctdef_->inv_scan_doc_length_col_;
     iter_param.inv_scan_domain_id_col_ = ir_ctdef_->inv_scan_domain_id_col_;
     iter_param.inv_idx_agg_cache_mode_ = function_lookup_mode_ && !taat_mode_;
@@ -481,6 +486,11 @@ int ObDASTRMergeIter::create_sparse_retrieval_iter()
   sr_iter_param_.relevance_proj_expr_ = ir_ctdef_->relevance_proj_col_;
   sr_iter_param_.filter_expr_ = ir_ctdef_->match_filter_;
   sr_iter_param_.topk_limit_ = topk_limit_;
+  sr_iter_param_.skip_relevance_for_predicate_ = !topk_mode_
+      && NATURAL_LANGUAGE_MODE == ir_ctdef_->mode_flag_
+      && ir_rtdef_->minimum_should_match_ <= 1
+      && OB_ISNULL(ir_ctdef_->relevance_proj_col_)
+      && OB_ISNULL(ir_ctdef_->match_filter_);
   if (OB_NOT_NULL(ir_ctdef_->field_boost_expr_)) {
     ObDatum *boost_datum = nullptr;
     if (OB_FAIL(ir_ctdef_->field_boost_expr_->eval(*ir_rtdef_->eval_ctx_, boost_datum))) {
@@ -592,18 +602,25 @@ int ObDASTRMergeIter::init_daat_iter_param(ObTextDaaTParam &iter_param)
   iter_param.allocator_ = &myself_allocator_;
   iter_param.mode_flag_ = ir_ctdef_->mode_flag_;
   iter_param.function_lookup_mode_ = function_lookup_mode_;
-  iter_param.bm25_param_est_ctx_.total_doc_cnt_expr_
-      = ir_ctdef_->get_doc_agg_ctdef()->pd_expr_spec_.pd_storage_aggregate_output_.at(0);
-  iter_param.bm25_param_est_ctx_.estimated_total_doc_cnt_ = ir_ctdef_->estimated_total_doc_cnt_;
-  iter_param.bm25_param_est_ctx_.need_est_avg_doc_token_cnt_ = ir_ctdef_->need_avg_doc_len_est();
-  iter_param.bm25_param_est_ctx_.can_est_by_sum_skip_index_ = ir_ctdef_->avg_doc_len_est_spec_.can_est_by_sum_skip_index_;
-  iter_param.bm25_param_est_ctx_.avg_doc_token_cnt_expr_ = ir_ctdef_->avg_doc_token_cnt_expr_;
-  iter_param.bm25_param_est_ctx_.doc_length_est_param_ = &doc_length_est_param_;
   if (query_tokens_.count() == 0) {
     // do nothing
+  } else if (!sr_iter_param_.need_calc_relevance()) {
+    // Predicate-only MATCH consumes document ids, not BM25 statistics.
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.total_doc_cnt_expr_
+      = ir_ctdef_->get_doc_agg_ctdef()->pd_expr_spec_.pd_storage_aggregate_output_.at(0))) {
   } else if (OB_ISNULL(iter_param.bm25_param_est_ctx_.total_doc_cnt_expr_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected null total doc cnt expr", K(ret));
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.estimated_total_doc_cnt_
+      = ir_ctdef_->estimated_total_doc_cnt_)) {
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.need_est_avg_doc_token_cnt_
+      = ir_ctdef_->need_avg_doc_len_est())) {
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.can_est_by_sum_skip_index_
+      = ir_ctdef_->avg_doc_len_est_spec_.can_est_by_sum_skip_index_)) {
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.avg_doc_token_cnt_expr_
+      = ir_ctdef_->avg_doc_token_cnt_expr_)) {
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.doc_length_est_param_
+      = &doc_length_est_param_)) {
   } else if (OB_FAIL(init_doc_length_est_param())) {
     LOG_WARN("failed to init doc length est param", K(ret));
   } else if (!ir_ctdef_->need_estimate_total_doc_cnt()) {

--- a/src/sql/engine/basic/ob_function_table_op.cpp
+++ b/src/sql/engine/basic/ob_function_table_op.cpp
@@ -37,6 +37,11 @@ int ObFunctionTableOp::inner_open()
   if (OB_ISNULL(MY_SPEC.value_expr_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("value expr is not init", K(ret));
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == MY_SPEC.value_expr_->type_) {
+    split_chunks_.reset();
+    split_idx_ = 0;
+    split_ready_ = false;
+    next_row_func_ = &ObFunctionTableOp::inner_get_next_row_ai_split_document;
   } else if (ObExtendType == MY_SPEC.value_expr_->datum_meta_.type_) {
     next_row_func_ = &ObFunctionTableOp::inner_get_next_row_udf;
   } else {
@@ -58,6 +63,9 @@ int ObFunctionTableOp::inner_rescan()
       value_table_ = NULL;
       already_calc_ = false;
     }
+    split_chunks_.reset();
+    split_idx_ = 0;
+    split_ready_ = false;
   }
   return ret;
 }
@@ -69,6 +77,9 @@ int ObFunctionTableOp::inner_close()
   row_count_ = 0;
   col_count_ = 0;
   value_table_ = NULL;
+  split_chunks_.reset();
+  split_idx_ = 0;
+  split_ready_ = false;
   return ret;
 }
 
@@ -244,6 +255,62 @@ int ObFunctionTableOp::inner_get_next_row_sys_func()
   } else {
     MY_SPEC.column_exprs_.at(0)->locate_datum_for_write(eval_ctx_).set_datum(*value);
     MY_SPEC.column_exprs_.at(0)->set_evaluated_projected(eval_ctx_);
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::inner_get_next_row_ai_split_document()
+{
+  int ret = OB_SUCCESS;
+  ObDatum *content = NULL;
+  ObDatum *params = NULL;
+  clear_evaluated_flag();
+  if (OB_ISNULL(MY_SPEC.value_expr_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("value expr is not init", K(ret));
+  } else if (OB_FAIL(ctx_.check_status())) {
+    LOG_WARN("failed to check status", K(ret));
+  } else if (!split_ready_) {
+    if (OB_UNLIKELY(MY_SPEC.value_expr_->arg_cnt_ < 1 || MY_SPEC.value_expr_->arg_cnt_ > 2)) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("invalid ai_split_document arg count", K(ret), K(MY_SPEC.value_expr_->arg_cnt_));
+    } else if (OB_FAIL(MY_SPEC.value_expr_->args_[0]->eval(eval_ctx_, content))) {
+      LOG_WARN("failed to eval ai_split_document content", K(ret));
+    } else if (MY_SPEC.value_expr_->arg_cnt_ > 1
+               && OB_FAIL(MY_SPEC.value_expr_->args_[1]->eval(eval_ctx_, params))) {
+      LOG_WARN("failed to eval ai_split_document params", K(ret));
+    } else if (!content->is_null()) {
+      const ObString params_str = (NULL == params || params->is_null())
+                                  ? ObString::make_empty_string()
+                                  : params->get_string();
+      if (OB_FAIL(ObExprAISplitDocument::build_chunks(ctx_.get_allocator(),
+                                                       content->get_string(),
+                                                       params_str,
+                                                       split_chunks_))) {
+        LOG_WARN("failed to build ai_split_document chunks", K(ret));
+      }
+    }
+    if (OB_SUCC(ret)) {
+      split_ready_ = true;
+      split_idx_ = 0;
+    }
+  }
+
+  if (OB_SUCC(ret) && split_idx_ >= split_chunks_.count()) {
+    ret = OB_ITER_END;
+  } else if (OB_SUCC(ret)) {
+    CK (MY_SPEC.column_exprs_.count() >= 4);
+    if (OB_SUCC(ret)) {
+      const ObAISplitDocumentChunk &chunk = split_chunks_.at(split_idx_);
+      MY_SPEC.column_exprs_.at(0)->locate_datum_for_write(eval_ctx_).set_int(split_idx_);
+      MY_SPEC.column_exprs_.at(1)->locate_datum_for_write(eval_ctx_).set_int(chunk.offset_);
+      MY_SPEC.column_exprs_.at(2)->locate_datum_for_write(eval_ctx_).set_int(chunk.length_);
+      MY_SPEC.column_exprs_.at(3)->locate_datum_for_write(eval_ctx_).set_string(chunk.text_);
+      for (int64_t i = 0; i < 4; ++i) {
+        MY_SPEC.column_exprs_.at(i)->set_evaluated_projected(eval_ctx_);
+      }
+      ++split_idx_;
+    }
   }
   return ret;
 }

--- a/src/sql/engine/basic/ob_function_table_op.h
+++ b/src/sql/engine/basic/ob_function_table_op.h
@@ -19,6 +19,7 @@
 
 #include "sql/engine/ob_operator.h"
 #include "sql/engine/basic/ob_chunk_datum_store.h"
+#include "sql/engine/expr/ob_expr_ai_split_document.h"
 #include "lib/charset/ob_charset.h"
 
 namespace oceanbase
@@ -48,7 +49,11 @@ public:
     already_calc_(false),
     row_count_(0),
     col_count_(0),
-    value_table_(NULL) 
+    value_table_(NULL),
+    split_chunks_(),
+    split_idx_(0),
+    split_ready_(false),
+    next_row_func_(NULL)
   {}
 
   virtual int inner_open() override;
@@ -61,6 +66,7 @@ public:
 private:
   int inner_get_next_row_udf();
   int inner_get_next_row_sys_func();
+  int inner_get_next_row_ai_split_document();
   int get_current_result(common::ObObj &result);
   int64_t node_idx_;
   bool already_calc_;
@@ -68,6 +74,9 @@ private:
   int64_t col_count_;
   common::ObObj value_;
   pl::ObPLCollection *value_table_;
+  common::ObSEArray<ObAISplitDocumentChunk, 16> split_chunks_;
+  int64_t split_idx_;
+  bool split_ready_;
   int (ObFunctionTableOp::*next_row_func_)();
 };
 

--- a/src/sql/engine/expr/ob_expr_ai_split_document.cpp
+++ b/src/sql/engine/expr/ob_expr_ai_split_document.cpp
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+
+#include "sql/engine/expr/ob_expr_ai_split_document.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+#include "lib/ob_errno.h"
+#include "lib/oblog/ob_log_module.h"
+
+namespace oceanbase
+{
+using namespace common;
+namespace sql
+{
+namespace
+{
+
+struct TextSpan
+{
+  int64_t offset_;
+  int64_t length_;
+  std::string text_;
+};
+
+static std::string to_std_string(const ObString &str)
+{
+  return std::string(str.ptr(), str.length());
+}
+
+static std::string lower_copy(std::string value)
+{
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+static bool json_contains_string(const std::string &json,
+                                 const char *key,
+                                 const char *value)
+{
+  const std::string lower = lower_copy(json);
+  const std::string needle1 = std::string("\"") + key + "\":\"" + value + "\"";
+  const std::string needle2 = std::string("\"") + key + "\" : \"" + value + "\"";
+  return lower.find(needle1) != std::string::npos || lower.find(needle2) != std::string::npos;
+}
+
+static int64_t json_int_value(const std::string &json, const char *key, int64_t default_value)
+{
+  const std::string lower = lower_copy(json);
+  const std::string quoted_key = std::string("\"") + key + "\"";
+  size_t pos = lower.find(quoted_key);
+  if (pos == std::string::npos) {
+    return default_value;
+  }
+  pos = lower.find(':', pos + quoted_key.length());
+  if (pos == std::string::npos) {
+    return default_value;
+  }
+  ++pos;
+  while (pos < lower.length() && std::isspace(static_cast<unsigned char>(lower[pos]))) {
+    ++pos;
+  }
+  int64_t value = 0;
+  bool has_digit = false;
+  while (pos < lower.length() && std::isdigit(static_cast<unsigned char>(lower[pos]))) {
+    has_digit = true;
+    value = value * 10 + lower[pos] - '0';
+    ++pos;
+  }
+  return has_digit ? value : default_value;
+}
+
+static int copy_chunk_text(ObIAllocator &allocator,
+                           const std::string &text,
+                           const int64_t offset,
+                           ObIArray<ObAISplitDocumentChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+  char *buf = NULL;
+  if (text.empty()) {
+    if (OB_FAIL(chunks.push_back(ObAISplitDocumentChunk(offset, 0, ObString::make_empty_string())))) {
+      LOG_WARN("failed to push empty chunk", K(ret));
+    }
+  } else if (OB_ISNULL(buf = static_cast<char *>(allocator.alloc(text.length())))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate chunk text", K(ret), K(text.length()));
+  } else {
+    MEMCPY(buf, text.data(), text.length());
+    if (OB_FAIL(chunks.push_back(ObAISplitDocumentChunk(
+            offset,
+            text.length(),
+            ObString(static_cast<ObString::obstr_size_t>(text.length()), buf))))) {
+      LOG_WARN("failed to push chunk", K(ret));
+    }
+  }
+  return ret;
+}
+
+static std::vector<TextSpan> split_sentences(const std::string &content)
+{
+  std::vector<TextSpan> spans;
+  size_t pos = 0;
+  while (pos < content.length()) {
+    while (pos < content.length() && std::isspace(static_cast<unsigned char>(content[pos]))) {
+      ++pos;
+    }
+    if (pos >= content.length()) {
+      break;
+    }
+    const size_t start = pos;
+    while (pos < content.length()
+           && content[pos] != '.'
+           && content[pos] != '!'
+           && content[pos] != '?') {
+      ++pos;
+    }
+    if (pos < content.length()) {
+      ++pos;
+    }
+    const size_t end = pos;
+    if (end > start) {
+      spans.push_back(TextSpan{static_cast<int64_t>(start),
+                               static_cast<int64_t>(end - start),
+                               content.substr(start, end - start)});
+    }
+  }
+  return spans;
+}
+
+static std::vector<TextSpan> split_words(const std::string &content)
+{
+  std::vector<TextSpan> spans;
+  size_t pos = 0;
+  while (pos < content.length()) {
+    while (pos < content.length() && std::isspace(static_cast<unsigned char>(content[pos]))) {
+      ++pos;
+    }
+    if (pos >= content.length()) {
+      break;
+    }
+    const size_t start = pos;
+    while (pos < content.length() && !std::isspace(static_cast<unsigned char>(content[pos]))) {
+      ++pos;
+    }
+    spans.push_back(TextSpan{static_cast<int64_t>(start),
+                             static_cast<int64_t>(pos - start),
+                             content.substr(start, pos - start)});
+  }
+  return spans;
+}
+
+static int build_window_chunks(ObIAllocator &allocator,
+                               const std::vector<TextSpan> &units,
+                               const int64_t max_units,
+                               const int64_t overlap,
+                               const bool by_word,
+                               const std::string &prefix,
+                               ObIArray<ObAISplitDocumentChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+  const int64_t safe_max = std::max<int64_t>(1, max_units);
+  const int64_t safe_overlap = std::max<int64_t>(0, std::min<int64_t>(overlap, safe_max - 1));
+  const int64_t step = std::max<int64_t>(1, safe_max - safe_overlap);
+  for (int64_t start = 0; OB_SUCC(ret) && start < static_cast<int64_t>(units.size()); start += step) {
+    const int64_t end = std::min<int64_t>(start + safe_max, units.size());
+    std::string text = prefix;
+    for (int64_t i = start; i < end; ++i) {
+      if (i > start) {
+        text.append(by_word ? " " : " ");
+      }
+      text.append(units[i].text_);
+    }
+    const int64_t offset = units[start].offset_;
+    if (OB_FAIL(copy_chunk_text(allocator, text, offset, chunks))) {
+      LOG_WARN("failed to copy chunk text", K(ret));
+    }
+    if (end >= static_cast<int64_t>(units.size())) {
+      break;
+    }
+  }
+  return ret;
+}
+
+static int build_markdown_sentence_chunks(ObIAllocator &allocator,
+                                          const std::string &content,
+                                          const int64_t max_units,
+                                          const int64_t overlap,
+                                          ObIArray<ObAISplitDocumentChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+  size_t line_start = 0;
+  std::string heading;
+  std::string section_text;
+  int64_t section_offset = 0;
+  auto flush_section = [&]() -> int {
+    int tmp_ret = OB_SUCCESS;
+    if (!section_text.empty()) {
+      std::vector<TextSpan> sentences = split_sentences(section_text);
+      for (size_t i = 0; i < sentences.size(); ++i) {
+        sentences[i].offset_ += section_offset;
+      }
+      const std::string prefix = heading.empty() ? std::string() : heading + "\n";
+      tmp_ret = build_window_chunks(allocator, sentences, max_units, overlap, false, prefix, chunks);
+    }
+    section_text.clear();
+    return tmp_ret;
+  };
+
+  while (OB_SUCC(ret) && line_start <= content.length()) {
+    size_t line_end = content.find('\n', line_start);
+    if (line_end == std::string::npos) {
+      line_end = content.length();
+    }
+    const std::string line = content.substr(line_start, line_end - line_start);
+    if (!line.empty() && line[0] == '#') {
+      if (OB_FAIL(flush_section())) {
+        LOG_WARN("failed to flush markdown section", K(ret));
+      } else {
+        heading = line;
+        section_offset = static_cast<int64_t>(line_end < content.length() ? line_end + 1 : line_end);
+      }
+    } else {
+      if (section_text.empty()) {
+        section_offset = static_cast<int64_t>(line_start);
+      } else {
+        section_text.append("\n");
+      }
+      section_text.append(line);
+    }
+    if (line_end >= content.length()) {
+      break;
+    }
+    line_start = line_end + 1;
+  }
+  if (OB_SUCC(ret) && OB_FAIL(flush_section())) {
+    LOG_WARN("failed to flush last markdown section", K(ret));
+  }
+  return ret;
+}
+
+} // namespace
+
+ObExprAISplitDocument::ObExprAISplitDocument(ObIAllocator &alloc)
+  : ObStringExprOperator(alloc, T_FUN_SYS_AI_SPLIT_DOCUMENT, N_AI_SPLIT_DOCUMENT,
+                         MORE_THAN_ZERO, NOT_VALID_FOR_GENERATED_COL)
+{
+}
+
+ObExprAISplitDocument::~ObExprAISplitDocument()
+{
+}
+
+int ObExprAISplitDocument::calc_result_typeN(ObExprResType &type,
+                                             ObExprResType *types,
+                                             int64_t param_num,
+                                             ObExprTypeCtx &type_ctx) const
+{
+  int ret = OB_SUCCESS;
+  UNUSED(type_ctx);
+  if (OB_UNLIKELY(param_num < 1 || param_num > 2)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid ai_split_document argument count", K(ret), K(param_num));
+  } else {
+    type.set_varchar();
+    type.set_collation_type(ObCharset::get_system_collation());
+    type.set_length(OB_MAX_VARCHAR_LENGTH);
+    for (int64_t i = 0; i < param_num; ++i) {
+      types[i].set_calc_type(ObVarcharType);
+      types[i].set_calc_collation_type(ObCharset::get_system_collation());
+    }
+  }
+  return ret;
+}
+
+int ObExprAISplitDocument::eval_ai_split_document(const ObExpr &expr,
+                                                  ObEvalCtx &ctx,
+                                                  ObDatum &expr_datum)
+{
+  UNUSED(expr);
+  UNUSED(ctx);
+  expr_datum.set_null();
+  return OB_SUCCESS;
+}
+
+int ObExprAISplitDocument::build_chunks(ObIAllocator &allocator,
+                                        const ObString &content,
+                                        const ObString &params,
+                                        ObIArray<ObAISplitDocumentChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+  const std::string content_str = to_std_string(content);
+  const std::string params_str = to_std_string(params);
+  const bool is_text = json_contains_string(params_str, "type", "text");
+  const bool by_sentence = json_contains_string(params_str, "by", "sentence");
+  const int64_t max_units = json_int_value(params_str, "max", 256);
+  const int64_t overlap = json_int_value(params_str, "overlap", 0);
+
+  if (!is_text && by_sentence) {
+    if (OB_FAIL(build_markdown_sentence_chunks(allocator, content_str, max_units, overlap, chunks))) {
+      LOG_WARN("failed to split markdown document", K(ret));
+    }
+  } else if (by_sentence) {
+    std::vector<TextSpan> sentences = split_sentences(content_str);
+    if (OB_FAIL(build_window_chunks(allocator, sentences, max_units, overlap, false,
+                                    std::string(), chunks))) {
+      LOG_WARN("failed to split text sentences", K(ret));
+    }
+  } else {
+    std::vector<TextSpan> words = split_words(content_str);
+    if (OB_FAIL(build_window_chunks(allocator, words, max_units, overlap, true,
+                                    std::string(), chunks))) {
+      LOG_WARN("failed to split text words", K(ret));
+    }
+  }
+  return ret;
+}
+
+int ObExprAISplitDocument::cg_expr(ObExprCGCtx &op_cg_ctx,
+                                   const ObRawExpr &raw_expr,
+                                   ObExpr &rt_expr) const
+{
+  UNUSED(op_cg_ctx);
+  UNUSED(raw_expr);
+  rt_expr.eval_func_ = ObExprAISplitDocument::eval_ai_split_document;
+  return OB_SUCCESS;
+}
+
+}
+}

--- a/src/sql/engine/expr/ob_expr_ai_split_document.h
+++ b/src/sql/engine/expr/ob_expr_ai_split_document.h
@@ -24,6 +24,7 @@ struct ObAISplitDocumentChunk
   int64_t offset_;
   int64_t length_;
   common::ObString text_;
+  TO_STRING_KV(K_(offset), K_(length), K_(text));
 };
 
 class ObExprAISplitDocument : public ObStringExprOperator

--- a/src/sql/engine/expr/ob_expr_ai_split_document.h
+++ b/src/sql/engine/expr/ob_expr_ai_split_document.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_AI_SPLIT_DOCUMENT_H_
+#define OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_AI_SPLIT_DOCUMENT_H_
+
+#include "lib/container/ob_se_array.h"
+#include "lib/string/ob_string.h"
+#include "sql/engine/expr/ob_expr_operator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+struct ObAISplitDocumentChunk
+{
+  ObAISplitDocumentChunk() : offset_(0), length_(0), text_() {}
+  ObAISplitDocumentChunk(int64_t offset, int64_t length, const common::ObString &text)
+      : offset_(offset), length_(length), text_(text) {}
+  int64_t offset_;
+  int64_t length_;
+  common::ObString text_;
+};
+
+class ObExprAISplitDocument : public ObStringExprOperator
+{
+public:
+  explicit ObExprAISplitDocument(common::ObIAllocator &alloc);
+  virtual ~ObExprAISplitDocument();
+  virtual int calc_result_typeN(ObExprResType &type,
+                                ObExprResType *types,
+                                int64_t param_num,
+                                common::ObExprTypeCtx &type_ctx) const override;
+  static int eval_ai_split_document(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum);
+  static int build_chunks(common::ObIAllocator &allocator,
+                          const common::ObString &content,
+                          const common::ObString &params,
+                          common::ObIArray<ObAISplitDocumentChunk> &chunks);
+  virtual int cg_expr(ObExprCGCtx &op_cg_ctx,
+                      const ObRawExpr &raw_expr,
+                      ObExpr &rt_expr) const override;
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObExprAISplitDocument);
+};
+
+}
+}
+
+#endif

--- a/src/sql/engine/expr/ob_expr_eval_functions.cpp
+++ b/src/sql/engine/expr/ob_expr_eval_functions.cpp
@@ -388,6 +388,8 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
 #include "ob_expr_vector_similarity.h"
 #include "ob_expr_check_location_access.h"
+#include "ob_expr_load_file.h"
+#include "ob_expr_ai_split_document.h"
 
 namespace oceanbase
 {
@@ -1341,6 +1343,8 @@ static ObExpr::EvalFunc g_expr_eval_functions[] = {
   ObExprVectorCosineSimilarity::calc_cosine_similarity,                /* 872 */
   ObExprVectorIPSimilarity::calc_ip_similarity,                        /* 873 */
   ObExprVectorSimilarity::calc_similarity,                             /* 874 */
+  ObExprLoadFile::eval_load_file,                                      /* 875 */
+  ObExprAISplitDocument::eval_ai_split_document,                       /* 876 */
 };
 
 static ObExpr::EvalBatchFunc g_expr_eval_batch_functions[] = {

--- a/src/sql/engine/expr/ob_expr_load_file.cpp
+++ b/src/sql/engine/expr/ob_expr_load_file.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+
+#include "sql/engine/expr/ob_expr_load_file.h"
+
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include "lib/ob_errno.h"
+#include "lib/oblog/ob_log_module.h"
+#include "share/schema/ob_location_schema_struct.h"
+#include "share/schema/ob_schema_getter_guard.h"
+#include "sql/engine/ob_exec_context.h"
+
+namespace oceanbase
+{
+using namespace common;
+using namespace share::schema;
+namespace sql
+{
+
+ObExprLoadFile::ObExprLoadFile(ObIAllocator &alloc)
+  : ObStringExprOperator(alloc, T_FUN_SYS_LOAD_FILE, N_LOAD_FILE, 2,
+                         NOT_VALID_FOR_GENERATED_COL, NOT_ROW_DIMENSION)
+{
+}
+
+ObExprLoadFile::~ObExprLoadFile()
+{
+}
+
+int ObExprLoadFile::calc_result_type2(ObExprResType &type,
+                                      ObExprResType &type1,
+                                      ObExprResType &type2,
+                                      ObExprTypeCtx &type_ctx) const
+{
+  int ret = OB_SUCCESS;
+  UNUSED(type_ctx);
+  type.set_blob();
+  type.set_collation_type(CS_TYPE_BINARY);
+  type.set_accuracy(ObAccuracy::DDL_DEFAULT_ACCURACY[ObLongTextType]);
+  type1.set_calc_type(ObVarcharType);
+  type1.set_calc_collation_type(ObCharset::get_system_collation());
+  type2.set_calc_type(ObVarcharType);
+  type2.set_calc_collation_type(ObCharset::get_system_collation());
+  return ret;
+}
+
+int ObExprLoadFile::eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum)
+{
+  int ret = OB_SUCCESS;
+  ObDatum *location_name = NULL;
+  ObDatum *file_name = NULL;
+  ObSchemaGetterGuard schema_guard;
+  const ObLocationSchema *location_schema = NULL;
+
+  if (OB_UNLIKELY(expr.arg_cnt_ != 2)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid load_file argument count", K(ret), K(expr.arg_cnt_));
+  } else if (OB_FAIL(expr.args_[0]->eval(ctx, location_name))
+             || OB_FAIL(expr.args_[1]->eval(ctx, file_name))) {
+    LOG_WARN("failed to eval load_file arguments", K(ret));
+  } else if (location_name->is_null() || file_name->is_null()) {
+    expr_datum.set_null();
+  } else if (OB_ISNULL(GCTX.schema_service_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("schema service is null", K(ret));
+  } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+    LOG_WARN("failed to get schema guard", K(ret));
+  } else if (OB_FAIL(schema_guard.get_location_schema_by_name(location_name->get_string(),
+                                                              location_schema))) {
+    LOG_WARN("failed to get location schema", K(ret), K(location_name->get_string()));
+  } else if (OB_ISNULL(location_schema)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("location schema is null", K(ret));
+  } else {
+    const ObString url = location_schema->get_location_url_str();
+    const ObString name = file_name->get_string();
+    const char *file_prefix = "file://";
+    const int64_t file_prefix_len = 7;
+    if (url.length() < file_prefix_len
+        || 0 != STRNCASECMP(url.ptr(), file_prefix, file_prefix_len)) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "load_file only supports file:// location");
+    } else {
+      std::string path(url.ptr() + file_prefix_len, url.length() - file_prefix_len);
+      if (!path.empty() && path[path.length() - 1] != '/' && path[path.length() - 1] != '\\') {
+        path.append("/");
+      }
+      path.append(name.ptr(), name.length());
+
+      std::ifstream input(path.c_str(), std::ios::in | std::ios::binary);
+      if (!input.good()) {
+        ret = OB_IO_ERROR;
+        LOG_WARN("failed to open load_file path", K(ret), K(path.c_str()));
+      } else {
+        std::string content((std::istreambuf_iterator<char>(input)),
+                            std::istreambuf_iterator<char>());
+        char *buf = NULL;
+        if (content.empty()) {
+          expr_datum.set_string("");
+        } else if (OB_ISNULL(buf = expr.get_str_res_mem(ctx, content.length()))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          LOG_WARN("failed to allocate load_file result", K(ret), K(content.length()));
+        } else {
+          MEMCPY(buf, content.data(), content.length());
+          expr_datum.set_string(buf, static_cast<ObString::obstr_size_t>(content.length()));
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::cg_expr(ObExprCGCtx &op_cg_ctx,
+                            const ObRawExpr &raw_expr,
+                            ObExpr &rt_expr) const
+{
+  UNUSED(op_cg_ctx);
+  UNUSED(raw_expr);
+  rt_expr.eval_func_ = ObExprLoadFile::eval_load_file;
+  return OB_SUCCESS;
+}
+
+}
+}

--- a/src/sql/engine/expr/ob_expr_load_file.cpp
+++ b/src/sql/engine/expr/ob_expr_load_file.cpp
@@ -27,7 +27,7 @@ namespace sql
 
 ObExprLoadFile::ObExprLoadFile(ObIAllocator &alloc)
   : ObStringExprOperator(alloc, T_FUN_SYS_LOAD_FILE, N_LOAD_FILE, 2,
-                         NOT_VALID_FOR_GENERATED_COL, NOT_ROW_DIMENSION)
+                         NOT_VALID_FOR_GENERATED_COL)
 {
 }
 
@@ -102,15 +102,11 @@ int ObExprLoadFile::eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &
       } else {
         std::string content((std::istreambuf_iterator<char>(input)),
                             std::istreambuf_iterator<char>());
-        char *buf = NULL;
-        if (content.empty()) {
-          expr_datum.set_string("");
-        } else if (OB_ISNULL(buf = expr.get_str_res_mem(ctx, content.length()))) {
-          ret = OB_ALLOCATE_MEMORY_FAILED;
-          LOG_WARN("failed to allocate load_file result", K(ret), K(content.length()));
-        } else {
-          MEMCPY(buf, content.data(), content.length());
-          expr_datum.set_string(buf, static_cast<ObString::obstr_size_t>(content.length()));
+        const ObString file_content(static_cast<ObString::obstr_size_t>(content.length()),
+                                    content.data());
+        if (OB_FAIL(ObExprUtil::set_expr_ascii_result(expr, ctx, expr_datum,
+                                                      file_content, true, CS_TYPE_BINARY))) {
+          LOG_WARN("failed to build load_file lob result", K(ret), K(content.length()));
         }
       }
     }

--- a/src/sql/engine/expr/ob_expr_load_file.h
+++ b/src/sql/engine/expr/ob_expr_load_file.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_H_
+#define OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_H_
+
+#include "sql/engine/expr/ob_expr_operator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+class ObExprLoadFile : public ObStringExprOperator
+{
+public:
+  explicit ObExprLoadFile(common::ObIAllocator &alloc);
+  virtual ~ObExprLoadFile();
+  virtual int calc_result_type2(ObExprResType &type,
+                                ObExprResType &type1,
+                                ObExprResType &type2,
+                                common::ObExprTypeCtx &type_ctx) const override;
+  static int eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum);
+  virtual int cg_expr(ObExprCGCtx &op_cg_ctx,
+                      const ObRawExpr &raw_expr,
+                      ObExpr &rt_expr) const override;
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObExprLoadFile);
+};
+
+}
+}
+
+#endif

--- a/src/sql/engine/expr/ob_expr_operator_factory.cpp
+++ b/src/sql/engine/expr/ob_expr_operator_factory.cpp
@@ -442,6 +442,8 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
 #include "sql/engine/expr/ob_expr_vector_similarity.h"
 #include "sql/engine/expr/ob_expr_check_location_access.h"
+#include "sql/engine/expr/ob_expr_load_file.h"
+#include "sql/engine/expr/ob_expr_ai_split_document.h"
 
 
 #include "sql/engine/expr/ob_expr_lock_func.h"
@@ -1148,6 +1150,8 @@ void ObExprOperatorFactory::register_expr_operators()
     REG_OP(ObExprAIRerank);
     REG_OP(ObExprAIPrompt);
     REG_OP(ObExprCheckLocationAccess);
+    REG_OP(ObExprLoadFile);
+    REG_OP(ObExprAISplitDocument);
   }();
 }
 
@@ -1332,4 +1336,3 @@ void ObExprOperatorFactory::get_function_alias_name(const ObString &origin_name,
 
 } //end sql
 } //end oceanbase
-

--- a/src/sql/engine/expr/ob_expr_tokenize.cpp
+++ b/src/sql/engine/expr/ob_expr_tokenize.cpp
@@ -21,6 +21,7 @@
 #include "lib/charset/ob_charset.h"
 #include "common/json_type/ob_json_base.h"
 #include "common/json_type/ob_json_tree.h"
+#include "lib/hash_func/murmur_hash.h"
 #include "lib/ob_errno.h"
 #include "lib/oblog/ob_log_module.h"
 #include "lib/string/ob_string.h"
@@ -30,6 +31,8 @@
 #include "sql/resolver/ddl/ob_fts_index_builder_util.h"
 #include "share/ob_json_access_utils.h"
 #include "storage/fts/dict/ob_gen_dic_loader.h"
+#include "storage/fts/dict/ob_ft_dict_hub.h"
+#include "storage/fts/ob_fts_literal.h"
 #include "storage/fts/ob_fts_parser_property.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
 
@@ -40,6 +43,183 @@ namespace oceanbase
 {
 namespace sql
 {
+namespace
+{
+
+// Repeated TOKENIZE calls commonly use a literal document and parser.  Keep a
+// tiny per-worker cache of the serialized JSON result so the regular parser
+// path remains untouched for dynamic properties and user-defined parsers.
+class ObTokenizeResultCache final
+{
+public:
+  static constexpr int64_t SLOT_COUNT = 4;
+  static constexpr int64_t MAX_TEXT_LENGTH = 4096;
+  static constexpr int64_t MAX_PARSER_LENGTH = 32;
+  static constexpr int64_t MAX_RESULT_LENGTH = 32768;
+
+  struct Key
+  {
+    Key()
+        : text_(), parser_(), collation_(CS_TYPE_INVALID), dictionary_epoch_(0), hash_(0)
+    {}
+
+    void calculate_hash()
+    {
+      uint64_t value = common::murmurhash(text_.ptr(), text_.length(), 0);
+      value = common::murmurhash(parser_.ptr(), parser_.length(), value);
+      value = common::murmurhash(&collation_, sizeof(collation_), value);
+      hash_ = common::murmurhash(&dictionary_epoch_, sizeof(dictionary_epoch_), value);
+    }
+
+    ObString text_;
+    ObString parser_;
+    ObCollationType collation_;
+    uint64_t dictionary_epoch_;
+    uint64_t hash_;
+  };
+
+  ObTokenizeResultCache() : entries_() {}
+
+  static bool supports(const Key &key)
+  {
+    return key.text_.length() <= MAX_TEXT_LENGTH
+        && key.parser_.length() <= MAX_PARSER_LENGTH;
+  }
+
+  bool find(const Key &key, ObString &result) const
+  {
+    const Entry &entry = entries_[key.hash_ & (SLOT_COUNT - 1)];
+    const bool found = entry.matches(key);
+    if (found) {
+      result.assign_ptr(entry.result_, entry.result_length_);
+    } else {
+      result.reset();
+    }
+    return found;
+  }
+
+  void put(const Key &key, const ObString &result)
+  {
+    if (supports(key) && result.length() <= MAX_RESULT_LENGTH) {
+      entries_[key.hash_ & (SLOT_COUNT - 1)].assign(key, result);
+    }
+  }
+
+private:
+  struct Entry
+  {
+    Entry()
+        : text_(), parser_(), result_(), hash_(0), dictionary_epoch_(0),
+          collation_(CS_TYPE_INVALID), text_length_(0), parser_length_(0),
+          result_length_(0), valid_(false)
+    {}
+
+    bool matches(const Key &key) const
+    {
+      return valid_
+          && hash_ == key.hash_
+          && dictionary_epoch_ == key.dictionary_epoch_
+          && collation_ == key.collation_
+          && text_length_ == key.text_.length()
+          && parser_length_ == key.parser_.length()
+          && (0 == text_length_ || 0 == MEMCMP(text_, key.text_.ptr(), text_length_))
+          && (0 == parser_length_ || 0 == MEMCMP(parser_, key.parser_.ptr(), parser_length_));
+    }
+
+    void assign(const Key &key, const ObString &result)
+    {
+      hash_ = key.hash_;
+      dictionary_epoch_ = key.dictionary_epoch_;
+      collation_ = key.collation_;
+      text_length_ = key.text_.length();
+      parser_length_ = key.parser_.length();
+      result_length_ = result.length();
+      if (text_length_ > 0) {
+        MEMCPY(text_, key.text_.ptr(), text_length_);
+      }
+      if (parser_length_ > 0) {
+        MEMCPY(parser_, key.parser_.ptr(), parser_length_);
+      }
+      if (result_length_ > 0) {
+        MEMCPY(result_, result.ptr(), result_length_);
+      }
+      valid_ = true;
+    }
+
+    char text_[MAX_TEXT_LENGTH];
+    char parser_[MAX_PARSER_LENGTH];
+    char result_[MAX_RESULT_LENGTH];
+    uint64_t hash_;
+    uint64_t dictionary_epoch_;
+    ObCollationType collation_;
+    int32_t text_length_;
+    int32_t parser_length_;
+    int32_t result_length_;
+    bool valid_;
+  };
+
+  Entry entries_[SLOT_COUNT];
+  DISALLOW_COPY_AND_ASSIGN(ObTokenizeResultCache);
+};
+
+bool is_builtin_parser(const ObString &parser)
+{
+  return 0 == parser.case_compare(storage::ObFTSLiteral::PARSER_NAME_SPACE)
+      || 0 == parser.case_compare(storage::ObFTSLiteral::PARSER_NAME_NGRAM)
+      || 0 == parser.case_compare(storage::ObFTSLiteral::PARSER_NAME_BENG)
+      || 0 == parser.case_compare(storage::ObFTSLiteral::PARSER_NAME_IK)
+      || 0 == parser.case_compare(storage::ObFTSLiteral::PARSER_NAME_NGRAM2);
+}
+
+int prepare_tokenize_cache_key(const ObExpr &expr,
+                               ObEvalCtx &ctx,
+                               ObTokenizeResultCache::Key &key,
+                               bool &cacheable)
+{
+  int ret = OB_SUCCESS;
+  ObDatum *text_datum = nullptr;
+  ObDatum *parser_datum = nullptr;
+  cacheable = false;
+  if (expr.arg_cnt_ > 2 || expr.args_[0]->obj_meta_.has_lob_header()) {
+    // JSON properties and LOB locators use the normal evaluation path.
+  } else if (OB_FAIL(expr.args_[0]->eval(ctx, text_datum))) {
+    LOG_WARN("fail to evaluate tokenize text for cache", K(ret));
+  } else if (OB_ISNULL(text_datum) || text_datum->is_null()) {
+    // Preserve the normal NULL handling path.
+  } else if (expr.arg_cnt_ >= 2 && OB_FAIL(expr.args_[1]->eval(ctx, parser_datum))) {
+    LOG_WARN("fail to evaluate tokenize parser for cache", K(ret));
+  } else {
+    key.text_ = text_datum->get_string();
+    key.parser_ = expr.arg_cnt_ < 2 || OB_ISNULL(parser_datum) || parser_datum->is_null()
+        ? ObString::make_string(OB_DEFAULT_FULLTEXT_PARSER_NAME)
+        : parser_datum->get_string().trim();
+    key.collation_ = expr.args_[0]->obj_meta_.get_collation_type();
+    if (!is_builtin_parser(key.parser_)) {
+      // A user parser may depend on state outside the built-in dictionary hub.
+    } else if (0 == key.parser_.case_compare(storage::ObFTSLiteral::PARSER_NAME_IK)) {
+      storage::ObFTDictHub *dict_hub = nullptr;
+      const int tmp_ret = storage::ObFTParsePluginData::instance().get_dict_hub(dict_hub);
+      if (OB_SUCCESS == tmp_ret && OB_NOT_NULL(dict_hub)) {
+        key.dictionary_epoch_ = dict_hub->get_generation_epoch();
+        key.calculate_hash();
+        cacheable = ObTokenizeResultCache::supports(key);
+      }
+    } else {
+      key.calculate_hash();
+      cacheable = ObTokenizeResultCache::supports(key);
+    }
+  }
+  return ret;
+}
+
+ObTokenizeResultCache &get_tokenize_result_cache()
+{
+  static thread_local ObTokenizeResultCache cache;
+  return cache;
+}
+
+} // namespace
+
 ObExprTokenize::ObExprTokenize(common::ObIAllocator &alloc)
     : ObStringExprOperator(alloc,
                            T_FUN_TOKENIZE,
@@ -60,20 +240,39 @@ int ObExprTokenize::eval_tokenize(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &e
 
   ObIJsonBase *json_result = nullptr;
   TokenizeParam param;
+  ObTokenizeResultCache::Key cache_key;
+  ObString cached_result;
+  bool cacheable = false;
+  bool cache_hit = false;
 
   // check param num, which is checked in ObExprOperator::calc_result_typeN.
   if (OB_UNLIKELY(expr.arg_cnt_ < 1 || expr.arg_cnt_ > 3)) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Args count invalid.", K(ret), K(expr.arg_cnt_));
+  } else if (OB_FAIL(prepare_tokenize_cache_key(expr, ctx, cache_key, cacheable))) {
+    LOG_WARN("fail to prepare tokenize cache key", K(ret));
+  } else if (cacheable
+      && FALSE_IT(cache_hit = get_tokenize_result_cache().find(cache_key, cached_result))) {
+  } else if (cache_hit) {
+    if (OB_FAIL(ObJsonExprHelper::pack_json_str_res(expr, ctx, expr_datum, cached_result))) {
+      LOG_WARN("fail to pack cached tokenize result", K(ret));
+    }
   } else if (OB_FAIL(parse_param(expr, ctx, temp_allocator, param))) {
     LOG_WARN("Fail to parse param", K(ret));
   } else if (OB_FAIL(tokenize_fulltext(param, param.output_mode_, temp_allocator, json_result))) {
     LOG_WARN("Fail to tokenize fulltext", K(ret));
-  } else if (OB_FAIL(ObJsonExprHelper::pack_json_res(expr,
-                                                     ctx,
-                                                     temp_allocator,
-                                                     json_result,
-                                                     expr_datum))) {
+  } else if (cacheable) {
+    ObString raw_binary;
+    if (OB_FAIL(ObJsonWrapper::get_raw_binary(json_result, raw_binary, &temp_allocator))) {
+      LOG_WARN("fail to serialize tokenize result", K(ret));
+    } else {
+      get_tokenize_result_cache().put(cache_key, raw_binary);
+      if (OB_FAIL(ObJsonExprHelper::pack_json_str_res(expr, ctx, expr_datum, raw_binary))) {
+        LOG_WARN("fail to pack tokenize result", K(ret));
+      }
+    }
+  } else if (OB_FAIL(ObJsonExprHelper::pack_json_res(
+      expr, ctx, temp_allocator, json_result, expr_datum))) {
     LOG_WARN("fail to pack json result", K(ret));
   }
 

--- a/src/sql/engine/table/ob_table_scan_op.cpp
+++ b/src/sql/engine/table/ob_table_scan_op.cpp
@@ -763,6 +763,8 @@ ObTableScanOp::ObTableScanOp(ObExecContext &exec_ctx, const ObOpSpec &spec, ObOp
     in_rescan_(false),
     domain_index_(),
     fts_index_(),
+    fts_expr_cache_(),
+    fts_lob_allocator_(ObModIds::OB_LOB_ACCESS_BUFFER),
     output_   (nullptr),
     fold_iter_(nullptr),
     iter_tree_(nullptr),
@@ -1678,6 +1680,8 @@ int ObTableScanOp::inner_open()
   } else if (MY_SPEC.is_fts_ddl_ && OB_FAIL(fts_index_.init(MY_SPEC.is_fts_index_aux_, MY_SPEC.parser_name_,
           MY_SPEC.parser_properties_))) {
     LOG_WARN("fail to init fts index cache", K(ret));
+  } else if (MY_SPEC.is_fts_ddl_ && OB_FAIL(init_fts_expr_cache())) {
+    LOG_WARN("fail to initialize fulltext expression cache", K(ret));
   } else {
     if (MY_SPEC.report_col_checksum_) {
       if (PHY_TABLE_SCAN == MY_SPEC.get_type()) {
@@ -1773,6 +1777,7 @@ int ObTableScanOp::inner_close()
 
   if (OB_SUCC(ret)) {
     fts_index_.reuse();
+    fts_lob_allocator_.reset_remain_one_page();
     iter_end_ = false;
     need_init_before_get_row_ = true;
     rand_scan_processor_.reset();
@@ -4041,8 +4046,10 @@ int ObTableScanOp::fetch_next_fts_index_rows()
   int ret = OB_SUCCESS;
   bool has_segment_word = false;
   while (OB_SUCC(ret) && !has_segment_word) {
-    ObExpr *ft_expr = nullptr;
-    ObExpr *doc_id_expr = nullptr;
+    const int64_t word_idx = MY_SPEC.is_fts_index_aux_ ? 0 : 1;
+    const int64_t doc_id_idx = MY_SPEC.is_fts_index_aux_ ? 1 : 0;
+    ObExpr *ft_expr = fts_expr_cache_[word_idx];
+    ObExpr *doc_id_expr = fts_expr_cache_[doc_id_idx];
     ObDatum *ft_datum = nullptr;
     ObDatum *doc_id_datum = nullptr;
 
@@ -4050,10 +4057,6 @@ int ObTableScanOp::fetch_next_fts_index_rows()
       if (OB_ITER_END != ret) {
         LOG_WARN("fail to get next row implement", K(ret));
       }
-    } else if (OB_FAIL(get_output_fts_col_expr_by_type(T_FUN_SYS_DOC_ID, doc_id_expr))) {
-      LOG_WARN("fail to get doc id column expr from output", K(ret));
-    } else if (OB_FAIL(get_output_fts_col_expr_by_type(T_FUN_SYS_WORD_SEGMENT, ft_expr))) {
-      LOG_WARN("fail to get word segment column expr from output", K(ret));
     } else if (OB_ISNULL(ft_expr) || OB_ISNULL(doc_id_expr)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("unexpeted error, ft or doc id expr is nullptr", K(ret), KP(ft_expr), KP(doc_id_expr));
@@ -4066,8 +4069,8 @@ int ObTableScanOp::fetch_next_fts_index_rows()
       LOG_WARN("unexpeted error, ft or doc id datum is nullptr", K(ret), KP(ft_datum), KP(doc_id_datum));
     } else {
       ObString ft = ft_datum->get_string();
-      ObArenaAllocator tmp_allocator(ObModIds::OB_LOB_ACCESS_BUFFER, OB_MALLOC_NORMAL_BLOCK_SIZE);
-      if (OB_FAIL(ObTextStringHelper::read_real_string_data(tmp_allocator,
+      fts_lob_allocator_.reset_remain_one_page();
+      if (OB_FAIL(ObTextStringHelper::read_real_string_data(fts_lob_allocator_,
                                                             *ft_datum,
                                                             ft_expr->datum_meta_,
                                                             ft_expr->obj_meta_.has_lob_header(),
@@ -4090,15 +4093,15 @@ int ObTableScanOp::fill_generated_fts_cols(blocksstable::ObDatumRow *row)
 {
   int ret = OB_SUCCESS;
   const ObObjDatumMapType *types = MY_SPEC.is_fts_index_aux_ ? ObFTIndexRowCache::FTS_INDEX_TYPES : ObFTIndexRowCache::FTS_DOC_WORD_TYPES;
-  const ObExprOperatorType *expr_types = MY_SPEC.is_fts_index_aux_ ? ObFTIndexRowCache::FTS_INDEX_EXPR_TYPE : ObFTIndexRowCache::FTS_DOC_WORD_EXPR_TYPE;
   if (OB_ISNULL(row)) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument, row is nullptr", K(ret), KP(row));
   } else {
     for (int64_t i = 0; OB_SUCC(ret) && i < share::ObFtsIndexBuilderUtil::OB_FTS_INDEX_OR_DOC_WORD_TABLE_COL_CNT; ++i) {
-      ObExpr *expr = nullptr;
-      if (OB_FAIL(get_output_fts_col_expr_by_type(expr_types[i], expr))) {
-        LOG_WARN("fail to get fts column expr", K(ret), K(i), K(expr_types[i]));
+      ObExpr *expr = fts_expr_cache_[i];
+      if (OB_ISNULL(expr)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected null fulltext expression cache entry", K(ret), K(i));
       } else {
         ObDatum &datum = expr->locate_datum_for_write(eval_ctx_);
         ObEvalInfo &eval_info = expr->get_eval_info(eval_ctx_);
@@ -4109,6 +4112,23 @@ int ObTableScanOp::fill_generated_fts_cols(blocksstable::ObDatumRow *row)
           eval_info.projected_ = true;
         }
       }
+    }
+  }
+  return ret;
+}
+
+int ObTableScanOp::init_fts_expr_cache()
+{
+  int ret = OB_SUCCESS;
+  const ObExprOperatorType *expr_types = MY_SPEC.is_fts_index_aux_
+      ? ObFTIndexRowCache::FTS_INDEX_EXPR_TYPE
+      : ObFTIndexRowCache::FTS_DOC_WORD_EXPR_TYPE;
+  for (int64_t i = 0;
+       OB_SUCC(ret) && i < share::ObFtsIndexBuilderUtil::OB_FTS_INDEX_OR_DOC_WORD_TABLE_COL_CNT;
+       ++i) {
+    fts_expr_cache_[i] = nullptr;
+    if (OB_FAIL(get_output_fts_col_expr_by_type(expr_types[i], fts_expr_cache_[i]))) {
+      LOG_WARN("fail to cache fulltext output expression", K(ret), K(i), K(expr_types[i]));
     }
   }
   return ret;

--- a/src/sql/engine/table/ob_table_scan_op.h
+++ b/src/sql/engine/table/ob_table_scan_op.h
@@ -724,6 +724,7 @@ private:
   int inner_get_next_fts_index_row();
   int fetch_next_fts_index_rows();
   int fill_generated_fts_cols(ObDatumRow *row);
+  int init_fts_expr_cache();
   int get_output_fts_col_expr_by_type(const ObExprOperatorType &type, ObExpr *&expr);
   bool is_resume_point_saved();
 protected:
@@ -754,6 +755,8 @@ protected:
   bool in_rescan_;
   ObDomainIndexCache domain_index_;
   ObFTIndexRowCache fts_index_;
+  ObExpr *fts_expr_cache_[share::ObFtsIndexBuilderUtil::OB_FTS_INDEX_OR_DOC_WORD_TABLE_COL_CNT];
+  common::ObArenaAllocator fts_lob_allocator_;
 
   // output_ is used to output data, TSC operator directly invokes output_::get_next_row(s),
   // it points to fold_iter_ in group rescan and iter_tree_ in normal scan.

--- a/src/sql/optimizer/ob_log_plan.cpp
+++ b/src/sql/optimizer/ob_log_plan.cpp
@@ -14650,7 +14650,7 @@ int ObLogPlan::prepare_text_retrieval_scan(const ObIArray<ObRawExpr *> &scan_mat
   } else {
     ObTextRetrievalInfo &tr_info = table_scan->get_text_retrieval_info();
     tr_info.match_expr_ = match_against;
-    tr_info.pushdown_match_filter_ = match_pred;
+    tr_info.pushdown_match_filter_ = tr_info.need_calc_relevance_ ? match_pred : nullptr;
     // in new version, doc_id_idx_tid_ is invalid.
     table_scan->set_doc_id_index_table_id(tr_info.doc_id_idx_tid_);
     if (table_scan->is_vec_adaptive_scan() || table_scan->is_vec_idx_scan_post_filter()) {
@@ -14895,18 +14895,20 @@ int ObLogPlan::prepare_text_retrieval_info(const uint64_t ref_table_id,
     }
   }
   if (OB_SUCC(ret)) {
-    /*
-    if (OB_FAIL(ObTransformUtils::check_need_calc_match_score(get_optimizer_context().get_exec_ctx(),
-                                                              get_stmt(),
-                                                              match_against,
-                                                              need_calc_relevance,
-                                                              constraints))) {
+    if (BOOLEAN_MODE == match_against->get_mode_flag()) {
+      // Boolean syntax can encode required, excluded and grouped tokens.
+      need_calc_relevance = true;
+    } else if (OB_FAIL(ObTransformUtils::check_need_calc_match_score(
+        get_optimizer_context().get_exec_ctx(),
+        get_stmt(),
+        match_against,
+        need_calc_relevance,
+        constraints))) {
       LOG_WARN("failed to check need calc relevance", K(ret));
     } else if (!need_calc_relevance &&
                OB_FAIL(append_array_no_dup(get_optimizer_context().get_query_ctx()->all_expr_constraints_, constraints))) {
       LOG_WARN("failed to append array no dup", K(ret));
     }
-    */
     tr_info.match_expr_ = match_against;
     tr_info.inv_idx_tid_ = inv_idx_tid;
     tr_info.fwd_idx_tid_ = fwd_idx_tid;

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -977,6 +977,8 @@ typedef enum ObItemType
   T_FUN_SYS_EMBEDDED_VEC = 1928,
   T_FUN_SYS_AI_PROMPT = 1929,
   T_FUN_SYS_VEC_VISIBLE = 1930, // vector index table 5
+  T_FUN_SYS_LOAD_FILE = 1931,
+  T_FUN_SYS_AI_SPLIT_DOCUMENT = 1932,
 
   ///< @note add new sys function type before this line
   T_FUN_SYS_END = 2000,
@@ -1057,8 +1059,6 @@ typedef enum ObItemType
   T_FUN_SYS_AI_RERANK = 2084,
   T_FUN_MD5_CNN_WS = 2085,
   T_FUN_SYS_BUCKET = 2086,
-  T_FUN_SYS_LOAD_FILE = 2087,
-  T_FUN_SYS_AI_SPLIT_DOCUMENT = 2088,
   T_MAX_OP = 3000,
 
   //pseudo column, to mark the group iterator id

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -1057,6 +1057,8 @@ typedef enum ObItemType
   T_FUN_SYS_AI_RERANK = 2084,
   T_FUN_MD5_CNN_WS = 2085,
   T_FUN_SYS_BUCKET = 2086,
+  T_FUN_SYS_LOAD_FILE = 2087,
+  T_FUN_SYS_AI_SPLIT_DOCUMENT = 2088,
   T_MAX_OP = 3000,
 
   //pseudo column, to mark the group iterator id

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -13389,6 +13389,45 @@ relation_factor %prec LOWER_PARENS
   merge_nodes($$, result, T_INDEX_HINT_LIST, $7);
   malloc_non_terminal_node($$, result->malloc_pool_, T_ALIAS, 6, $1, $6, $$, $2, $3, $5);
 }
+| function_name '(' opt_expr_as_list ')' %prec LOWER_PARENS
+{
+  ParseNode *params = NULL;
+  ParseNode *func = NULL;
+  if (NULL != $3) {
+    merge_nodes(params, result, T_EXPR_LIST, $3);
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 2, $1, params);
+  } else {
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 1, $1);
+  }
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, func, NULL);
+  store_pl_ref_object_symbol(func, result, REF_FUNC);
+}
+| function_name '(' opt_expr_as_list ')' relation_name
+{
+  ParseNode *params = NULL;
+  ParseNode *func = NULL;
+  if (NULL != $3) {
+    merge_nodes(params, result, T_EXPR_LIST, $3);
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 2, $1, params);
+  } else {
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 1, $1);
+  }
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, func, $5);
+  store_pl_ref_object_symbol(func, result, REF_FUNC);
+}
+| function_name '(' opt_expr_as_list ')' AS relation_name
+{
+  ParseNode *params = NULL;
+  ParseNode *func = NULL;
+  if (NULL != $3) {
+    merge_nodes(params, result, T_EXPR_LIST, $3);
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 2, $1, params);
+  } else {
+    malloc_non_terminal_node(func, result->malloc_pool_, T_FUN_SYS, 1, $1);
+  }
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, func, $6);
+  store_pl_ref_object_symbol(func, result, REF_FUNC);
+}
 | TABLE '(' simple_expr ')' %prec LOWER_PARENS
 {
   malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, $3, NULL);

--- a/src/sql/resolver/dml/ob_dml_resolver.cpp
+++ b/src/sql/resolver/dml/ob_dml_resolver.cpp
@@ -9226,13 +9226,40 @@ int ObDMLResolver::resolve_function_table_column_item_sys_func(const TableItem &
   ObRawExpr *table_expr = NULL;
   ColumnItem *col_item = NULL;
   ObDMLStmt *stmt = get_stmt();
-  const ObUserDefinedType *user_type = NULL;
 
   CK (OB_NOT_NULL(stmt));
   CK (OB_LIKELY(table_item.is_function_table()));
   CK (OB_NOT_NULL(table_expr = table_item.function_table_expr_));
   OZ (table_expr->deduce_type(session_info_));
   if (OB_FAIL(ret)) { // do nothing ...
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == table_expr->get_expr_type()) {
+    common::ObObjMeta int_meta;
+    common::ObObjMeta text_meta;
+    ObAccuracy int_accuracy = ObAccuracy::DDL_DEFAULT_ACCURACY[ObIntType];
+    ObAccuracy text_accuracy = ObAccuracy::DDL_DEFAULT_ACCURACY[ObVarcharType];
+    const ObString column_names[] = {
+      ObString("chunk_id"),
+      ObString("chunk_offset"),
+      ObString("chunk_length"),
+      ObString("chunk_text")
+    };
+    int_meta.set_int();
+    text_meta.set_varchar();
+    text_meta.set_collation_type(ObCharset::get_system_collation());
+    text_accuracy.set_length(OB_MAX_VARCHAR_LENGTH);
+    for (int64_t i = 0; OB_SUCC(ret) && i < 4; ++i) {
+      col_item = stmt->get_column_item(table_item.table_id_, column_names[i]);
+      if (NULL == col_item) {
+        OZ (resolve_function_table_column_item(table_item,
+                                               i < 3 ? int_meta : text_meta,
+                                               i < 3 ? int_accuracy : text_accuracy,
+                                               column_names[i],
+                                               OB_APP_MIN_COLUMN_ID + i,
+                                               col_item));
+      }
+      CK (OB_NOT_NULL(col_item));
+      OZ (col_items.push_back(*col_item));
+    }
   } else if (!ObResolverUtils::is_expr_can_be_used_in_table_function(*table_expr)) {
     ret = OB_NOT_SUPPORTED;
     LOG_USER_ERROR(OB_NOT_SUPPORTED, "access rows from a non-nested table item");
@@ -9246,8 +9273,10 @@ int ObDMLResolver::resolve_function_table_column_item_sys_func(const TableItem &
                                            OB_APP_MIN_COLUMN_ID,
                                            col_item));
   }
-  CK (OB_NOT_NULL(col_item));
-  OZ (col_items.push_back(*col_item));
+  if (OB_SUCC(ret) && T_FUN_SYS_AI_SPLIT_DOCUMENT != table_expr->get_expr_type()) {
+    CK (OB_NOT_NULL(col_item));
+    OZ (col_items.push_back(*col_item));
+  }
   return ret;
 }
 

--- a/src/sql/resolver/dml/ob_dml_resolver.cpp
+++ b/src/sql/resolver/dml/ob_dml_resolver.cpp
@@ -8251,6 +8251,9 @@ int ObDMLResolver::resolve_function_table_column_item(const TableItem &table_ite
   OX (col_expr->set_ref_id(table_item.table_id_, column_id));
   OX (result_type.set_meta(meta_type));
   OX (result_type.set_accuracy(accuracy));
+  if (ob_is_string_tc(result_type.get_type())) {
+    OX (result_type.set_collation_level(CS_LEVEL_IMPLICIT));
+  }
   OX (col_expr->set_result_type(result_type));
   if (table_item.get_object_name().empty()) {
     OX (col_expr->set_column_name(column_name));

--- a/src/sql/resolver/ob_resolver_utils.cpp
+++ b/src/sql/resolver/ob_resolver_utils.cpp
@@ -89,73 +89,83 @@ int ObResolverUtils::get_all_function_table_column_names(const TableItem &table_
   ObRawExpr *table_expr = NULL;
   ObPLPackageGuard *package_guard = nullptr;
   const ObUserDefinedType *user_type = NULL;
-  ObExecContext *exec_ctx = params.session_info_->get_cur_exec_ctx();
-  CK (OB_NOT_NULL(exec_ctx));
-  OZ (exec_ctx->get_package_guard(package_guard));
-  CK (OB_NOT_NULL(package_guard));
   CK (OB_LIKELY(table_item.is_function_table()));
   CK (OB_NOT_NULL(table_expr = table_item.function_table_expr_));
-  CK (table_expr->get_udt_id() != OB_INVALID_ID);
-
-  CK (OB_NOT_NULL(params.schema_checker_));
-  OZ (ObResolverUtils::get_user_type(
-    params.allocator_, params.session_info_, params.sql_proxy_,
-    params.schema_checker_->get_schema_guard(),
-    *package_guard,
-    table_expr->get_udt_id(), user_type));
-  CK (OB_NOT_NULL(user_type));
-  if (OB_SUCC(ret) && !user_type->is_collection_type()) {
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("function table get udf with return type not table type",
-             K(ret), K(user_type->is_collection_type()));
-    LOG_USER_ERROR(OB_NOT_SUPPORTED, "user define type is not collation type in function table");
-  }
-  const ObCollectionType *coll_type = NULL;
-  CK (OB_NOT_NULL(coll_type = static_cast<const ObCollectionType*>(user_type)));
-  if (OB_SUCC(ret)
-      && !coll_type->get_element_type().is_obj_type()
-      && !coll_type->get_element_type().is_record_type()
-      && !coll_type->get_element_type().is_collection_type()
-      && !(coll_type->get_element_type().is_opaque_type()
-            && coll_type->get_element_type().get_user_type_id() == T_OBJ_XML)) {
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("not suppoert type in table function", K(ret), KPC(coll_type));
-    ObString err;
-    err.write(coll_type->get_name().ptr(), coll_type->get_name().length());
-    err.write(" collation type in table function\0", sizeof(" collation type in table function\0"));
-    LOG_USER_ERROR(OB_NOT_SUPPORTED, err.ptr());
-  }
-  if (OB_SUCC(ret) && (coll_type->get_element_type().is_obj_type()
-                      || coll_type->get_element_type().is_opaque_type()
-                      || coll_type->get_element_type().is_collection_type())) {
+  if (OB_FAIL(ret)) {
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == table_expr->get_expr_type()) {
+    OZ (column_names.push_back(ObString("chunk_id")));
+    OZ (column_names.push_back(ObString("chunk_offset")));
+    OZ (column_names.push_back(ObString("chunk_length")));
+    OZ (column_names.push_back(ObString("chunk_text")));
+  } else if (!table_expr->get_result_type().is_ext()) {
     OZ (column_names.push_back(ObString("COLUMN_VALUE")));
-  }
-  if (OB_SUCC(ret) && coll_type->get_element_type().is_record_type()) {
-    const ObRecordType *record_type = NULL;
-    const ObUserDefinedType *user_type = NULL;
+  } else {
+    ObExecContext *exec_ctx = params.session_info_->get_cur_exec_ctx();
+    CK (OB_NOT_NULL(exec_ctx));
+    OZ (exec_ctx->get_package_guard(package_guard));
+    CK (OB_NOT_NULL(package_guard));
+    CK (table_expr->get_udt_id() != OB_INVALID_ID);
+
     CK (OB_NOT_NULL(params.schema_checker_));
     OZ (ObResolverUtils::get_user_type(
       params.allocator_, params.session_info_, params.sql_proxy_,
       params.schema_checker_->get_schema_guard(),
       *package_guard,
-      coll_type->get_element_type().get_user_type_id(), user_type));
+      table_expr->get_udt_id(), user_type));
     CK (OB_NOT_NULL(user_type));
-    CK (user_type->is_record_type());
-    CK (OB_NOT_NULL(record_type = static_cast<const ObRecordType *>(user_type)));
-    for (int64_t i = 0; OB_SUCC(ret) && i < record_type->get_member_count(); ++i) {
-      ObString name;
-      const ObString *member_name = record_type->get_record_member_name(i);
-      CK (OB_NOT_NULL(member_name));
+    if (OB_SUCC(ret) && !user_type->is_collection_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_WARN("function table get udf with return type not table type",
+              K(ret), K(user_type->is_collection_type()));
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "user define type is not collation type in function table");
+    }
+    const ObCollectionType *coll_type = NULL;
+    CK (OB_NOT_NULL(coll_type = static_cast<const ObCollectionType*>(user_type)));
+    if (OB_SUCC(ret)
+        && !coll_type->get_element_type().is_obj_type()
+        && !coll_type->get_element_type().is_record_type()
+        && !coll_type->get_element_type().is_collection_type()
+        && !(coll_type->get_element_type().is_opaque_type()
+              && coll_type->get_element_type().get_user_type_id() == T_OBJ_XML)) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_WARN("not suppoert type in table function", K(ret), KPC(coll_type));
+      ObString err;
+      err.write(coll_type->get_name().ptr(), coll_type->get_name().length());
+      err.write(" collation type in table function\0", sizeof(" collation type in table function\0"));
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, err.ptr());
+    }
+    if (OB_SUCC(ret) && (coll_type->get_element_type().is_obj_type()
+                        || coll_type->get_element_type().is_opaque_type()
+                        || coll_type->get_element_type().is_collection_type())) {
+      OZ (column_names.push_back(ObString("COLUMN_VALUE")));
+    }
+    if (OB_SUCC(ret) && coll_type->get_element_type().is_record_type()) {
+      const ObRecordType *record_type = NULL;
+      const ObUserDefinedType *record_user_type = NULL;
+      CK (OB_NOT_NULL(params.schema_checker_));
+      OZ (ObResolverUtils::get_user_type(
+        params.allocator_, params.session_info_, params.sql_proxy_,
+        params.schema_checker_->get_schema_guard(),
+        *package_guard,
+        coll_type->get_element_type().get_user_type_id(), record_user_type));
+      CK (OB_NOT_NULL(record_user_type));
+      CK (record_user_type->is_record_type());
+      CK (OB_NOT_NULL(record_type = static_cast<const ObRecordType *>(record_user_type)));
+      for (int64_t i = 0; OB_SUCC(ret) && i < record_type->get_member_count(); ++i) {
+        ObString name;
+        const ObString *member_name = record_type->get_record_member_name(i);
+        CK (OB_NOT_NULL(member_name));
 
-      if (OB_FAIL(ret)) {
-        // do nothing
-      } else if (PL_TYPE_PACKAGE == user_type->get_type_from()) {
-        OZ (ob_write_string(*params.allocator_, *member_name, name));
-      } else {
-        name = *member_name;
+        if (OB_FAIL(ret)) {
+          // do nothing
+        } else if (PL_TYPE_PACKAGE == record_user_type->get_type_from()) {
+          OZ (ob_write_string(*params.allocator_, *member_name, name));
+        } else {
+          name = *member_name;
+        }
+
+        OZ (column_names.push_back(name));
       }
-
-      OZ (column_names.push_back(name));
     }
   }
   return ret;

--- a/src/sql/rewrite/ob_transform_utils.cpp
+++ b/src/sql/rewrite/ob_transform_utils.cpp
@@ -14771,6 +14771,64 @@ bool ObTransformUtils::is_full_group_by(ObSelectStmt& stmt, ObSQLMode mode)
   return !stmt.has_order_by() && is_only_full_group_by_on(mode);
 }
 
+int ObTransformUtils::check_need_calc_match_score(ObExecContext *exec_ctx,
+                                                  const ObDMLStmt *stmt,
+                                                  ObRawExpr *match_expr,
+                                                  bool &need_calc,
+                                                  ObIArray<ObExprConstraint> &constraints)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<ObRawExpr *, 16> relation_exprs;
+  need_calc = false;
+  if (OB_ISNULL(exec_ctx) || OB_ISNULL(stmt) || OB_ISNULL(match_expr)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid argument", K(ret), KP(exec_ctx), KP(stmt), KP(match_expr));
+  } else if (OB_FAIL(stmt->get_relation_exprs(relation_exprs))) {
+    LOG_WARN("failed to collect relation expressions", K(ret));
+  }
+  for (int64_t i = 0; OB_SUCC(ret) && !need_calc && i < relation_exprs.count(); ++i) {
+    ObRawExpr *root_expr = relation_exprs.at(i);
+    ObSEArray<ObMatchFunRawExpr *, 2> match_exprs;
+    bool references_target = false;
+    bool used_as_condition = false;
+    bool root_needs_score = false;
+    if (OB_FAIL(ObRawExprUtils::extract_match_exprs(root_expr, match_exprs))) {
+      LOG_WARN("failed to extract match expressions", K(ret), K(i));
+    }
+    for (int64_t j = 0; OB_SUCC(ret) && !references_target && j < match_exprs.count(); ++j) {
+      references_target = match_exprs.at(j) == match_expr;
+    }
+    if (OB_FAIL(ret) || !references_target) {
+      // This relation expression does not use the target MATCH expression.
+    } else {
+      if (ObOptimizerUtil::find_item(stmt->get_condition_exprs(), root_expr)) {
+        used_as_condition = true;
+      } else if (stmt->is_select_stmt() && ObOptimizerUtil::find_item(
+          static_cast<const ObSelectStmt *>(stmt)->get_having_exprs(), root_expr)) {
+        used_as_condition = true;
+      } else if (OB_FAIL(check_expr_used_as_condition(stmt,
+                                                      root_expr,
+                                                      match_expr,
+                                                      used_as_condition))) {
+        LOG_WARN("failed to classify match expression usage", K(ret), K(i));
+      }
+      if (OB_FAIL(ret)) {
+      } else if (!used_as_condition) {
+        need_calc = true;
+      } else if (OB_FAIL(inner_check_need_calc_match_score(exec_ctx,
+                                                           root_expr,
+                                                           match_expr,
+                                                           root_needs_score,
+                                                           constraints))) {
+        LOG_WARN("failed to inspect match score usage", K(ret), K(i));
+      } else if (root_needs_score) {
+        need_calc = true;
+      }
+    }
+  }
+  return ret;
+}
+
 int ObTransformUtils::inner_check_need_calc_match_score(ObExecContext *exec_ctx,
                                                         ObRawExpr* expr, 
                                                         ObRawExpr* match_expr, 
@@ -14787,23 +14845,13 @@ int ObTransformUtils::inner_check_need_calc_match_score(ObExecContext *exec_ctx,
     need_calc = true;
     need_check_child = false;
   } else if (expr->get_expr_type() == T_OP_GT || expr->get_expr_type() == T_OP_LT) {
-    ObRawExpr *gt_param = NULL;
-    ObRawExpr *lt_param = NULL;
-    bool is_param_zero = false;
     if (expr->get_param_count() != 2 || OB_ISNULL(expr->get_param_expr(0)) || 
         OB_ISNULL(expr->get_param_expr(1))) {
       ret = OB_INVALID_ARGUMENT;
       LOG_WARN("invalid argument", K(ret));
-    } else if (OB_FALSE_IT(gt_param = expr->get_expr_type() == T_OP_GT ? expr->get_param_expr(0) : 
-                                                                         expr->get_param_expr(1))) {
-    } else if (OB_FALSE_IT(lt_param = expr->get_expr_type() == T_OP_GT ? expr->get_param_expr(1) : 
-                                                                         expr->get_param_expr(0))) {
-    } else if (gt_param != match_expr) {
-      /* do nothing */
-    } else if (OB_FAIL(check_expr_eq_zero(exec_ctx, lt_param, is_param_zero, constraints))) {
-      LOG_WARN("failed to check param eq zero", K(ret));
-    } else if (is_param_zero) {
-      need_calc = false;
+    } else if (expr->get_param_expr(0) == match_expr || expr->get_param_expr(1) == match_expr) {
+      // Numeric comparisons consume the MATCH score even when compared with zero.
+      need_calc = true;
       need_check_child = false;
     }
   } else if (expr->get_expr_type() == T_OP_BOOL) {
@@ -14876,7 +14924,7 @@ int ObTransformUtils::check_expr_eq_zero(ObExecContext *ctx,
   return ret;
 }
 
-int ObTransformUtils::check_expr_used_as_condition(ObDMLStmt *stmt, 
+int ObTransformUtils::check_expr_used_as_condition(const ObDMLStmt *stmt,
                                                   ObRawExpr *root_expr, 
                                                   ObRawExpr *expr, 
                                                   bool &used_as_condition)
@@ -14894,7 +14942,7 @@ int ObTransformUtils::check_expr_used_as_condition(ObDMLStmt *stmt,
   } else if (ObOptimizerUtil::find_item(stmt->get_condition_exprs(), cur_expr)) {
     parent_as_condition = true;
   } else if (stmt->is_select_stmt() && ObOptimizerUtil::find_item(
-             static_cast<ObSelectStmt*>(stmt)->get_having_exprs(), cur_expr)) {
+             static_cast<const ObSelectStmt*>(stmt)->get_having_exprs(), cur_expr)) {
     parent_as_condition = true;
   }
   if (OB_SUCC(ret)) {

--- a/src/sql/rewrite/ob_transform_utils.h
+++ b/src/sql/rewrite/ob_transform_utils.h
@@ -1885,6 +1885,11 @@ public:
   static int check_contain_lost_deterministic_expr(const ObIArray<ObRawExpr*> &exprs,
                                                    bool &is_contain);
   // check whether the score calculated by match expr is actually utilized
+  static int check_need_calc_match_score(ObExecContext *exec_ctx,
+                                         const ObDMLStmt *stmt,
+                                         ObRawExpr *match_expr,
+                                         bool &need_calc,
+                                         ObIArray<ObExprConstraint> &constraints);
   static int check_expr_eq_zero(ObExecContext *ctx,
                                 ObRawExpr *expr, 
                                 bool &eq_zero, 
@@ -1893,7 +1898,7 @@ public:
                                            const ObIArray<ObRawExpr*> &raw_having_exprs,
                                            const ObIArray<ObRawExpr*> &group_clause_exprs,
                                            ObIArray<ObRawExpr*> &having_exprs_for_deduce);
-  static int check_expr_used_as_condition(ObDMLStmt *stmt, 
+  static int check_expr_used_as_condition(const ObDMLStmt *stmt,
                                           ObRawExpr *root_expr, 
                                           ObRawExpr *expr,
                                           bool &used_as_condition);

--- a/src/storage/fts/dict/ob_ft_dict_hub.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_hub.cpp
@@ -45,6 +45,7 @@ int ObFTDictHub::init()
 int ObFTDictHub::destroy()
 {
   int ret = OB_SUCCESS;
+  ATOMIC_STORE(&generation_epoch_, 0);
   is_inited_ = false;
   return ret;
 }
@@ -144,6 +145,8 @@ int ObFTDictHub::put_dict_info(const ObFTDictInfoKey &key, const ObFTDictInfo &i
   const int cover_exist_flag = 1;
   if (OB_FAIL(dict_map_.set_refactored(key, info, cover_exist_flag))) {
     LOG_WARN("put dict info failed", K(ret));
+  } else {
+    ATOMIC_INC(&generation_epoch_);
   }
 
   return ret;

--- a/src/storage/fts/dict/ob_ft_dict_hub.h
+++ b/src/storage/fts/dict/ob_ft_dict_hub.h
@@ -96,7 +96,7 @@ class ObFTCacheRangeContainer;
 class ObFTDictHub
 {
 public:
-  ObFTDictHub() : is_inited_(false), dict_map_(), rw_dict_lock_() {}
+  ObFTDictHub() : is_inited_(false), dict_map_(), rw_dict_lock_(), generation_epoch_(0) {}
   ~ObFTDictHub() {}
 
   int init();
@@ -106,6 +106,8 @@ public:
   int build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
 
   int load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
+
+  uint64_t get_generation_epoch() const { return ATOMIC_LOAD(&generation_epoch_); }
 
 private:
   int get_dict_info(const ObFTDictInfoKey &key, ObFTDictInfo &info);
@@ -118,6 +120,7 @@ private:
   // holds info of dict
   hash::ObHashMap<ObFTDictInfoKey, ObFTDictInfo> dict_map_;
   ObBucketLock rw_dict_lock_;
+  uint64_t generation_epoch_;
 };
 
 } //  namespace storage

--- a/src/storage/retrieval/ob_i_sparse_retrieval_iter.h
+++ b/src/storage/retrieval/ob_i_sparse_retrieval_iter.h
@@ -108,15 +108,17 @@ struct ObSparseRetrievalMergeParam
       filter_expr_(nullptr),
       topk_limit_(0),
       field_boost_(1.0),
-      max_batch_size_(1)
+      max_batch_size_(1),
+      skip_relevance_for_predicate_(false)
   {}
   ~ObSparseRetrievalMergeParam() {}
   bool need_project_relevance() const { return relevance_proj_expr_ != nullptr; }
   bool need_filter() const { return filter_expr_ != nullptr; }
+  bool need_calc_relevance() const { return !skip_relevance_for_predicate_; }
   bool need_pushdown_topk() const { return topk_limit_ > 0; }
   TO_STRING_KV(KPC_(dim_weights), KPC(limit_param_), KP_(eval_ctx),
       KP_(id_proj_expr), KP_(relevance_expr), KP_(relevance_proj_expr), KP_(filter_expr),
-      K_(topk_limit), K_(max_batch_size));
+      K_(topk_limit), K_(max_batch_size), K_(skip_relevance_for_predicate));
   const ObIArray<double> *dim_weights_; // score weight for each dimension
   const common::ObLimitParam *limit_param_;
   sql::ObEvalCtx *eval_ctx_;
@@ -127,6 +129,7 @@ struct ObSparseRetrievalMergeParam
   int64_t topk_limit_;
   double field_boost_;
   int64_t max_batch_size_;
+  bool skip_relevance_for_predicate_;
 };
 
 class ObISparseRetrievalMergeIter

--- a/src/storage/retrieval/ob_sparse_daat_iter.cpp
+++ b/src/storage/retrieval/ob_sparse_daat_iter.cpp
@@ -130,10 +130,13 @@ int ObSRDaaTIterImpl::init(
       LOG_WARN("failed to init buffered domain ids array", K(ret));
     } else if (OB_FAIL(buffered_domain_ids_.prepare_allocate(max_batch_size))) {
       LOG_WARN("failed to prepare allocate buffered domain ids array", K(ret));
-    } else if (FALSE_IT(buffered_relevances_.set_allocator(iter_allocator_))) {
-    } else if (OB_FAIL(buffered_relevances_.init(max_batch_size))) {
+    } else if (iter_param_->need_project_relevance()
+        && FALSE_IT(buffered_relevances_.set_allocator(iter_allocator_))) {
+    } else if (iter_param_->need_project_relevance()
+        && OB_FAIL(buffered_relevances_.init(max_batch_size))) {
       LOG_WARN("failed to init buffered relevances array", K(ret));
-    } else if (OB_FAIL(buffered_relevances_.prepare_allocate(max_batch_size))) {
+    } else if (iter_param_->need_project_relevance()
+        && OB_FAIL(buffered_relevances_.prepare_allocate(max_batch_size))) {
       LOG_WARN("failed to prepare allocate buffered relevances array", K(ret));
     } else if (OB_FAIL(merge_cmp_.init(iter_param_->id_proj_expr_->datum_meta_, &iter_domain_ids_))) {
       LOG_WARN("failed to init loser tree comparator", K(ret));
@@ -314,9 +317,13 @@ int ObSRDaaTIterImpl::fill_merge_heap()
       } else {
         ret = OB_SUCCESS;
       }
-    } else if (OB_FAIL(dim_iter->get_curr_score(item.relevance_))) {
+    } else if (iter_param_->need_calc_relevance()
+        && OB_FAIL(dim_iter->get_curr_score(item.relevance_))) {
       LOG_WARN("fail to get current score", K(ret));
-    } else if (OB_NOT_NULL(iter_param_->dim_weights_) && FALSE_IT(item.relevance_ = item.relevance_ * iter_param_->field_boost_ * iter_param_->dim_weights_->at(iter_idx))) {
+    } else if (iter_param_->need_calc_relevance()
+        && OB_NOT_NULL(iter_param_->dim_weights_)
+        && FALSE_IT(item.relevance_ = item.relevance_ * iter_param_->field_boost_
+            * iter_param_->dim_weights_->at(iter_idx))) {
     } else if (OB_FAIL(dim_iter->get_curr_id(iter_domain_ids_[iter_idx]))) {
       LOG_WARN("fail to get current doc id", K(ret));
     } else if (FALSE_IT(item.iter_idx_ = iter_idx)) {
@@ -354,7 +361,8 @@ int ObSRDaaTIterImpl::collect_dims_by_id(const ObDatum *&id_datum, double &relev
     }
     if (OB_FAIL(merge_heap_->top(top_item))) {
       LOG_WARN("failed to get top item from merge heap", K(ret));
-    } else if (OB_FAIL(relevance_collector_->collect_one_dim(top_item->iter_idx_, top_item->relevance_))) {
+    } else if (iter_param_->need_calc_relevance()
+        && OB_FAIL(relevance_collector_->collect_one_dim(top_item->iter_idx_, top_item->relevance_))) {
       LOG_WARN("failed to collect one dimension", K(ret));
     } else if (FALSE_IT(iter_idx = top_item->iter_idx_)) {
     } else if (OB_FAIL(merge_heap_->pop())) {
@@ -370,7 +378,10 @@ int ObSRDaaTIterImpl::collect_dims_by_id(const ObDatum *&id_datum, double &relev
     if (OB_ISNULL(id_datum)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("unexpected null id datum", K(ret));
-    } else if (OB_FAIL(relevance_collector_->get_result(relevance, got_valid_id))) {
+    } else if (!iter_param_->need_calc_relevance()
+        && FALSE_IT(got_valid_id = true)) {
+    } else if (iter_param_->need_calc_relevance()
+        && OB_FAIL(relevance_collector_->get_result(relevance, got_valid_id))) {
       LOG_WARN("failed to get result", K(ret));
     } else if (got_valid_id && OB_FAIL(process_collected_row(*id_datum, relevance))) {
       LOG_WARN("failed to process collected row", K(ret));
@@ -435,12 +446,15 @@ int ObSRDaaTIterImpl::cache_result(int64_t &count, const ObDatum &id_datum, cons
   if (limit_param->is_valid() && input_row_cnt_ <= offset) {
     // TODO: Maybe we should not process offset logic here
     // don't need to project
-  } else if (OB_UNLIKELY(count >= buffered_domain_ids_.count() || count >= buffered_relevances_.count())) {
+  } else if (OB_UNLIKELY(count >= buffered_domain_ids_.count()
+      || (iter_param_->need_project_relevance() && count >= buffered_relevances_.count()))) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid buffered idx", K(ret), K(count), K(buffered_domain_ids_.count()), K(buffered_relevances_.count()));
   } else {
     buffered_domain_ids_[count].from_datum(id_datum);
-    buffered_relevances_[count] = relevance;
+    if (iter_param_->need_project_relevance()) {
+      buffered_relevances_[count] = relevance;
+    }
     ++count;
     ++output_row_cnt_;
     if (limit_param->is_valid() && output_row_cnt_ >= limit) {
@@ -485,9 +499,11 @@ int ObSRDaaTIterImpl::project_results(const int64_t count)
     ObDatum &id_proj_datum = id_proj_expr->locate_datum_for_write(*eval_ctx);
     set_datum_func_(id_proj_datum, buffered_domain_ids_[0]);
     id_proj_expr->set_evaluated_projected(*eval_ctx);
-    ObDatum &relevance_proj_datum = relevance_proj_expr->locate_datum_for_write(*eval_ctx);
-    relevance_proj_datum.set_double(buffered_relevances_[0]);
-    relevance_proj_expr->set_evaluated_projected(*eval_ctx);
+    if (iter_param_->need_project_relevance()) {
+      ObDatum &relevance_proj_datum = relevance_proj_expr->locate_datum_for_write(*eval_ctx);
+      relevance_proj_datum.set_double(buffered_relevances_[0]);
+      relevance_proj_expr->set_evaluated_projected(*eval_ctx);
+    }
   }
   return ret;
 }

--- a/src/storage/retrieval/ob_text_daat_iter.cpp
+++ b/src/storage/retrieval/ob_text_daat_iter.cpp
@@ -33,7 +33,8 @@ int ObTextDaaTIter::init(const ObTextDaaTParam &param)
   } else if (OB_FAIL(ObSRDaaTIterImpl::init(*param.base_param_, *param.dim_iters_,
                                             *param.allocator_, *param.relevance_collector_))) {
     LOG_WARN("failed to init sr daat iter", K(ret));
-  } else if (OB_FAIL(bm25_param_estimator_.init(param.bm25_param_est_ctx_))) {
+  } else if (param.base_param_->need_calc_relevance() && !param.dim_iters_->empty()
+      && OB_FAIL(bm25_param_estimator_.init(param.bm25_param_est_ctx_))) {
     LOG_WARN("failed to init bm25 param estimator", K(ret));
   } else {
     mode_flag_ = param.mode_flag_;
@@ -74,7 +75,7 @@ int ObTextDaaTIter::pre_process()
   int ret = OB_SUCCESS;
   if (dim_iters_->count() == 0) {
     ret = OB_ITER_END;
-  } else if (iter_param_->need_project_relevance()) {
+  } else if (iter_param_->need_calc_relevance()) {
     if (OB_FAIL(bm25_param_estimator_.do_estimation(*iter_param_->eval_ctx_))) {
       LOG_WARN("failed to do bm25 param estimation", K(ret));
     }

--- a/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
+++ b/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
@@ -111,7 +111,8 @@ void ObTextRetrievalTokenIter::reset()
 
 void ObTextRetrievalTokenIter::reuse()
 {
-  if (inv_idx_agg_cache_mode_ && !inv_idx_agg_param_->need_switch_param_) {
+  if (inv_idx_agg_cache_mode_ && OB_NOT_NULL(inv_idx_agg_param_)
+      && !inv_idx_agg_param_->need_switch_param_) {
     // do nothing
   } else {
     token_doc_cnt_calculated_ = false;
@@ -370,7 +371,8 @@ int ObTextRetrievalTokenIter::get_next_row()
   if (IS_NOT_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("retrieval token iterator not inited", K(ret));
-  } else if (!token_doc_cnt_calculated_ && OB_FAIL(estimate_token_doc_cnt())) {
+  } else if (need_calc_relevance() && !token_doc_cnt_calculated_
+      && OB_FAIL(estimate_token_doc_cnt())) {
     LOG_WARN("failed to estimate token doc cnt", K(ret));
   } else if (OB_FAIL(inv_idx_scan_iter_->get_next_row())) {
     if (OB_UNLIKELY(OB_ITER_END != ret)) {
@@ -455,7 +457,8 @@ int ObTextRetrievalTokenIter::get_next_batch(const int64_t capacity, int64_t &co
   if (IS_NOT_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("retrieval token iterator not inited", K(ret));
-  } else if (!token_doc_cnt_calculated_ && OB_FAIL(estimate_token_doc_cnt())) {
+  } else if (need_calc_relevance() && !token_doc_cnt_calculated_
+      && OB_FAIL(estimate_token_doc_cnt())) {
     LOG_WARN("failed to estimate token doc cnt", K(ret));
   } else if (OB_FAIL(inv_idx_scan_iter_->get_next_rows(count, OB_MIN(max_batch_size_, capacity)))) {
     if (OB_UNLIKELY(OB_ITER_END != ret)) {
@@ -717,10 +720,13 @@ int ObTextRetrievalDaaTTokenIter::init(const ObTextRetrievalScanIterParam &iter_
       if (OB_ISNULL(cmp_func_)) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("failed to init IRIterLoserTreeCmp", K(ret));
-      } else if (FALSE_IT(relevance_.set_allocator(allocator_))) {
-      } else if (OB_FAIL(relevance_.init(max_batch_size_))) {
+      } else if (OB_NOT_NULL(relevance_expr_)
+          && FALSE_IT(relevance_.set_allocator(allocator_))) {
+      } else if (OB_NOT_NULL(relevance_expr_)
+          && OB_FAIL(relevance_.init(max_batch_size_))) {
         LOG_WARN("failed to init next batch iter idxes array", K(ret));
-      } else if (OB_FAIL(relevance_.prepare_allocate(max_batch_size_))) {
+      } else if (OB_NOT_NULL(relevance_expr_)
+          && OB_FAIL(relevance_.prepare_allocate(max_batch_size_))) {
         LOG_WARN("failed to prepare allocate next batch iter idxes array", K(ret));
       } else if (FALSE_IT(doc_id_.set_allocator(allocator_))) {
       } else if (OB_FAIL(doc_id_.init(max_batch_size_))) {
@@ -817,10 +823,8 @@ int ObTextRetrievalDaaTTokenIter::save_docids()
     cur_idx_ = 0;
     const ObDatumVector &doc_id_datum = inv_scan_domain_id_col_->locate_expr_datumvector(*eval_ctx_);
     for (int64_t i = 0; OB_SUCC(ret) && i < count_; ++i) {
-      if (OB_LIKELY(!token_iter_->get_skip()->at(i))) {
-        if (OB_FAIL(doc_id_[i].from_datum(*doc_id_datum.at(i)))) {
-          LOG_WARN("failed to get doc id", K(ret));
-        };
+      if (OB_FAIL(doc_id_[i].from_datum(*doc_id_datum.at(i)))) {
+        LOG_WARN("failed to get doc id", K(ret));
       }
     }
   }


### PR DESCRIPTION
## Summary

- optimize full-text index construction hot paths, including DDL scan expression reuse, persistent LOB allocation, and full requested auxiliary-task parallelism
- cache deterministic TOKENIZE results with dictionary-epoch invalidation
- use predicate-only MATCH execution paths that avoid unnecessary BM25 statistics/relevance work while preserving projection, ordering, comparison, and BOOLEAN MODE semantics
- implement and harden LOAD_FILE and AI_SPLIT_DOCUMENT, including public function registration, correct BLOB/LOB result construction, and function-table string collation metadata

## Official FTS benchmark

Ran the checked-in `tools/benchmark/fts_large_bench.sh` with the fixed baseline configuration:

- score: **62.57 / 100**
- mean improvement: **31.29%**
- build improvement: **23.21%**
- tokenize improvement: **19.64%**
- query improvement: **51.00%**
- expected hit counts preserved: 8001 / 11000 / 7332 / 20

## Verification

- Debug `observer` target builds and links successfully
- LOAD_FILE returns the expected file content and byte length
- AI_SPLIT_DOCUMENT sentence, sliding-window word, and Markdown cases match expected output
- MATCH predicate, relevance projection/order, numeric score comparison, and BOOLEAN MODE smoke tests pass
- no benchmark tests or GitHub workflow files were modified