### PR TITLE
feat: implement LOAD_FILE and AI_SPLIT_DOCUMENT

### DIFF
--- a/deps/oblib/src/CMakeLists.txt
+++ b/deps/oblib/src/CMakeLists.txt
@@ -342,7 +342,7 @@ else()
     ${DEP_DIR}/lib/sqlite/libsqlite3.a
     ${DEP_DIR}/lib/libz.a
     ${DEP_DIR}/lib/libicui18n.a
-    ${DEP_DIR}/lib/libicustubdata.a
+    ${DEP_DIR}/lib/libicudata.a
     ${DEP_DIR}/lib/libicuuc.a
     ${DEP_DIR}/lib/libprotobuf-c.a
     $<$<NOT:$<BOOL:${BUILD_EMBED_MODE}>>:${_LIB_PATH}/libarrow.a>

--- a/deps/oblib/src/lib/CMakeLists.txt
+++ b/deps/oblib/src/lib/CMakeLists.txt
@@ -225,6 +225,11 @@ ob_set_subtarget(oblib_lib ob_vector_util
   vector/ob_vsag_adaptor.cpp
 )
 
+ob_set_subtarget(oblib_lib ai_split_document
+  ai_split_document/ob_ai_split_document.cpp
+  ai_split_document/ob_ai_split_document_util.cpp
+)
+
 ob_lib_add_target(oblib_lib)
 
 ob_set_subtarget(oblib_lib_bitmap common

--- a/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.cpp
+++ b/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.cpp
@@ -1,0 +1,589 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define USING_LOG_PREFIX LIB
+
+#include "lib/ai_split_document/ob_ai_split_document.h"
+#include "lib/ai_split_document/ob_ai_split_document_util.h"
+#include "lib/alloc/malloc_hook.h"
+#include "lib/allocator/ob_malloc.h"
+#include "lib/oblog/ob_log_module.h"
+#include <cctype>
+#include <limits>
+
+namespace oceanbase
+{
+namespace common
+{
+
+namespace
+{
+bool is_space(const char ch)
+{
+  return 0 != std::isspace(static_cast<unsigned char>(ch));
+}
+} // namespace
+
+#define EXTRACT_JSON_STRING(json_key, string_value, process)                         \
+  if (0 == elem.first.case_compare(json_key)) {                                     \
+    if (elem.second->json_type() != ObJsonNodeType::J_STRING) {                     \
+      ret = OB_INVALID_ARGUMENT;                                                     \
+      LOG_WARN("invalid document split parameter type", K(ret), K(elem.first),      \
+               K(elem.second->json_type()));                                         \
+      FORWARD_USER_ERROR(ret, "parameter " json_key " must be a string");          \
+    } else {                                                                         \
+      string_value.assign_ptr(elem.second->get_data(), elem.second->get_data_length()); \
+      process;                                                                       \
+    }                                                                                \
+  } else
+
+#define EXTRACT_JSON_INTEGER(json_key, integer_value)                               \
+  if (0 == elem.first.case_compare(json_key)) {                                     \
+    if (elem.second->json_type() != ObJsonNodeType::J_INT                           \
+        && elem.second->json_type() != ObJsonNodeType::J_UINT) {                    \
+      ret = OB_INVALID_ARGUMENT;                                                     \
+      LOG_WARN("invalid document split parameter type", K(ret), K(elem.first),      \
+               K(elem.second->json_type()));                                         \
+      FORWARD_USER_ERROR(ret, "parameter " json_key " must be an integer");       \
+    } else if (elem.second->json_type() == ObJsonNodeType::J_UINT) {                \
+      const uint64_t uint_value = elem.second->get_uint();                           \
+      if (uint_value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) { \
+        ret = OB_INVALID_ARGUMENT;                                                    \
+        LOG_WARN("document split parameter is out of range", K(ret), K(elem.first), \
+                 K(uint_value));                                                      \
+        FORWARD_USER_ERROR(ret, "parameter " json_key " is out of range");       \
+      } else {                                                                        \
+        integer_value = static_cast<int64_t>(uint_value);                            \
+      }                                                                               \
+    } else {                                                                          \
+      integer_value = elem.second->get_int();                                        \
+    }                                                                                \
+  } else
+
+int ObAiSplitDocInput::init(const ObString &content, const ObIJsonBase *params_node)
+{
+  int ret = OB_SUCCESS;
+  content_ = content;
+  if (OB_FAIL(params_.init(params_node))) {
+    LOG_WARN("failed to initialize document split parameters", K(ret));
+  }
+  return ret;
+}
+
+int ObAiSplitDocParams::init(const ObIJsonBase *params_node)
+{
+  int ret = OB_SUCCESS;
+  reset();
+  if (OB_ISNULL(params_node)) {
+    // Use defaults.
+  } else if (params_node->json_type() != ObJsonNodeType::J_OBJECT) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("document split parameters must be a JSON object", K(ret),
+             K(params_node->json_type()));
+    FORWARD_USER_ERROR(ret, "parameters must be a JSON object");
+  } else {
+    ObString type_str;
+    ObString by_str;
+    JsonObjectIterator iter = params_node->object_iterator();
+    while (OB_SUCC(ret) && !iter.end()) {
+      ObJsonObjPair elem;
+      if (OB_FAIL(iter.get_elem(elem))) {
+        LOG_WARN("failed to read document split parameter", K(ret));
+      } else {
+        EXTRACT_JSON_STRING("type", type_str, parse_type(type_str))
+        EXTRACT_JSON_STRING("by", by_str, parse_by(by_str))
+        EXTRACT_JSON_INTEGER("max", max_)
+        EXTRACT_JSON_INTEGER("overlap", overlap_)
+        {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_WARN("unknown document split parameter", K(ret), K(elem.first));
+          FORWARD_USER_ERROR_MSG(ret, "unknown parameter '%.*s'",
+                                 elem.first.length(), elem.first.ptr());
+        }
+      }
+      iter.next();
+    }
+  }
+  if (OB_SUCC(ret) && OB_FAIL(check_validity())) {
+    LOG_WARN("invalid document split parameters", K(ret), K(*this));
+  }
+  return ret;
+}
+
+int ObAiSplitDocParams::parse_type(const ObString &type_str)
+{
+  int ret = OB_SUCCESS;
+  if (0 == type_str.case_compare("text")) {
+    type_ = ObAiSplitContentType::TEXT;
+  } else if (0 == type_str.case_compare("markdown")) {
+    type_ = ObAiSplitContentType::MARKDOWN;
+  } else {
+    type_ = ObAiSplitContentType::MAX_CONTENT_TYPE;
+  }
+  return ret;
+}
+
+int ObAiSplitDocParams::parse_by(const ObString &by_str)
+{
+  int ret = OB_SUCCESS;
+  if (0 == by_str.case_compare("word")) {
+    by_ = ObAiSplitByUnit::WORD;
+  } else if (0 == by_str.case_compare("sentence")) {
+    by_ = ObAiSplitByUnit::SENTENCE;
+  } else {
+    by_ = ObAiSplitByUnit::MAX_UNIT_TYPE;
+  }
+  return ret;
+}
+
+int ObAiSplitDocParams::check_validity() const
+{
+  int ret = OB_SUCCESS;
+  if (max_ <= 0 || max_ > 1000) {
+    ret = OB_INVALID_ARGUMENT;
+    FORWARD_USER_ERROR(ret, "parameter max must be between 1 and 1000");
+  } else if (overlap_ < 0 || overlap_ > max_ / 2) {
+    ret = OB_INVALID_ARGUMENT;
+    FORWARD_USER_ERROR(ret, "parameter overlap must be between 0 and max/2");
+  } else if (by_ == ObAiSplitByUnit::MAX_UNIT_TYPE) {
+    ret = OB_INVALID_ARGUMENT;
+    FORWARD_USER_ERROR(ret, "parameter by must be 'word' or 'sentence'");
+  } else if (type_ == ObAiSplitContentType::MAX_CONTENT_TYPE) {
+    ret = OB_INVALID_ARGUMENT;
+    FORWARD_USER_ERROR(ret, "parameter type must be 'text' or 'markdown'");
+  }
+  return ret;
+}
+
+int ObAiSplitDocAdapter::init(ObIAllocator &allocator, const ObString &content,
+                              const ObAiSplitDocParams &params)
+{
+  int ret = OB_SUCCESS;
+  if (is_inited_) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("document split adapter already initialized", K(ret));
+  } else {
+    reset();
+    allocator_ = &allocator;
+    if (OB_FAIL(ObAiSplitDocumentUtil::create_doc_split_iterator(params, allocator,
+                                                                 iterator_))) {
+      LOG_WARN("failed to create document split iterator", K(ret));
+    } else if (OB_ISNULL(iterator_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("document split iterator is null", K(ret));
+    } else if (OB_FAIL(iterator_->open(content, allocator, params))) {
+      LOG_WARN("failed to open document split iterator", K(ret));
+    } else {
+      is_inited_ = true;
+    }
+    if (OB_FAIL(ret)) {
+      reset();
+    }
+  }
+  return ret;
+}
+
+int ObAiSplitDocAdapter::get_next_row()
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_ || OB_ISNULL(iterator_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("document split adapter is not initialized", K(ret));
+  } else if (OB_FAIL(iterator_->get_next_row(cur_chunk_))) {
+    if (ret != OB_ITER_END) {
+      LOG_WARN("failed to get next document chunk", K(ret));
+    }
+  } else {
+    ++cur_idx_;
+  }
+  return ret;
+}
+
+void ObAiSplitDocAdapter::reset()
+{
+  if (OB_NOT_NULL(iterator_)) {
+    iterator_->close();
+    if (OB_NOT_NULL(allocator_)) {
+      OB_DELETEx(ObDocSplitIterator, allocator_, iterator_);
+    } else {
+      iterator_ = nullptr;
+    }
+  }
+  allocator_ = nullptr;
+  is_inited_ = false;
+  cur_idx_ = -1;
+  cur_chunk_.reset();
+}
+
+int ObTextSplitIterator::open(const ObString &content, ObIAllocator &allocator,
+                              const ObAiSplitDocParams &params)
+{
+  UNUSED(allocator);
+  int ret = OB_SUCCESS;
+  if (is_inited_) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("text split iterator already initialized", K(ret));
+  } else {
+    content_ = content;
+    params_.assign(params);
+    chunk_id_ = 0;
+    chunk_start_offset_ = 0;
+    next_chunk_start_ = 0;
+    unit_since_window_start_ = 0;
+    current_boundary_ = 0;
+    is_done_ = false;
+
+    lib::ObMallocHookAttrGuard malloc_guard(lib::ObMemAttr("AiSplitDoc"));
+    UErrorCode status = U_ZERO_ERROR;
+    if (params_.by_ == ObAiSplitByUnit::WORD) {
+      bi_ = icu::BreakIterator::createWordInstance(icu::Locale::getDefault(), status);
+    } else if (params_.by_ == ObAiSplitByUnit::SENTENCE) {
+      bi_ = icu::BreakIterator::createSentenceInstance(icu::Locale::getDefault(), status);
+    } else {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("invalid split unit", K(ret), K(params_.by_));
+    }
+    if (OB_SUCC(ret) && (U_FAILURE(status) || OB_ISNULL(bi_))) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("failed to create ICU BreakIterator", K(ret), K(status));
+    }
+    if (OB_SUCC(ret)) {
+      status = U_ZERO_ERROR;
+      utext_ = utext_openUTF8(nullptr, content_.ptr(), content_.length(), &status);
+      if (U_FAILURE(status) || OB_ISNULL(utext_)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("failed to create ICU UText", K(ret), K(status));
+      }
+    }
+    if (OB_SUCC(ret)) {
+      status = U_ZERO_ERROR;
+      bi_->setText(utext_, status);
+      if (U_FAILURE(status)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("failed to bind UText to BreakIterator", K(ret), K(status));
+      }
+    }
+    if (OB_SUCC(ret)) {
+      is_inited_ = true;
+    } else {
+      close();
+    }
+  }
+  return ret;
+}
+
+int ObTextSplitIterator::get_next_row(ObAiSplitDocChunk &chunk)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("text split iterator is not initialized", K(ret));
+  } else if (is_done_) {
+    ret = OB_ITER_END;
+  } else {
+    chunk.reset();
+    const int64_t max_unit = params_.max_;
+    const int64_t overlap_unit = params_.overlap_;
+    const int64_t chunk_step = max_unit - overlap_unit;
+    int64_t window_start = chunk_start_offset_;
+    int64_t unit_count = (0 == chunk_start_offset_) ? 0 : overlap_unit;
+    int64_t boundary = current_boundary_;
+    bool chunk_found = false;
+
+    while (boundary != icu::BreakIterator::DONE && !chunk_found) {
+      boundary = bi_->next();
+      if (boundary != icu::BreakIterator::DONE) {
+        if ((params_.by_ == ObAiSplitByUnit::WORD
+             && bi_->getRuleStatus() != UBRK_WORD_NONE)
+            || params_.by_ == ObAiSplitByUnit::SENTENCE) {
+          ++unit_count;
+          ++unit_since_window_start_;
+        }
+        if (unit_count >= max_unit) {
+          while (window_start < boundary && window_start < content_.length()
+                 && is_space(content_[window_start])) {
+            ++window_start;
+          }
+          int64_t window_end = boundary;
+          while (window_end > window_start && is_space(content_[window_end - 1])) {
+            --window_end;
+          }
+          if (window_start < window_end) {
+            chunk.init(chunk_id_++, window_start, window_end - window_start,
+                       ObString(window_end - window_start, content_.ptr() + window_start));
+            chunk_found = true;
+          }
+          unit_count = overlap_unit;
+          if (0 == overlap_unit) {
+            next_chunk_start_ = boundary;
+          }
+          window_start = next_chunk_start_;
+          chunk_start_offset_ = window_start;
+        }
+        if (unit_since_window_start_ >= chunk_step) {
+          next_chunk_start_ = boundary;
+          unit_since_window_start_ = 0;
+        }
+      }
+    }
+    current_boundary_ = boundary;
+
+    if (!chunk_found && boundary == icu::BreakIterator::DONE) {
+      if (unit_count > overlap_unit || 0 == chunk_id_) {
+        int64_t end = content_.length();
+        while (window_start < end && is_space(content_[window_start])) {
+          ++window_start;
+        }
+        while (end > window_start && is_space(content_[end - 1])) {
+          --end;
+        }
+        if (window_start < end) {
+          chunk.init(chunk_id_++, window_start, end - window_start,
+                     ObString(end - window_start, content_.ptr() + window_start));
+          chunk_found = true;
+        }
+      }
+      is_done_ = true;
+    }
+    if (!chunk_found) {
+      ret = OB_ITER_END;
+    }
+  }
+  return ret;
+}
+
+int ObTextSplitIterator::close()
+{
+  int ret = OB_SUCCESS;
+  is_inited_ = false;
+  content_.reset();
+  params_.reset();
+  chunk_id_ = 0;
+  chunk_start_offset_ = 0;
+  next_chunk_start_ = 0;
+  unit_since_window_start_ = 0;
+  current_boundary_ = 0;
+  is_done_ = false;
+  if (OB_NOT_NULL(bi_)) {
+    delete bi_;
+    bi_ = nullptr;
+  }
+  if (OB_NOT_NULL(utext_)) {
+    utext_close(utext_);
+    utext_ = nullptr;
+  }
+  return ret;
+}
+
+int ObMarkdownSplitIterator::open(const ObString &content, ObIAllocator &allocator,
+                                  const ObAiSplitDocParams &params)
+{
+  int ret = OB_SUCCESS;
+  if (is_inited_) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("markdown split iterator already initialized", K(ret));
+  } else {
+    allocator_ = &allocator;
+    content_ = content;
+    params_.assign(params);
+    chunk_id_ = 0;
+    section_start_offset_ = 0;
+    section_title_.reset();
+    section_content_.reset();
+    is_done_ = false;
+    row_alloc_.clear();
+    void *buf = allocator.alloc(sizeof(ObTextSplitIterator));
+    if (OB_ISNULL(buf)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate nested text split iterator", K(ret));
+    } else {
+      iterator_ = new (buf) ObTextSplitIterator();
+      is_inited_ = true;
+    }
+  }
+  return ret;
+}
+
+int ObMarkdownSplitIterator::get_next_row(ObAiSplitDocChunk &chunk)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("markdown split iterator is not initialized", K(ret));
+  } else if (is_done_) {
+    ret = OB_ITER_END;
+  } else {
+    if (!section_title_.empty()) {
+      row_alloc_.clear();
+    }
+    chunk.reset();
+    ObAiSplitDocChunk text_chunk;
+    bool chunk_found = false;
+    while (OB_SUCC(ret) && !chunk_found) {
+      if (OB_NOT_NULL(iterator_) && iterator_->is_inited()) {
+        if (OB_FAIL(iterator_->get_next_row(text_chunk))) {
+          if (ret == OB_ITER_END) {
+            iterator_->close();
+            ret = OB_SUCCESS;
+          } else {
+            LOG_WARN("failed to split markdown section", K(ret));
+          }
+        } else {
+          const int64_t section_offset = section_content_.ptr() - content_.ptr();
+          chunk.init(chunk_id_++, section_offset + text_chunk.chunk_offset_,
+                     text_chunk.chunk_length_, text_chunk.chunk_text_);
+          if (!section_title_.empty()) {
+            const int64_t total_len = section_title_.length() + text_chunk.chunk_text_.length();
+            char *buf = static_cast<char *>(row_alloc_.alloc(total_len));
+            if (OB_ISNULL(buf)) {
+              ret = OB_ALLOCATE_MEMORY_FAILED;
+              LOG_WARN("failed to allocate markdown chunk", K(ret), K(total_len));
+            } else {
+              MEMCPY(buf, section_title_.ptr(), section_title_.length());
+              MEMCPY(buf + section_title_.length(), text_chunk.chunk_text_.ptr(),
+                     text_chunk.chunk_text_.length());
+              chunk.chunk_text_.assign_ptr(buf, total_len);
+            }
+          }
+          chunk_found = OB_SUCC(ret);
+        }
+      } else if (OB_FAIL(get_next_section(section_title_, section_content_))) {
+        if (ret == OB_ITER_END) {
+          is_done_ = true;
+        } else {
+          LOG_WARN("failed to read markdown section", K(ret));
+        }
+      } else if (!section_title_.empty() && is_empty_section(section_content_)) {
+        const int64_t title_offset = section_title_.ptr() - content_.ptr();
+        chunk.init(chunk_id_++, title_offset, section_title_.length(), section_title_);
+        chunk_found = true;
+      } else if (OB_FAIL(iterator_->open(section_content_, *allocator_, params_))) {
+        LOG_WARN("failed to open markdown section iterator", K(ret));
+      }
+    }
+  }
+  return ret;
+}
+
+int ObMarkdownSplitIterator::close()
+{
+  int ret = OB_SUCCESS;
+  is_inited_ = false;
+  content_.reset();
+  params_.reset();
+  chunk_id_ = 0;
+  section_start_offset_ = 0;
+  section_title_.reset();
+  section_content_.reset();
+  is_done_ = false;
+  if (OB_NOT_NULL(iterator_)) {
+    iterator_->close();
+    if (OB_NOT_NULL(allocator_)) {
+      OB_DELETEx(ObTextSplitIterator, allocator_, iterator_);
+    } else {
+      iterator_ = nullptr;
+    }
+  }
+  row_alloc_.clear();
+  allocator_ = nullptr;
+  return ret;
+}
+
+int ObMarkdownSplitIterator::get_next_section(ObString &section_title,
+                                              ObString &section_content)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+  } else if (section_start_offset_ >= content_.length()) {
+    ret = OB_ITER_END;
+  } else {
+    section_title.reset();
+    section_content.reset();
+    bool has_title = false;
+    bool section_end = false;
+    int64_t content_start = section_start_offset_;
+    int64_t content_end = content_start;
+    int64_t line_start = section_start_offset_;
+    int64_t line_end = line_start;
+    while (OB_SUCC(ret) && line_start < content_.length() && !section_end) {
+      if (OB_FAIL(get_next_line(line_start, line_end))) {
+        LOG_WARN("failed to read markdown line", K(ret));
+      } else if (is_title_line(
+                   ObString(line_end - line_start, content_.ptr() + line_start),
+                   DEFAULT_TITLE_LEVEL)) {
+        if (!has_title) {
+          has_title = true;
+          const int64_t title_end = line_end < content_.length() ? line_end + 1
+                                                                 : content_.length();
+          section_title.assign_ptr(content_.ptr() + line_start, title_end - line_start);
+          content_start = title_end;
+        } else {
+          section_end = true;
+          content_end = line_start;
+        }
+      }
+      line_start = line_end + 1;
+    }
+    if (OB_SUCC(ret)) {
+      if (!section_end) {
+        content_end = line_end < content_.length() ? line_end + 1 : line_end;
+      }
+      section_content.assign_ptr(content_.ptr() + content_start, content_end - content_start);
+      section_start_offset_ = content_end;
+    }
+  }
+  return ret;
+}
+
+int ObMarkdownSplitIterator::get_next_line(const int64_t line_start_offset,
+                                           int64_t &line_end_offset)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+  } else if (line_start_offset >= content_.length()) {
+    ret = OB_ITER_END;
+  } else {
+    line_end_offset = line_start_offset;
+    while (line_end_offset < content_.length() && content_[line_end_offset] != '\n') {
+      ++line_end_offset;
+    }
+  }
+  return ret;
+}
+
+bool ObMarkdownSplitIterator::is_empty_section(const ObString &section_content) const
+{
+  int64_t pos = 0;
+  while (pos < section_content.length() && is_space(section_content[pos])) {
+    ++pos;
+  }
+  return pos == section_content.length();
+}
+
+bool ObMarkdownSplitIterator::is_title_line(const ObString &line,
+                                            const int64_t title_level) const
+{
+  int64_t pos = 0;
+  while (pos < line.length() && line[pos] == '#') {
+    ++pos;
+  }
+  return pos == title_level;
+}
+
+} // namespace common
+} // namespace oceanbase

--- a/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.cpp
+++ b/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.cpp
@@ -22,7 +22,6 @@
 #include "lib/allocator/ob_malloc.h"
 #include "lib/oblog/ob_log_module.h"
 #include <cctype>
-#include <limits>
 
 namespace oceanbase
 {
@@ -37,87 +36,25 @@ bool is_space(const char ch)
 }
 } // namespace
 
-#define EXTRACT_JSON_STRING(json_key, string_value, process)                         \
-  if (0 == elem.first.case_compare(json_key)) {                                     \
-    if (elem.second->json_type() != ObJsonNodeType::J_STRING) {                     \
-      ret = OB_INVALID_ARGUMENT;                                                     \
-      LOG_WARN("invalid document split parameter type", K(ret), K(elem.first),      \
-               K(elem.second->json_type()));                                         \
-      FORWARD_USER_ERROR(ret, "parameter " json_key " must be a string");          \
-    } else {                                                                         \
-      string_value.assign_ptr(elem.second->get_data(), elem.second->get_data_length()); \
-      process;                                                                       \
-    }                                                                                \
-  } else
-
-#define EXTRACT_JSON_INTEGER(json_key, integer_value)                               \
-  if (0 == elem.first.case_compare(json_key)) {                                     \
-    if (elem.second->json_type() != ObJsonNodeType::J_INT                           \
-        && elem.second->json_type() != ObJsonNodeType::J_UINT) {                    \
-      ret = OB_INVALID_ARGUMENT;                                                     \
-      LOG_WARN("invalid document split parameter type", K(ret), K(elem.first),      \
-               K(elem.second->json_type()));                                         \
-      FORWARD_USER_ERROR(ret, "parameter " json_key " must be an integer");       \
-    } else if (elem.second->json_type() == ObJsonNodeType::J_UINT) {                \
-      const uint64_t uint_value = elem.second->get_uint();                           \
-      if (uint_value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) { \
-        ret = OB_INVALID_ARGUMENT;                                                    \
-        LOG_WARN("document split parameter is out of range", K(ret), K(elem.first), \
-                 K(uint_value));                                                      \
-        FORWARD_USER_ERROR(ret, "parameter " json_key " is out of range");       \
-      } else {                                                                        \
-        integer_value = static_cast<int64_t>(uint_value);                            \
-      }                                                                               \
-    } else {                                                                          \
-      integer_value = elem.second->get_int();                                        \
-    }                                                                                \
-  } else
-
-int ObAiSplitDocInput::init(const ObString &content, const ObIJsonBase *params_node)
+int ObAiSplitDocInput::init(const ObString &content, const ObAiSplitDocParams &params)
 {
-  int ret = OB_SUCCESS;
   content_ = content;
-  if (OB_FAIL(params_.init(params_node))) {
-    LOG_WARN("failed to initialize document split parameters", K(ret));
-  }
-  return ret;
+  params_.assign(params);
+  return OB_SUCCESS;
 }
 
-int ObAiSplitDocParams::init(const ObIJsonBase *params_node)
+int ObAiSplitDocParams::init(const ObString &type_str, const ObString &by_str,
+                             const int64_t max, const int64_t overlap)
 {
   int ret = OB_SUCCESS;
   reset();
-  if (OB_ISNULL(params_node)) {
-    // Use defaults.
-  } else if (params_node->json_type() != ObJsonNodeType::J_OBJECT) {
-    ret = OB_INVALID_ARGUMENT;
-    LOG_WARN("document split parameters must be a JSON object", K(ret),
-             K(params_node->json_type()));
-    FORWARD_USER_ERROR(ret, "parameters must be a JSON object");
-  } else {
-    ObString type_str;
-    ObString by_str;
-    JsonObjectIterator iter = params_node->object_iterator();
-    while (OB_SUCC(ret) && !iter.end()) {
-      ObJsonObjPair elem;
-      if (OB_FAIL(iter.get_elem(elem))) {
-        LOG_WARN("failed to read document split parameter", K(ret));
-      } else {
-        EXTRACT_JSON_STRING("type", type_str, parse_type(type_str))
-        EXTRACT_JSON_STRING("by", by_str, parse_by(by_str))
-        EXTRACT_JSON_INTEGER("max", max_)
-        EXTRACT_JSON_INTEGER("overlap", overlap_)
-        {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("unknown document split parameter", K(ret), K(elem.first));
-          FORWARD_USER_ERROR_MSG(ret, "unknown parameter '%.*s'",
-                                 elem.first.length(), elem.first.ptr());
-        }
-      }
-      iter.next();
-    }
-  }
-  if (OB_SUCC(ret) && OB_FAIL(check_validity())) {
+  max_ = max;
+  overlap_ = overlap;
+  if (OB_FAIL(parse_type(type_str))) {
+    LOG_WARN("failed to parse document content type", K(ret), K(type_str));
+  } else if (OB_FAIL(parse_by(by_str))) {
+    LOG_WARN("failed to parse document split unit", K(ret), K(by_str));
+  } else if (OB_FAIL(check_validity())) {
     LOG_WARN("invalid document split parameters", K(ret), K(*this));
   }
   return ret;

--- a/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.h
+++ b/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.h
@@ -21,6 +21,7 @@
 #include "lib/allocator/page_arena.h"
 #include "lib/string/ob_string.h"
 #include "lib/utility/ob_macro_utils.h"
+#include "lib/utility/ob_print_utils.h"
 #include <unicode/brkiter.h>
 #include <unicode/utext.h>
 

--- a/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.h
+++ b/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.h
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_H_
+#define OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_H_
+
+#include "lib/allocator/ob_allocator.h"
+#include "lib/allocator/page_arena.h"
+#include "lib/string/ob_string.h"
+#include "lib/utility/ob_macro_utils.h"
+#include "common/json_type/ob_json_base.h"
+#include "common/json_type/ob_json_parse.h"
+#include <unicode/brkiter.h>
+#include <unicode/utext.h>
+
+namespace oceanbase
+{
+namespace common
+{
+
+enum class ObAiSplitContentType
+{
+  TEXT = 0,
+  MARKDOWN,
+  MAX_CONTENT_TYPE,
+};
+
+enum class ObAiSplitByUnit
+{
+  WORD = 0,
+  SENTENCE,
+  MAX_UNIT_TYPE,
+};
+
+struct ObAiSplitDocParams
+{
+  ObAiSplitDocParams()
+    : type_(ObAiSplitContentType::MARKDOWN),
+      by_(ObAiSplitByUnit::WORD),
+      max_(256),
+      overlap_(0)
+  {}
+
+  void reset()
+  {
+    type_ = ObAiSplitContentType::MARKDOWN;
+    by_ = ObAiSplitByUnit::WORD;
+    max_ = 256;
+    overlap_ = 0;
+  }
+  void assign(const ObAiSplitDocParams &other)
+  {
+    type_ = other.type_;
+    by_ = other.by_;
+    max_ = other.max_;
+    overlap_ = other.overlap_;
+  }
+  int init(const ObIJsonBase *params_node);
+  int check_validity() const;
+
+  ObAiSplitContentType type_;
+  ObAiSplitByUnit by_;
+  int64_t max_;
+  int64_t overlap_;
+
+  TO_STRING_KV(K_(type), K_(by), K_(max), K_(overlap));
+
+private:
+  int parse_type(const ObString &type_str);
+  int parse_by(const ObString &by_str);
+};
+
+struct ObAiSplitDocChunk
+{
+  ObAiSplitDocChunk()
+    : chunk_id_(0), chunk_offset_(0), chunk_length_(0), chunk_text_()
+  {}
+
+  void init(const int64_t id, const int64_t offset, const int64_t length,
+            const ObString &text)
+  {
+    chunk_id_ = id;
+    chunk_offset_ = offset;
+    chunk_length_ = length;
+    chunk_text_ = text;
+  }
+  void reset()
+  {
+    chunk_id_ = 0;
+    chunk_offset_ = 0;
+    chunk_length_ = 0;
+    chunk_text_.reset();
+  }
+
+  int64_t chunk_id_;
+  int64_t chunk_offset_;
+  int64_t chunk_length_;
+  ObString chunk_text_;
+
+  TO_STRING_KV(K_(chunk_id), K_(chunk_offset), K_(chunk_length), K_(chunk_text));
+};
+
+struct ObAiSplitDocInput
+{
+  ObAiSplitDocInput() : content_(), params_() {}
+
+  int init(const ObString &content, const ObIJsonBase *params_node);
+  void reset()
+  {
+    content_.reset();
+    params_.reset();
+  }
+
+  ObString content_;
+  ObAiSplitDocParams params_;
+
+  TO_STRING_KV(K_(content), K_(params));
+};
+
+class ObDocSplitIterator
+{
+public:
+  ObDocSplitIterator() {}
+  virtual ~ObDocSplitIterator() {}
+  virtual int open(const ObString &content, ObIAllocator &allocator,
+                   const ObAiSplitDocParams &params) = 0;
+  virtual int get_next_row(ObAiSplitDocChunk &chunk) = 0;
+  virtual int close() = 0;
+};
+
+class ObTextSplitIterator : public ObDocSplitIterator
+{
+public:
+  ObTextSplitIterator()
+    : is_inited_(false),
+      content_(),
+      params_(),
+      chunk_id_(0),
+      chunk_start_offset_(0),
+      next_chunk_start_(0),
+      unit_since_window_start_(0),
+      current_boundary_(0),
+      is_done_(false),
+      bi_(nullptr),
+      utext_(nullptr)
+  {}
+  virtual ~ObTextSplitIterator() override { close(); }
+
+  bool is_inited() const { return is_inited_; }
+  virtual int open(const ObString &content, ObIAllocator &allocator,
+                   const ObAiSplitDocParams &params) override;
+  virtual int get_next_row(ObAiSplitDocChunk &chunk) override;
+  virtual int close() override;
+
+private:
+  bool is_inited_;
+  ObString content_;
+  ObAiSplitDocParams params_;
+  int64_t chunk_id_;
+  int64_t chunk_start_offset_;
+  int64_t next_chunk_start_;
+  int64_t unit_since_window_start_;
+  int64_t current_boundary_;
+  bool is_done_;
+  icu::BreakIterator *bi_;
+  UText *utext_;
+};
+
+class ObMarkdownSplitIterator : public ObDocSplitIterator
+{
+public:
+  ObMarkdownSplitIterator()
+    : is_inited_(false),
+      content_(),
+      params_(),
+      chunk_id_(0),
+      section_start_offset_(0),
+      section_title_(),
+      section_content_(),
+      is_done_(false),
+      row_alloc_(),
+      allocator_(nullptr),
+      iterator_(nullptr)
+  {}
+  virtual ~ObMarkdownSplitIterator() override { close(); }
+
+  virtual int open(const ObString &content, ObIAllocator &allocator,
+                   const ObAiSplitDocParams &params) override;
+  virtual int get_next_row(ObAiSplitDocChunk &chunk) override;
+  virtual int close() override;
+
+private:
+  static const int64_t DEFAULT_TITLE_LEVEL = 1;
+  int get_next_section(ObString &section_title, ObString &section_content);
+  int get_next_line(const int64_t line_start_offset, int64_t &line_end_offset);
+  bool is_empty_section(const ObString &section_content) const;
+  bool is_title_line(const ObString &line, const int64_t title_level) const;
+
+private:
+  bool is_inited_;
+  ObString content_;
+  ObAiSplitDocParams params_;
+  int64_t chunk_id_;
+  int64_t section_start_offset_;
+  ObString section_title_;
+  ObString section_content_;
+  bool is_done_;
+  ObArenaAllocator row_alloc_;
+  ObIAllocator *allocator_;
+  ObTextSplitIterator *iterator_;
+};
+
+class ObAiSplitDocAdapter
+{
+public:
+  ObAiSplitDocAdapter()
+    : is_inited_(false), cur_chunk_(), cur_idx_(-1), allocator_(nullptr), iterator_(nullptr)
+  {}
+  ~ObAiSplitDocAdapter() { reset(); }
+
+  int init(ObIAllocator &allocator, const ObString &content,
+           const ObAiSplitDocParams &params);
+  int get_next_row();
+  bool is_inited() const { return is_inited_; }
+  int64_t get_cur_idx() const { return cur_idx_; }
+  const ObAiSplitDocChunk &get_cur_chunk() const { return cur_chunk_; }
+  void reset();
+
+private:
+  bool is_inited_;
+  ObAiSplitDocChunk cur_chunk_;
+  int64_t cur_idx_;
+  ObIAllocator *allocator_;
+  ObDocSplitIterator *iterator_;
+};
+
+} // namespace common
+} // namespace oceanbase
+
+#endif // OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_H_

--- a/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.h
+++ b/deps/oblib/src/lib/ai_split_document/ob_ai_split_document.h
@@ -21,8 +21,6 @@
 #include "lib/allocator/page_arena.h"
 #include "lib/string/ob_string.h"
 #include "lib/utility/ob_macro_utils.h"
-#include "common/json_type/ob_json_base.h"
-#include "common/json_type/ob_json_parse.h"
 #include <unicode/brkiter.h>
 #include <unicode/utext.h>
 
@@ -68,7 +66,8 @@ struct ObAiSplitDocParams
     max_ = other.max_;
     overlap_ = other.overlap_;
   }
-  int init(const ObIJsonBase *params_node);
+  int init(const ObString &type_str, const ObString &by_str,
+           const int64_t max, const int64_t overlap);
   int check_validity() const;
 
   ObAiSplitContentType type_;
@@ -117,7 +116,7 @@ struct ObAiSplitDocInput
 {
   ObAiSplitDocInput() : content_(), params_() {}
 
-  int init(const ObString &content, const ObIJsonBase *params_node);
+  int init(const ObString &content, const ObAiSplitDocParams &params);
   void reset()
   {
     content_.reset();

--- a/deps/oblib/src/lib/ai_split_document/ob_ai_split_document_util.cpp
+++ b/deps/oblib/src/lib/ai_split_document/ob_ai_split_document_util.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define USING_LOG_PREFIX LIB
+
+#include "lib/ai_split_document/ob_ai_split_document_util.h"
+#include "lib/oblog/ob_log_module.h"
+
+namespace oceanbase
+{
+namespace common
+{
+
+template <typename IteratorType>
+static int create_iterator(ObIAllocator &allocator, ObDocSplitIterator *&iterator)
+{
+  int ret = OB_SUCCESS;
+  void *buf = allocator.alloc(sizeof(IteratorType));
+  if (OB_ISNULL(buf)) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate document split iterator", K(ret));
+  } else {
+    iterator = new (buf) IteratorType();
+  }
+  return ret;
+}
+
+int ObAiSplitDocumentUtil::create_doc_split_iterator(const ObAiSplitDocParams &params,
+                                                     ObIAllocator &allocator,
+                                                     ObDocSplitIterator *&iterator)
+{
+  int ret = OB_SUCCESS;
+  iterator = nullptr;
+  if (params.type_ == ObAiSplitContentType::TEXT) {
+    ret = create_iterator<ObTextSplitIterator>(allocator, iterator);
+  } else if (params.type_ == ObAiSplitContentType::MARKDOWN) {
+    ret = create_iterator<ObMarkdownSplitIterator>(allocator, iterator);
+  } else {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid document content type", K(ret), K(params.type_));
+    LOG_USER_ERROR(OB_INVALID_ARGUMENT, "type must be 'text' or 'markdown'");
+  }
+  return ret;
+}
+
+} // namespace common
+} // namespace oceanbase

--- a/deps/oblib/src/lib/ai_split_document/ob_ai_split_document_util.h
+++ b/deps/oblib/src/lib/ai_split_document/ob_ai_split_document_util.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_UTIL_H_
+#define OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_UTIL_H_
+
+#include "lib/ai_split_document/ob_ai_split_document.h"
+
+namespace oceanbase
+{
+namespace common
+{
+
+class ObAiSplitDocumentUtil
+{
+public:
+  static int create_doc_split_iterator(const ObAiSplitDocParams &params,
+                                       ObIAllocator &allocator,
+                                       ObDocSplitIterator *&iterator);
+};
+
+} // namespace common
+} // namespace oceanbase
+
+#endif // OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_UTIL_H_

--- a/deps/oblib/src/lib/ob_name_def.h
+++ b/deps/oblib/src/lib/ob_name_def.h
@@ -1258,5 +1258,6 @@
 #define N_AI_EMBED                          "ai_embed"
 #define N_AI_RERANK                         "ai_rerank"
 #define N_AI_PROMPT                         "ai_prompt"
+#define N_LOAD_FILE                         "load_file"
 #define N_CHECK_LOCATION_ACCESS "check_location_access"
 #endif //OCEANBASE_LIB_OB_NAME_DEF_H_

--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -977,6 +977,7 @@ typedef enum ObItemType
   T_FUN_SYS_EMBEDDED_VEC = 1928,
   T_FUN_SYS_AI_PROMPT = 1929,
   T_FUN_SYS_VEC_VISIBLE = 1930, // vector index table 5
+  T_FUN_SYS_LOAD_FILE = 1941,
 
   ///< @note add new sys function type before this line
   T_FUN_SYS_END = 2000,
@@ -2882,6 +2883,7 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_AI_SPLIT_DOCUMENT_EXPRESSION = 4960,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/share/parameter/ob_parameter_seed.ipp
+++ b/src/share/parameter/ob_parameter_seed.ipp
@@ -431,6 +431,9 @@ DEF_PARAM(_min_const_integer_precision, INT, OB_CLUSTER_PARAMETER, "1", "[1, 20]
 DEF_PARAM(_lob_rowsets_max_rows, INT, OB_CLUSTER_PARAMETER, "65535", "[1, 65535]",
         "max batch size of physical plan with lob data",
         ObParameterAttr(Section::TENANT, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
+DEF_PARAM(document_ai_file_max_size, CAP, OB_CLUSTER_PARAMETER, "100MB", "[0MB, 500MB]",
+        "max size of document AI processing file",
+        ObParameterAttr(Section::TENANT, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
 DEF_PARAM(_use_hash_rollup, STR_WITH_CHECKER, OB_CLUSTER_PARAMETER, "AUTO", common::ObConfigEnableHashRollupChecker,
         "policy of hash based rollup plan:"\
         "AUTO: hash rollup plan is up to optimizer;"\

--- a/src/sql/CMakeLists.txt
+++ b/src/sql/CMakeLists.txt
@@ -960,6 +960,7 @@ ob_set_subtarget(ob_sql engine_expr
   engine/expr/ob_expr_ai/ob_expr_ai_embed.cpp
   engine/expr/ob_expr_ai/ob_expr_ai_rerank.cpp
   engine/expr/ob_expr_ai/ob_expr_ai_prompt.cpp
+  engine/expr/ob_expr_ai/ob_expr_load_file.cpp
 )
 
 ob_set_subtarget(ob_sql_extra ALONE

--- a/src/sql/code_generator/ob_static_engine_expr_cg.cpp
+++ b/src/sql/code_generator/ob_static_engine_expr_cg.cpp
@@ -124,6 +124,10 @@ int ObStaticEngineExprCG::detect_batch_size(const ObRawExprUniqueSet &exprs,
           } else {
             max_batch_size = compute_max_batch_size(raw_exprs.at(i));
           }
+          if (T_FUN_SYS_LOAD_FILE == raw_exprs.at(i)->get_expr_type()) {
+            max_batch_size = std::min(
+                max_batch_size, static_cast<int64_t>(ObExprBatchSize::small));
+          }
           batch_size = std::min(batch_size, max_batch_size);
         }
       }
@@ -139,12 +143,16 @@ int ObStaticEngineExprCG::detect_batch_size(const ObRawExprUniqueSet &exprs,
       } else {
         auto expr_cnt = vectorized_exprs.count();
         bool has_large_data = false;
+        bool has_load_file_expr = false;
         for (int i = 0; i < expr_cnt; i++) {
           ObRawExpr *raw_expr = vectorized_exprs.at(i);
           const ObRawExprResType &result_type = raw_expr->get_result_type();
           row_size += reserve_data_consume(result_type.get_type(), result_type.get_precision()) +
                       get_expr_datum_fixed_header_size();
           has_large_data = is_large_data(vectorized_exprs.at(i)->get_data_type());
+          if (T_FUN_SYS_LOAD_FILE == vectorized_exprs.at(i)->get_expr_type()) {
+            has_load_file_expr = true;
+          }
         }
         batch_size = config_target_maxsize / row_size;
         LOG_TRACE("detect_batch_size", K(row_size), K(batch_size), K(expr_cnt), K(has_large_data), K(lob_rowsets_max_rows));
@@ -155,6 +163,10 @@ int ObStaticEngineExprCG::detect_batch_size(const ObRawExprUniqueSet &exprs,
         batch_size = next_pow2(batch_size);
         if (has_large_data) {
           batch_size = std::min(lob_rowsets_max_rows, batch_size);
+        }
+        if (has_load_file_expr) {
+          batch_size = std::min(
+              static_cast<int64_t>(ObExprBatchSize::small), batch_size);
         }
         // range limit check
         if (batch_size < MIN_ROWSIZE) {

--- a/src/sql/engine/basic/ob_json_table_op.cpp
+++ b/src/sql/engine/basic/ob_json_table_op.cpp
@@ -19,6 +19,7 @@
 #include "sql/engine/expr/ob_expr_multi_mode_func_helper.h"
 #include "sql/engine/expr/ob_expr_json_value.h"
 #include "sql/engine/expr/ob_expr_json_query.h"
+#include "sql/engine/expr/ob_expr_lob_utils.h"
 #include "common/xml/ob_binary_aggregate.h"
 #include "sql/engine/expr/ob_expr_rb_func_helper.h"
 #include "sql/engine/expr/ob_array_expr_utils.h"
@@ -332,7 +333,8 @@ OB_DEF_SERIALIZE(ObJsonTableSpec)
     OB_UNIS_ENCODE(info);
   }
   if (OB_FAIL(ret)) {
-  } else if (table_type_ == MulModeTableType::OB_RB_ITERATE_TABLE_TYPE
+  } else if (table_type_ == MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE
+             || table_type_ == MulModeTableType::OB_RB_ITERATE_TABLE_TYPE
              || table_type_ == MulModeTableType::OB_UNNEST_TABLE_TYPE) {
     OB_UNIS_ENCODE(table_type_);
     int32_t value_exprs_count = value_exprs_.count() - 1;
@@ -361,7 +363,8 @@ OB_DEF_SERIALIZE_SIZE(ObJsonTableSpec)
     const ObJtColInfo& info = *cols_def_.at(i);
     OB_UNIS_ADD_LEN(info);
   }
-  if (table_type_ == MulModeTableType::OB_RB_ITERATE_TABLE_TYPE
+  if (table_type_ == MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE
+      || table_type_ == MulModeTableType::OB_RB_ITERATE_TABLE_TYPE
       || table_type_ == MulModeTableType::OB_UNNEST_TABLE_TYPE) {
     OB_UNIS_ADD_LEN(table_type_);
     int32_t value_exprs_count = value_exprs_.count() - 1;
@@ -408,12 +411,16 @@ OB_DEF_DESERIALIZE(ObJsonTableSpec)
         table_type_flag = OB_RB_ITERATE_TABLE;
       } else if (col_info->col_type_ == COL_TYPE_UNNEST) {
         table_type_flag = OB_UNNEST_TABLE;
+      } else if (col_info->col_type_ == COL_TYPE_AI_SPLIT_DOCUMENT) {
+        table_type_flag = OB_AI_SPLIT_DOCUMENT_TABLE;
       }
     }
   }
 
   if (OB_FAIL(ret)) {
-  } else if (table_type_flag == OB_RB_ITERATE_TABLE || table_type_flag == OB_UNNEST_TABLE) {
+  } else if (table_type_flag == OB_RB_ITERATE_TABLE
+             || table_type_flag == OB_UNNEST_TABLE
+             || table_type_flag == OB_AI_SPLIT_DOCUMENT_TABLE) {
     OB_UNIS_DECODE(table_type_);
     int32_t value_exprs_count = 0;
     OB_UNIS_DECODE(value_exprs_count);
@@ -641,6 +648,8 @@ int ObJsonTableOp::inner_rescan()
   int ret = OB_SUCCESS;
   if (OB_FAIL(ObOperator::inner_rescan())) {
     LOG_WARN("failed to inner rescan", K(ret));
+  } else if (OB_FAIL(root_->reset(&jt_ctx_))) {
+    LOG_WARN("failed to reset table function tree", K(ret));
   } else {
     jt_ctx_.row_alloc_.reuse();
   }
@@ -662,8 +671,6 @@ int ObJsonTableOp::reset_variable()
   } else if (MY_SPEC.value_exprs_.empty()) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("failed to open iter, value expr is null.", K(ret));
-  } else if (OB_FAIL(root_->reset(&jt_ctx_))) {
-    LOG_WARN("failed to open table func xml column node.", K(ret));
   } else {
     is_evaled_ = false;
   }
@@ -733,6 +740,16 @@ int ObJsonTableOp::init()
       } else if (OB_ISNULL(jt_ctx_.table_func_ = new (table_func_buf) UnnestTableFunc())) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("failed to new unnest node", K(ret));
+      }
+    } else if (jt_ctx_.is_ai_split_document_table_func()) {
+      table_func_buf = jt_ctx_.op_exec_alloc_->alloc(sizeof(AiSplitDocumentTableFunc));
+      if (OB_ISNULL(table_func_buf)) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("failed to allocate ai_split_document table function", K(ret));
+      } else if (OB_ISNULL(jt_ctx_.table_func_ =
+                              new (table_func_buf) AiSplitDocumentTableFunc())) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("failed to create ai_split_document table function", K(ret));
       }
     }
   }
@@ -946,6 +963,44 @@ int RegularCol::eval_unnest_col(ObRegCol &col_node, void* in, JtScanCtx* ctx, Ob
     }
   }
 
+  return ret;
+}
+
+int RegularCol::eval_ai_split_document_col(ObRegCol &col_node, void *in,
+                                           JtScanCtx *ctx, ObExpr *col_expr)
+{
+  INIT_SUCC(ret);
+  ObAiSplitDocAdapter *adapter = static_cast<ObAiSplitDocAdapter *>(in);
+  ObDatum &res_datum = col_expr->locate_datum_for_write(*ctx->eval_ctx_);
+  if (OB_ISNULL(adapter) || !adapter->is_inited() || adapter->get_cur_idx() < 0) {
+    res_datum.set_null();
+  } else {
+    const ObAiSplitDocChunk &chunk = adapter->get_cur_chunk();
+    const ObString &column_name = col_node.col_info_.col_name_;
+    if (0 == column_name.case_compare("CHUNK_ID")) {
+      res_datum.set_int(chunk.chunk_id_);
+    } else if (0 == column_name.case_compare("CHUNK_OFFSET")) {
+      res_datum.set_int(chunk.chunk_offset_);
+    } else if (0 == column_name.case_compare("CHUNK_LENGTH")) {
+      res_datum.set_int(chunk.chunk_length_);
+    } else if (0 == column_name.case_compare("CHUNK_TEXT")) {
+      ObTextStringDatumResult text_result(col_expr->datum_meta_.type_, col_expr,
+                                          ctx->eval_ctx_, &res_datum);
+      if (OB_FAIL(text_result.init(chunk.chunk_text_.length()))) {
+        LOG_WARN("failed to initialize ai_split_document text result", K(ret));
+      } else if (OB_FAIL(text_result.append(chunk.chunk_text_))) {
+        LOG_WARN("failed to write ai_split_document text result", K(ret));
+      } else {
+        text_result.set_result();
+      }
+    } else {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected ai_split_document output column", K(ret), K(column_name));
+    }
+  }
+  if (OB_SUCC(ret)) {
+    col_expr->get_eval_info(*ctx->eval_ctx_).evaluated_ = true;
+  }
   return ret;
 }
 
@@ -1198,6 +1253,181 @@ int UnnestTableFunc::get_iter_value(ObRegCol &col_node, JtScanCtx* ctx, bool &is
   return ret;
 }
 
+int AiSplitDocumentTableFunc::eval_input(ObJsonTableOp &jt, JtScanCtx &ctx,
+                                         ObEvalCtx &eval_ctx)
+{
+  INIT_SUCC(ret);
+  ObString content;
+  ObIJsonBase *params_node = NULL;
+  if (!ctx.is_ai_split_document_table_func()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid ai_split_document table function", K(ret));
+  } else if (ctx.spec_ptr_->value_exprs_.count() < 2) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("ai_split_document requires two expressions", K(ret),
+             K(ctx.spec_ptr_->value_exprs_.count()));
+  } else {
+    jt.reset_columns();
+  }
+
+  if (OB_SUCC(ret)) {
+    ObExpr *content_expr = ctx.spec_ptr_->value_exprs_.at(0);
+    ObDatum *content_datum = NULL;
+    if (OB_ISNULL(content_expr)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("ai_split_document content expression is null", K(ret));
+    } else if (OB_FAIL(content_expr->eval(eval_ctx, content_datum))) {
+      LOG_WARN("failed to evaluate ai_split_document content", K(ret));
+    } else if (OB_ISNULL(content_datum) || content_datum->is_null()) {
+      ret = OB_ITER_END;
+    } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(
+                           ctx.row_alloc_, *content_datum, content_expr->datum_meta_,
+                           content_expr->obj_meta_.has_lob_header(), content,
+                           ctx.exec_ctx_))) {
+      LOG_WARN("failed to read ai_split_document content", K(ret));
+    }
+  }
+
+  if (OB_SUCC(ret)) {
+    ObExpr *params_expr = ctx.spec_ptr_->value_exprs_.at(1);
+    ObDatum *params_datum = NULL;
+    if (OB_ISNULL(params_expr)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("ai_split_document parameters expression is null", K(ret));
+    } else if (OB_FAIL(params_expr->eval(eval_ctx, params_datum))) {
+      LOG_WARN("failed to evaluate ai_split_document parameters", K(ret));
+    } else if (OB_NOT_NULL(params_datum) && !params_datum->is_null()) {
+      const ObObjType params_type = params_expr->datum_meta_.type_;
+      const ObCollationType params_cs_type = params_expr->datum_meta_.cs_type_;
+      ObString params_str;
+      bool is_null = false;
+      MultimodeAlloctor tmp_allocator(ctx.row_alloc_, T_AI_SPLIT_DOCUMENT_EXPRESSION, ret);
+      if (params_type == ObNCharType
+          || !(params_type == ObJsonType || params_type == ObRawType
+               || ob_is_string_type(params_type))) {
+        ret = OB_ERR_INVALID_TYPE_FOR_OP;
+        LOG_WARN("invalid ai_split_document parameters type", K(ret), K(params_type));
+      } else if (OB_FAIL(ObJsonExprHelper::get_json_or_str_data(
+                           params_expr, eval_ctx, tmp_allocator, params_str, is_null))) {
+        LOG_WARN("failed to read ai_split_document parameters", K(ret));
+      } else if (is_null || params_str.empty()) {
+        is_null = true;
+      } else if (OB_FALSE_IT(tmp_allocator.set_baseline_size(params_str.length()))) {
+      } else if (ob_is_string_type(params_type)
+                 && params_cs_type != CS_TYPE_BINARY
+                 && ObCharset::charset_type_by_coll(params_cs_type) != CHARSET_UTF8MB4) {
+        const int64_t buf_len = params_str.length() * 2;
+        uint32_t result_len = 0;
+        char *buf = static_cast<char *>(tmp_allocator.alloc(buf_len));
+        if (OB_ISNULL(buf)) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          LOG_WARN("failed to allocate converted JSON parameters", K(ret));
+        } else if (OB_FAIL(ObCharset::charset_convert(
+                              params_cs_type, params_str.ptr(), params_str.length(),
+                              CS_TYPE_UTF8MB4_BIN, buf, buf_len, result_len))) {
+          LOG_WARN("failed to convert JSON parameters to utf8mb4", K(ret));
+        } else {
+          params_str.assign_ptr(buf, result_len);
+        }
+      }
+      if (OB_SUCC(ret) && !is_null) {
+        const ObJsonInType input_type = ObJsonExprHelper::get_json_internal_type(params_type);
+        const ObJsonInType expect_type = ObJsonInType::JSON_TREE;
+        const uint32_t parse_flag = ObJsonParser::JSN_RELAXED_FLAG
+                                    | ObJsonParser::JSN_UNIQUE_FLAG;
+        if (OB_FAIL(ObJsonBaseFactory::get_json_base(
+                        &tmp_allocator, params_str, input_type, expect_type,
+                        params_node, parse_flag,
+                        ObJsonExprHelper::get_json_max_depth_config()))) {
+          LOG_WARN("failed to parse ai_split_document parameters", K(ret), K(params_str));
+        }
+      }
+    }
+  }
+
+  if (OB_SUCC(ret)) {
+    void *buf = ctx.row_alloc_.alloc(sizeof(ObAiSplitDocInput));
+    if (OB_ISNULL(buf)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate ai_split_document input", K(ret));
+    } else {
+      ObAiSplitDocInput *input = new (buf) ObAiSplitDocInput();
+      if (OB_FAIL(input->init(content, params_node))) {
+        LOG_WARN("failed to initialize ai_split_document input", K(ret));
+      } else {
+        jt.input_ = input;
+      }
+    }
+  }
+  return ret;
+}
+
+int AiSplitDocumentTableFunc::reset_ctx(ObRegCol &scan_node, JtScanCtx *&ctx)
+{
+  INIT_SUCC(ret);
+  if (OB_NOT_NULL(scan_node.path_)) {
+    ObAiSplitDocAdapter *adapter = static_cast<ObAiSplitDocAdapter *>(scan_node.path_);
+    OB_DELETEx(ObAiSplitDocAdapter, &ctx->row_alloc_, adapter);
+    scan_node.path_ = NULL;
+    scan_node.iter_ = NULL;
+  }
+  return ret;
+}
+
+int AiSplitDocumentTableFunc::init_ctx(ObRegCol &scan_node, JtScanCtx *&ctx)
+{
+  UNUSED(ctx);
+  INIT_SUCC(ret);
+  scan_node.tab_type_ = MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE;
+  return ret;
+}
+
+int AiSplitDocumentTableFunc::reset_path_iter(ObRegCol &scan_node, void *in,
+                                              JtScanCtx *&ctx, ScanType init_flag,
+                                              bool &is_null_value)
+{
+  UNUSED(init_flag);
+  INIT_SUCC(ret);
+  ObAiSplitDocInput *input = static_cast<ObAiSplitDocInput *>(in);
+  if (OB_ISNULL(input)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("ai_split_document input is null", K(ret));
+  } else {
+    ObAiSplitDocAdapter *adapter = OB_NEWx(ObAiSplitDocAdapter, &ctx->row_alloc_);
+    if (OB_ISNULL(adapter)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate ai_split_document adapter", K(ret));
+    } else if (OB_FAIL(adapter->init(ctx->row_alloc_, input->content_, input->params_))) {
+      LOG_WARN("failed to initialize ai_split_document adapter", K(ret));
+      OB_DELETEx(ObAiSplitDocAdapter, &ctx->row_alloc_, adapter);
+    } else {
+      scan_node.iter_ = adapter;
+      scan_node.path_ = adapter;
+      ret = get_iter_value(scan_node, ctx, is_null_value);
+    }
+  }
+  return ret;
+}
+
+int AiSplitDocumentTableFunc::get_iter_value(ObRegCol &col_node, JtScanCtx *ctx,
+                                             bool &is_null_value)
+{
+  UNUSED(ctx);
+  UNUSED(is_null_value);
+  INIT_SUCC(ret);
+  ObAiSplitDocAdapter *adapter = static_cast<ObAiSplitDocAdapter *>(col_node.iter_);
+  if (OB_ISNULL(adapter)) {
+    ret = OB_ITER_END;
+  } else if (OB_FAIL(adapter->get_next_row())) {
+    if (ret != OB_ITER_END) {
+      LOG_WARN("failed to get ai_split_document row", K(ret));
+    }
+  } else {
+    ++col_node.cur_pos_;
+  }
+  return ret;
+}
+
 // default value cast type check
 bool RegularCol::check_cast_allowed(const ObObjType orig_type,
                                     const ObCollationType orig_cs_type,
@@ -1327,8 +1557,13 @@ void ObRegCol::destroy()
     if (tab_type_ == OB_ORA_JSON_TABLE_TYPE) { // do nothing current
       ObJsonPath* json_path = static_cast<ObJsonPath*>(path_);
       json_path->~ObJsonPath();
+    } else if (tab_type_ == OB_AI_SPLIT_DOCUMENT_TABLE_TYPE) {
+      ObAiSplitDocAdapter *adapter = static_cast<ObAiSplitDocAdapter *>(path_);
+      adapter->~ObAiSplitDocAdapter();
+      path_ = NULL;
     }
   }
+  iter_ = NULL;
 }
 
 void UnionNode::destroy()
@@ -1382,6 +1617,11 @@ int ObRegCol::eval_regular_col(void *in, JtScanCtx* ctx, bool& is_null_value)
   } else if (col_type == COL_TYPE_UNNEST) {
     if (OB_FAIL(RegularCol::eval_unnest_col(*this, in, ctx, col_expr))) {
       LOG_WARN("fail to eval unnest col", K(ret), K(col_type), K(cur_pos_), K(col_info_.output_column_idx_));
+    }
+  } else if (col_type == COL_TYPE_AI_SPLIT_DOCUMENT) {
+    if (OB_FAIL(RegularCol::eval_ai_split_document_col(*this, in, ctx, col_expr))) {
+      LOG_WARN("failed to evaluate ai_split_document column", K(ret), K(col_type),
+               K(cur_pos_), K(col_info_.output_column_idx_));
     }
   } else if (col_type == COL_TYPE_ORDINALITY) {
     if (OB_ISNULL(in)) {
@@ -1713,7 +1953,8 @@ int ObJsonTableOp::inner_get_next_row()
   bool is_root_null = false;
   if (!(jt_ctx_.is_json_table_func()
         || jt_ctx_.is_rb_iterate_table_func()
-        || jt_ctx_.is_unnest_table_func())) {
+        || jt_ctx_.is_unnest_table_func()
+        || jt_ctx_.is_ai_split_document_table_func())) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unsupport table function", K(ret));
   } else if (is_evaled_) {

--- a/src/sql/engine/basic/ob_json_table_op.cpp
+++ b/src/sql/engine/basic/ob_json_table_op.cpp
@@ -24,6 +24,7 @@
 #include "sql/engine/expr/ob_expr_rb_func_helper.h"
 #include "sql/engine/expr/ob_array_expr_utils.h"
 #include "share/roaringbitmap/ob_rb_utils.h"
+#include <limits>
 
 namespace oceanbase
 {
@@ -1253,12 +1254,87 @@ int UnnestTableFunc::get_iter_value(ObRegCol &col_node, JtScanCtx* ctx, bool &is
   return ret;
 }
 
+static int parse_ai_split_document_params(const ObIJsonBase *params_node,
+                                          ObAiSplitDocParams &params)
+{
+  INIT_SUCC(ret);
+  ObString type_str = ObString::make_string("markdown");
+  ObString by_str = ObString::make_string("word");
+  int64_t max = 256;
+  int64_t overlap = 0;
+  if (OB_ISNULL(params_node)) {
+    // Use defaults.
+  } else if (params_node->json_type() != ObJsonNodeType::J_OBJECT) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("document split parameters must be a JSON object", K(ret),
+             K(params_node->json_type()));
+    FORWARD_USER_ERROR(ret, "parameters must be a JSON object");
+  } else {
+    JsonObjectIterator iter = params_node->object_iterator();
+    while (OB_SUCC(ret) && !iter.end()) {
+      ObJsonObjPair elem;
+      if (OB_FAIL(iter.get_elem(elem))) {
+        LOG_WARN("failed to read document split parameter", K(ret));
+      } else if (0 == elem.first.case_compare("type")
+                 || 0 == elem.first.case_compare("by")) {
+        const bool is_type = 0 == elem.first.case_compare("type");
+        if (elem.second->json_type() != ObJsonNodeType::J_STRING) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_WARN("invalid document split parameter type", K(ret), K(elem.first),
+                   K(elem.second->json_type()));
+          FORWARD_USER_ERROR_MSG(ret, "parameter %s must be a string",
+                                 is_type ? "type" : "by");
+        } else if (is_type) {
+          type_str.assign_ptr(elem.second->get_data(), elem.second->get_data_length());
+        } else {
+          by_str.assign_ptr(elem.second->get_data(), elem.second->get_data_length());
+        }
+      } else if (0 == elem.first.case_compare("max")
+                 || 0 == elem.first.case_compare("overlap")) {
+        const bool is_max = 0 == elem.first.case_compare("max");
+        int64_t &value = is_max ? max : overlap;
+        if (elem.second->json_type() != ObJsonNodeType::J_INT
+            && elem.second->json_type() != ObJsonNodeType::J_UINT) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_WARN("invalid document split parameter type", K(ret), K(elem.first),
+                   K(elem.second->json_type()));
+          FORWARD_USER_ERROR_MSG(ret, "parameter %s must be an integer",
+                                 is_max ? "max" : "overlap");
+        } else if (elem.second->json_type() == ObJsonNodeType::J_UINT) {
+          const uint64_t uint_value = elem.second->get_uint();
+          if (uint_value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+            ret = OB_INVALID_ARGUMENT;
+            LOG_WARN("document split parameter is out of range", K(ret), K(elem.first),
+                     K(uint_value));
+            FORWARD_USER_ERROR_MSG(ret, "parameter %s is out of range",
+                                   is_max ? "max" : "overlap");
+          } else {
+            value = static_cast<int64_t>(uint_value);
+          }
+        } else {
+          value = elem.second->get_int();
+        }
+      } else {
+        ret = OB_INVALID_ARGUMENT;
+        LOG_WARN("unknown document split parameter", K(ret), K(elem.first));
+        FORWARD_USER_ERROR_MSG(ret, "unknown parameter '%.*s'",
+                               elem.first.length(), elem.first.ptr());
+      }
+      iter.next();
+    }
+  }
+  if (OB_SUCC(ret) && OB_FAIL(params.init(type_str, by_str, max, overlap))) {
+    LOG_WARN("failed to initialize document split parameters", K(ret));
+  }
+  return ret;
+}
+
 int AiSplitDocumentTableFunc::eval_input(ObJsonTableOp &jt, JtScanCtx &ctx,
                                          ObEvalCtx &eval_ctx)
 {
   INIT_SUCC(ret);
   ObString content;
-  ObIJsonBase *params_node = NULL;
+  ObAiSplitDocParams params;
   if (!ctx.is_ai_split_document_table_func()) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("invalid ai_split_document table function", K(ret));
@@ -1329,6 +1405,7 @@ int AiSplitDocumentTableFunc::eval_input(ObJsonTableOp &jt, JtScanCtx &ctx,
         }
       }
       if (OB_SUCC(ret) && !is_null) {
+        ObIJsonBase *params_node = NULL;
         const ObJsonInType input_type = ObJsonExprHelper::get_json_internal_type(params_type);
         const ObJsonInType expect_type = ObJsonInType::JSON_TREE;
         const uint32_t parse_flag = ObJsonParser::JSN_RELAXED_FLAG
@@ -1338,6 +1415,8 @@ int AiSplitDocumentTableFunc::eval_input(ObJsonTableOp &jt, JtScanCtx &ctx,
                         params_node, parse_flag,
                         ObJsonExprHelper::get_json_max_depth_config()))) {
           LOG_WARN("failed to parse ai_split_document parameters", K(ret), K(params_str));
+        } else if (OB_FAIL(parse_ai_split_document_params(params_node, params))) {
+          LOG_WARN("failed to initialize ai_split_document parameters", K(ret));
         }
       }
     }
@@ -1350,7 +1429,7 @@ int AiSplitDocumentTableFunc::eval_input(ObJsonTableOp &jt, JtScanCtx &ctx,
       LOG_WARN("failed to allocate ai_split_document input", K(ret));
     } else {
       ObAiSplitDocInput *input = new (buf) ObAiSplitDocInput();
-      if (OB_FAIL(input->init(content, params_node))) {
+      if (OB_FAIL(input->init(content, params))) {
         LOG_WARN("failed to initialize ai_split_document input", K(ret));
       } else {
         jt.input_ = input;

--- a/src/sql/engine/basic/ob_json_table_op.cpp
+++ b/src/sql/engine/basic/ob_json_table_op.cpp
@@ -1302,9 +1302,7 @@ int AiSplitDocumentTableFunc::eval_input(ObJsonTableOp &jt, JtScanCtx &ctx,
       ObString params_str;
       bool is_null = false;
       MultimodeAlloctor tmp_allocator(ctx.row_alloc_, T_AI_SPLIT_DOCUMENT_EXPRESSION, ret);
-      if (params_type == ObNCharType
-          || !(params_type == ObJsonType || params_type == ObRawType
-               || ob_is_string_type(params_type))) {
+      if (!(params_type == ObJsonType || ob_is_string_type(params_type))) {
         ret = OB_ERR_INVALID_TYPE_FOR_OP;
         LOG_WARN("invalid ai_split_document parameters type", K(ret), K(params_type));
       } else if (OB_FAIL(ObJsonExprHelper::get_json_or_str_data(

--- a/src/sql/engine/basic/ob_json_table_op.h
+++ b/src/sql/engine/basic/ob_json_table_op.h
@@ -28,6 +28,8 @@
 #include "sql/engine/expr/ob_expr.h"
 #include "sql/engine/expr/ob_json_param_type.h"
 #include "sql/engine/expr/ob_expr_json_utils.h"
+#include "lib/ai_split_document/ob_ai_split_document.h"
+#include "lib/ai_split_document/ob_ai_split_document_util.h"
 
 namespace oceanbase
 {
@@ -50,6 +52,7 @@ enum table_type : int8_t {
   OB_XML_TABLE = 2,
   OB_RB_ITERATE_TABLE = 3,
   OB_UNNEST_TABLE = 4,
+  OB_AI_SPLIT_DOCUMENT_TABLE = 5,
 };
 
 typedef enum JtNodeType {
@@ -166,6 +169,10 @@ struct JtScanCtx {
 
   bool is_unnest_table_func() {
     return spec_ptr_->table_type_ == OB_UNNEST_TABLE_TYPE;
+  }
+
+  bool is_ai_split_document_table_func() {
+    return spec_ptr_->table_type_ == OB_AI_SPLIT_DOCUMENT_TABLE_TYPE;
   }
 
   ObJsonTableSpec* spec_ptr_;
@@ -330,6 +337,19 @@ public:
   int reset_path_iter(ObRegCol &scan_node, void* in, JtScanCtx*& ctx, ScanType init_flag, bool &is_null_value);
   int get_iter_value(ObRegCol &col_node, JtScanCtx* ctx, bool &is_null_value);
   int reset_ctx(ObRegCol &scan_node, JtScanCtx*& ctx);
+};
+
+class AiSplitDocumentTableFunc : public MulModeTableFunc {
+public:
+  AiSplitDocumentTableFunc() : MulModeTableFunc() {}
+  ~AiSplitDocumentTableFunc() {}
+
+  int init_ctx(ObRegCol &scan_node, JtScanCtx*& ctx);
+  int eval_input(ObJsonTableOp &jt, JtScanCtx &ctx, ObEvalCtx &eval_ctx);
+  int reset_path_iter(ObRegCol &scan_node, void *in, JtScanCtx *&ctx,
+                      ScanType init_flag, bool &is_null_value);
+  int get_iter_value(ObRegCol &col_node, JtScanCtx *ctx, bool &is_null_value);
+  int reset_ctx(ObRegCol &scan_node, JtScanCtx *&ctx);
 };
 
 class ObMultiModeTableNode {
@@ -513,6 +533,8 @@ public:
   static int eval_value_col(ObRegCol &col_node, JtScanCtx* ctx, ObExpr* col_expr, bool& is_null);
   static int eval_exist_col(ObRegCol &col_node, JtScanCtx* ctx, ObExpr* col_expr, bool& is_null);
   static int eval_unnest_col(ObRegCol &col_node, void* in, JtScanCtx* ctx, ObExpr* col_expr);
+  static int eval_ai_split_document_col(ObRegCol &col_node, void *in,
+                                        JtScanCtx *ctx, ObExpr *col_expr);
   static void proc_query_on_error(JtScanCtx* ctx, ObRegCol &col_node, int& ret, bool& is_null);
   static int check_default_val_cast_allowed(JtScanCtx* ctx, ObMultiModeTableNode &col_node, ObExpr* expr)  { return 0; }  // check type of default value
   static int set_val_on_empty(JtScanCtx* ctx, ObRegCol &col_node, bool& need_cast_res, bool& is_null);

--- a/src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.cpp
+++ b/src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+
+#include "ob_expr_load_file.h"
+#include "lib/string/ob_string_buffer.h"
+#include "share/config/ob_tenant_config_mgr.h"
+#include "share/io/ob_backup_io_adapter.h"
+#include "share/io/ob_backup_storage_info.h"
+#include "share/schema/ob_schema_getter_guard.h"
+#include "sql/engine/expr/ob_expr_lob_utils.h"
+#include "sql/engine/expr/ob_expr_multi_mode_func_helper.h"
+#include "sql/engine/ob_exec_context.h"
+
+using namespace oceanbase::common;
+using namespace oceanbase::share::schema;
+
+namespace oceanbase
+{
+namespace sql
+{
+
+ObExprLoadFile::ObExprLoadFile(ObIAllocator &alloc)
+    : ObFuncExprOperator(alloc, T_FUN_SYS_LOAD_FILE, N_LOAD_FILE, 2,
+                         NOT_VALID_FOR_GENERATED_COL, NOT_ROW_DIMENSION)
+{
+}
+
+ObExprLoadFile::~ObExprLoadFile()
+{
+}
+
+int ObExprLoadFile::calc_result_type2(ObExprResType &type,
+                                      ObExprResType &type1,
+                                      ObExprResType &type2,
+                                      ObExprTypeCtx &type_ctx) const
+{
+  int ret = OB_SUCCESS;
+  bool is_null_result = false;
+  UNUSED(type_ctx);
+
+  if (type1.is_null() || type2.is_null()) {
+    is_null_result = true;
+  } else if (!ob_is_string_type(type1.get_type())) {
+    ret = OB_ERR_INVALID_TYPE_FOR_OP;
+    LOG_WARN("invalid location name type", K(ret), K(type1.get_type()));
+  } else if (!ob_is_string_type(type2.get_type())) {
+    ret = OB_ERR_INVALID_TYPE_FOR_OP;
+    LOG_WARN("invalid file name type", K(ret), K(type2.get_type()));
+  } else {
+    type1.set_calc_type(ObVarcharType);
+    type1.set_calc_collation_type(CS_TYPE_UTF8MB4_BIN);
+    type2.set_calc_type(ObVarcharType);
+    type2.set_calc_collation_type(CS_TYPE_UTF8MB4_BIN);
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (is_null_result) {
+    type.set_null();
+  } else {
+    type.set_blob();
+    type.set_length(OB_MAX_LONGTEXT_LENGTH);
+  }
+  return ret;
+}
+
+int ObExprLoadFile::eval_load_file(const ObExpr &expr,
+                                   ObEvalCtx &ctx,
+                                   ObDatum &expr_datum)
+{
+  int ret = OB_SUCCESS;
+  ObDatum *location_name_datum = nullptr;
+  ObDatum *filename_datum = nullptr;
+
+  if (ob_is_null(expr.obj_meta_.get_type())) {
+    expr_datum.set_null();
+  } else if (OB_FAIL(expr.eval_param_value(ctx, location_name_datum, filename_datum))) {
+    LOG_WARN("failed to evaluate load_file parameters", K(ret));
+  } else if (location_name_datum->is_null() || filename_datum->is_null()) {
+    expr_datum.set_null();
+  } else {
+    ObEvalCtx::TempAllocGuard tmp_alloc_guard(ctx);
+    MultimodeAlloctor allocator(tmp_alloc_guard.get_allocator(), expr.type_, ret, N_LOAD_FILE);
+    lib::ObMallocHookAttrGuard malloc_guard(lib::ObMemAttr(N_LOAD_FILE));
+    ObString location_name;
+    ObString filename;
+    ObString file_data;
+
+    if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(
+                         allocator,
+                         *location_name_datum,
+                         expr.args_[0]->datum_meta_,
+                         expr.args_[0]->obj_meta_.has_lob_header(),
+                         location_name,
+                         &ctx.exec_ctx_))) {
+      LOG_WARN("failed to read location name", K(ret));
+    } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(
+                         allocator,
+                         *filename_datum,
+                         expr.args_[1]->datum_meta_,
+                         expr.args_[1]->obj_meta_.has_lob_header(),
+                         filename,
+                         &ctx.exec_ctx_))) {
+      LOG_WARN("failed to read file name", K(ret));
+    } else if (OB_FAIL(read_file_from_location(
+                         location_name, filename, ctx.exec_ctx_, allocator, file_data))) {
+      LOG_WARN("failed to read file from location", K(ret), K(location_name), K(filename));
+    } else if (OB_FAIL(ObTextStringHelper::string_to_templob_result(
+                         expr, ctx, expr_datum, file_data))) {
+      LOG_WARN("failed to build load_file result", K(ret), K(file_data.length()));
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::eval_load_file_vector(const ObExpr &expr,
+                                          ObEvalCtx &ctx,
+                                          const ObBitVector &skip,
+                                          const EvalBound &bound)
+{
+  int ret = OB_SUCCESS;
+
+  if (OB_FAIL(expr.eval_vector_param_value(ctx, skip, bound))) {
+    LOG_WARN("failed to evaluate load_file vector parameters", K(ret));
+  } else {
+    ObIVector *location_name_vec = expr.args_[0]->get_vector(ctx);
+    ObIVector *filename_vec = expr.args_[1]->get_vector(ctx);
+    ObIVector *result_vec = expr.get_vector(ctx);
+    ObBitVector &eval_flags = expr.get_evaluated_flags(ctx);
+
+    for (int64_t idx = bound.start(); OB_SUCC(ret) && idx < bound.end(); ++idx) {
+      if (skip.at(idx) || eval_flags.at(idx)) {
+        continue;
+      }
+      eval_flags.set(idx);
+
+      if (ob_is_null(expr.obj_meta_.get_type())
+          || location_name_vec->is_null(idx)
+          || filename_vec->is_null(idx)) {
+        result_vec->set_null(idx);
+      } else {
+        ObEvalCtx::TempAllocGuard tmp_alloc_guard(ctx);
+        MultimodeAlloctor allocator(tmp_alloc_guard.get_allocator(), expr.type_, ret, N_LOAD_FILE);
+        lib::ObMallocHookAttrGuard malloc_guard(lib::ObMemAttr(N_LOAD_FILE));
+        ObString location_name;
+        ObString filename;
+        ObString file_data;
+
+        if (OB_FAIL(ret)) {
+        } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(
+                             allocator,
+                             location_name_vec,
+                             expr.args_[0]->datum_meta_,
+                             expr.args_[0]->obj_meta_.has_lob_header(),
+                             location_name,
+                             idx,
+                             &ctx.exec_ctx_))) {
+          LOG_WARN("failed to read vector location name", K(ret), K(idx));
+        } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(
+                             allocator,
+                             filename_vec,
+                             expr.args_[1]->datum_meta_,
+                             expr.args_[1]->obj_meta_.has_lob_header(),
+                             filename,
+                             idx,
+                             &ctx.exec_ctx_))) {
+          LOG_WARN("failed to read vector file name", K(ret), K(idx));
+        } else if (OB_FAIL(read_file_from_location(
+                             location_name, filename, ctx.exec_ctx_, allocator, file_data))) {
+          LOG_WARN("failed to read file from location", K(ret), K(location_name), K(filename), K(idx));
+        } else {
+          ObTextStringVectorResult<ObIVector> blob_result(
+              expr.datum_meta_.type_, &expr, &ctx, result_vec, idx);
+          if (OB_FAIL(blob_result.init_with_batch_idx(file_data.length(), idx))) {
+            LOG_WARN("failed to initialize vector BLOB result", K(ret), K(idx), K(file_data.length()));
+          } else if (OB_FAIL(blob_result.append(file_data))) {
+            LOG_WARN("failed to append vector BLOB result", K(ret), K(idx), K(file_data.length()));
+          } else {
+            blob_result.set_result();
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::read_file_from_location(const ObString &location_name,
+                                            const ObString &filename,
+                                            ObExecContext &exec_ctx,
+                                            ObIAllocator &allocator,
+                                            ObString &file_data)
+{
+  int ret = OB_SUCCESS;
+  const ObSQLSessionInfo *session_info = exec_ctx.get_my_session();
+  ObSchemaGetterGuard schema_guard;
+  const ObLocationSchema *location_schema = nullptr;
+  share::schema::ObSessionPrivInfo session_priv;
+  omt::ObTenantConfigGuard tenant_config(TENANT_CONF());
+  const int64_t max_file_size = tenant_config.is_valid()
+      ? static_cast<int64_t>(tenant_config->document_ai_file_max_size)
+      : DEFAULT_DOCUMENT_AI_FILE_MAX_SIZE;
+
+  if (location_name.empty() || filename.empty()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("location name or file name is empty", K(ret));
+  } else if (OB_ISNULL(session_info) || OB_ISNULL(GCTX.schema_service_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("session or schema service is null", K(ret), KP(session_info), KP(GCTX.schema_service_));
+  } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+    LOG_WARN("failed to get tenant schema guard", K(ret));
+  } else if (OB_FAIL(schema_guard.get_location_schema_by_name(location_name, location_schema))) {
+    LOG_WARN("failed to get location schema", K(ret), K(location_name));
+  } else if (OB_ISNULL(location_schema)) {
+    ret = OB_LOCATION_OBJ_NOT_EXIST;
+    LOG_WARN("location object does not exist", K(ret), K(location_name));
+  } else if (OB_FAIL(session_info->get_session_priv_info(session_priv))) {
+    LOG_WARN("failed to get session privilege information", K(ret));
+  } else if (OB_FAIL(schema_guard.check_location_access(
+                       session_priv,
+                       session_info->get_enable_role_array(),
+                       location_name,
+                       false /* read only */))) {
+    LOG_WARN("location read access denied", K(ret), K(location_name));
+  } else {
+    const ObString &location_url = location_schema->get_location_url_str();
+    const ObString &access_info = location_schema->get_location_access_info_str();
+    ObString file_url;
+    ObString file_url_cstr;
+    ObString access_info_cstr;
+    share::ObBackupStorageInfo storage_info;
+    ObBackupIoAdapter io_adapter;
+    int64_t file_size = -1;
+    int64_t read_size = 0;
+    char *buffer = nullptr;
+
+    if (OB_FAIL(build_file_path(location_url, filename, allocator, file_url))) {
+      LOG_WARN("failed to build file path", K(ret), K(location_url), K(filename));
+    } else if (OB_FAIL(ob_write_string(allocator, file_url, file_url_cstr, true))) {
+      LOG_WARN("failed to build C-style file URL", K(ret), K(file_url));
+    } else if (OB_FAIL(ob_write_string(allocator, access_info, access_info_cstr, true))) {
+      LOG_WARN("failed to build C-style location access information", K(ret));
+    } else if (OB_FAIL(storage_info.set(file_url_cstr.ptr(), access_info_cstr.ptr()))) {
+      LOG_WARN("failed to initialize storage information", K(ret), K(file_url));
+    } else if (OB_FAIL(io_adapter.get_file_length(file_url, &storage_info, file_size))) {
+      LOG_WARN("failed to get file size", K(ret), K(file_url));
+    } else if (file_size < 0) {
+      ret = OB_OBJECT_NAME_NOT_EXIST;
+      LOG_WARN("file does not exist", K(ret), K(file_url), K(file_size));
+    } else if (0 == file_size) {
+      ret = OB_INVALID_DATA;
+      LOG_WARN("empty files are not supported", K(ret), K(file_url));
+      FORWARD_USER_ERROR(ret, "invalid file size (empty file)");
+    } else if (file_size > max_file_size) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_WARN("file exceeds document AI size limit", K(ret), K(file_size), K(max_file_size));
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "file size exceeds document ai file max size is");
+    } else if (OB_ISNULL(buffer = static_cast<char *>(allocator.alloc(file_size)))) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate file buffer", K(ret), K(file_size));
+    } else if (OB_FAIL(io_adapter.read_single_file(
+                         file_url,
+                         &storage_info,
+                         buffer,
+                         file_size,
+                         read_size,
+                         ObStorageIdMod::get_default_id_mod()))) {
+      LOG_WARN("failed to read file", K(ret), K(file_url), K(file_size));
+    } else if (read_size != file_size) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("file read size mismatch", K(ret), K(file_url), K(file_size), K(read_size));
+    } else {
+      file_data.assign_ptr(buffer, static_cast<int32_t>(read_size));
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::build_file_path(const ObString &location_url,
+                                    const ObString &filename,
+                                    ObIAllocator &allocator,
+                                    ObString &full_path)
+{
+  int ret = OB_SUCCESS;
+  ObStringBuffer path_buffer(&allocator);
+  bool has_parent_component = false;
+
+  for (int64_t component_start = 0, pos = 0;
+       !has_parent_component && pos <= filename.length(); ++pos) {
+    if (pos == filename.length() || '/' == filename.ptr()[pos]) {
+      has_parent_component = 2 == pos - component_start
+                             && '.' == filename.ptr()[component_start]
+                             && '.' == filename.ptr()[component_start + 1];
+      component_start = pos + 1;
+    }
+  }
+
+  if (location_url.empty() || filename.empty()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("location URL or file name is empty", K(ret));
+  } else if (has_parent_component) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("file name cannot contain a parent directory component", K(ret), K(filename));
+  } else if (OB_FAIL(path_buffer.reserve(location_url.length() + filename.length() + 1))) {
+    LOG_WARN("failed to reserve file path buffer", K(ret), K(location_url.length()), K(filename.length()));
+  } else if (OB_FAIL(path_buffer.append(location_url))) {
+    LOG_WARN("failed to append location URL", K(ret), K(location_url));
+  } else {
+    const bool url_has_separator = '/' == location_url.ptr()[location_url.length() - 1];
+    const bool filename_has_separator = '/' == filename.ptr()[0];
+    ObString normalized_filename = filename;
+
+    if (url_has_separator && filename_has_separator) {
+      normalized_filename.assign_ptr(filename.ptr() + 1, filename.length() - 1);
+    } else if (!url_has_separator && !filename_has_separator
+               && OB_FAIL(path_buffer.append("/"))) {
+      LOG_WARN("failed to append file path separator", K(ret));
+    }
+
+    if (OB_FAIL(ret)) {
+    } else if (normalized_filename.empty()) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("file name is empty after path normalization", K(ret), K(filename));
+    } else if (OB_FAIL(path_buffer.append(normalized_filename))) {
+      LOG_WARN("failed to append file name", K(ret), K(normalized_filename));
+    } else if (OB_FAIL(path_buffer.get_result_string(full_path))) {
+      LOG_WARN("failed to take ownership of file path buffer", K(ret));
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::cg_expr(ObExprCGCtx &op_cg_ctx,
+                            const ObRawExpr &raw_expr,
+                            ObExpr &rt_expr) const
+{
+  UNUSED(op_cg_ctx);
+  UNUSED(raw_expr);
+  rt_expr.eval_func_ = eval_load_file;
+  rt_expr.eval_vector_func_ = eval_load_file_vector;
+  return OB_SUCCESS;
+}
+
+} // namespace sql
+} // namespace oceanbase

--- a/src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.h
+++ b/src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_H_
+#define OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_H_
+
+#include "sql/engine/expr/ob_expr_operator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+class ObExprLoadFile : public ObFuncExprOperator
+{
+public:
+  explicit ObExprLoadFile(common::ObIAllocator &alloc);
+  virtual ~ObExprLoadFile();
+
+  virtual int calc_result_type2(ObExprResType &type,
+                                ObExprResType &type1,
+                                ObExprResType &type2,
+                                common::ObExprTypeCtx &type_ctx) const override;
+  static int eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum);
+  static int eval_load_file_vector(const ObExpr &expr,
+                                   ObEvalCtx &ctx,
+                                   const ObBitVector &skip,
+                                   const EvalBound &bound);
+  virtual int cg_expr(ObExprCGCtx &op_cg_ctx,
+                      const ObRawExpr &raw_expr,
+                      ObExpr &rt_expr) const override;
+
+  static const int64_t DEFAULT_DOCUMENT_AI_FILE_MAX_SIZE = 100 * 1024 * 1024;
+
+private:
+  static int read_file_from_location(const common::ObString &location_name,
+                                     const common::ObString &filename,
+                                     ObExecContext &exec_ctx,
+                                     common::ObIAllocator &allocator,
+                                     common::ObString &file_data);
+  static int build_file_path(const common::ObString &location_url,
+                             const common::ObString &filename,
+                             common::ObIAllocator &allocator,
+                             common::ObString &full_path);
+
+  DISALLOW_COPY_AND_ASSIGN(ObExprLoadFile);
+};
+
+} // namespace sql
+} // namespace oceanbase
+
+#endif // OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_H_

--- a/src/sql/engine/expr/ob_expr_eval_functions.cpp
+++ b/src/sql/engine/expr/ob_expr_eval_functions.cpp
@@ -386,6 +386,7 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_embed.h"
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_rerank.h"
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
+#include "sql/engine/expr/ob_expr_ai/ob_expr_load_file.h"
 #include "ob_expr_vector_similarity.h"
 #include "ob_expr_check_location_access.h"
 
@@ -1341,6 +1342,7 @@ static ObExpr::EvalFunc g_expr_eval_functions[] = {
   ObExprVectorCosineSimilarity::calc_cosine_similarity,                /* 872 */
   ObExprVectorIPSimilarity::calc_ip_similarity,                        /* 873 */
   ObExprVectorSimilarity::calc_similarity,                             /* 874 */
+  ObExprLoadFile::eval_load_file,                                      /* 875 */
 };
 
 static ObExpr::EvalBatchFunc g_expr_eval_batch_functions[] = {
@@ -1767,6 +1769,7 @@ static ObExpr::EvalVectorFunc g_expr_eval_vector_functions[] = {
   ObExprAIComplete::eval_ai_complete_vector,                             /* 227 */
   ObExprAIEmbed::eval_ai_embed_vector,                                   /* 228 */
   NULL, // ObExprAIRerank::eval_ai_rerank_vector,                        /* 229 */
+  ObExprLoadFile::eval_load_file_vector,                                 /* 230 */
 };
 
 static ObExpr::EvalFunc g_decimal_int_eval_functions[] = {

--- a/src/sql/engine/expr/ob_expr_operator_factory.cpp
+++ b/src/sql/engine/expr/ob_expr_operator_factory.cpp
@@ -440,6 +440,7 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_embed.h"
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_rerank.h"
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
+#include "sql/engine/expr/ob_expr_ai/ob_expr_load_file.h"
 #include "sql/engine/expr/ob_expr_vector_similarity.h"
 #include "sql/engine/expr/ob_expr_check_location_access.h"
 
@@ -1147,6 +1148,7 @@ void ObExprOperatorFactory::register_expr_operators()
     REG_OP(ObExprAIEmbed);
     REG_OP(ObExprAIRerank);
     REG_OP(ObExprAIPrompt);
+    REG_OP(ObExprLoadFile);
     REG_OP(ObExprCheckLocationAccess);
   }();
 }

--- a/src/sql/ob_sql_define.h
+++ b/src/sql/ob_sql_define.h
@@ -129,6 +129,7 @@ enum JtColType {
   COL_TYPE_ORDINALITY_XML = 9,
   COL_TYPE_RB_ITERATE = 10,
   COL_TYPE_UNNEST = 11,
+  COL_TYPE_AI_SPLIT_DOCUMENT = 12,
 };
 
 enum ObNameTypeClass

--- a/src/sql/parser/non_reserved_keywords_mysql_mode.c
+++ b/src/sql/parser/non_reserved_keywords_mysql_mode.c
@@ -1162,6 +1162,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"INCONSISTENT", INCONSISTENT},
   {"INDIVIDUAL", INDIVIDUAL},
   {"hybrid_search", HYBRID_SEARCH},
+  {"ai_split_document", AI_SPLIT_DOCUMENT},
 };
 
 /** https://dev.mysql.com/doc/refman/5.7/en/sql-syntax-prepared-statements.html

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -977,6 +977,7 @@ typedef enum ObItemType
   T_FUN_SYS_EMBEDDED_VEC = 1928,
   T_FUN_SYS_AI_PROMPT = 1929,
   T_FUN_SYS_VEC_VISIBLE = 1930, // vector index table 5
+  T_FUN_SYS_LOAD_FILE = 1941,
 
   ///< @note add new sys function type before this line
   T_FUN_SYS_END = 2000,
@@ -2881,6 +2882,7 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_AI_SPLIT_DOCUMENT_EXPRESSION = 4960,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -274,7 +274,7 @@ END_P SET_VAR DELIMITER
 //-----------------------------reserved keyword end-------------------------------------------------
 %token <non_reserved_keyword>
 //-----------------------------non_reserved keyword begin-------------------------------------------
-        ACCESS ACCESS_INFO ACCESSID ACCESSKEY ACCESSTYPE ACCOUNT ACTION ACTIVE ADDDATE AFTER AGAINST AGGREGATE AI ALGORITHM ALL_META ALL_USER ALWAYS ALLOW ANALYSE ANY
+        ACCESS ACCESS_INFO ACCESSID ACCESSKEY ACCESSTYPE ACCOUNT ACTION ACTIVE ADDDATE AFTER AGAINST AGGREGATE AI AI_SPLIT_DOCUMENT ALGORITHM ALL_META ALL_USER ALWAYS ALLOW ANALYSE ANY
         APPID APPROX_COUNT_DISTINCT APPROX_COUNT_DISTINCT_SYNOPSIS APPROX_COUNT_DISTINCT_SYNOPSIS_MERGE
         ARRAY ASCII ASIS AT ATTRIBUTE AUTHORS AUTO AUTOEXTEND_SIZE AUTO_INCREMENT AUTO_INCREMENT_MODE AUTO_INCREMENT_CACHE_SIZE
         AVG AVG_ROW_LENGTH ACTIVATE AVAILABILITY ARCHIVELOG ASYNCHRONOUS AUDIT ADMIN AUTO_REFRESH API_MODE APPROX APPROXIMATE ARRAY_AGG ARRAY_FILTER ARRAY_FIRST ARRAY_MAP ARRAY_SORTBY 
@@ -537,7 +537,7 @@ END_P SET_VAR DELIMITER
 %type <node> skip_index_type opt_skip_index_type_list
 %type <node> opt_rebuild_column_store
 %type <node> vec_index_params vec_index_param vec_index_param_value opt_with_vector_index_parameters
-%type <node> json_table_expr rb_iterate_expr unnest_expr mock_jt_on_error_on_empty jt_column_list json_table_column_def 
+%type <node> json_table_expr rb_iterate_expr ai_split_document_expr unnest_expr mock_jt_on_error_on_empty jt_column_list json_table_column_def
 %type <node> json_table_ordinality_column_def json_table_exists_column_def json_table_value_column_def json_table_nested_column_def
 %type <node> opt_value_on_empty_or_error_or_mismatch opt_on_mismatch
 %type <node> table_values_clause table_values_clause_with_order_by_and_limit values_row_list row_value
@@ -12983,6 +12983,10 @@ tbl_name
 {
   $$ = $1;
 }
+| ai_split_document_expr
+{
+  $$ = $1;
+}
 | unnest_expr
 {
   $$ = $1;
@@ -21821,6 +21825,51 @@ RB_ITERATE '(' simple_expr ')'
 }
 ;
 
+ai_split_document_expr:
+AI_SPLIT_DOCUMENT '(' simple_expr ')'
+{
+  ParseNode *params_node = NULL;
+  malloc_terminal_node(params_node, result->malloc_pool_, T_VARCHAR);
+  params_node->str_value_ = "";
+  params_node->str_len_ = 0;
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION,
+                           3, $3, params_node, NULL);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ')' relation_name
+{
+  ParseNode *params_node = NULL;
+  malloc_terminal_node(params_node, result->malloc_pool_, T_VARCHAR);
+  params_node->str_value_ = "";
+  params_node->str_len_ = 0;
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION,
+                           3, $3, params_node, $5);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ')' AS relation_name
+{
+  ParseNode *params_node = NULL;
+  malloc_terminal_node(params_node, result->malloc_pool_, T_VARCHAR);
+  params_node->str_value_ = "";
+  params_node->str_len_ = 0;
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION,
+                           3, $3, params_node, $6);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ',' simple_expr ')'
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION,
+                           3, $3, $5, NULL);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ',' simple_expr ')' relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION,
+                           3, $3, $5, $7);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ',' simple_expr ')' AS relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION,
+                           3, $3, $5, $8);
+}
+;
+
 unnest_expr:
 UNNEST '(' simple_expr_list ')' 
 {
@@ -22881,6 +22930,7 @@ ACCESS_INFO
 |       INCONSISTENT 
 |       INDIVIDUAL
 |       HYBRID_SEARCH
+|       AI_SPLIT_DOCUMENT
 ;
 
 unreserved_keyword_special:

--- a/src/sql/printer/ob_dml_stmt_printer.cpp
+++ b/src/sql/printer/ob_dml_stmt_printer.cpp
@@ -382,6 +382,23 @@ int ObDMLStmtPrinter::print_table(const TableItem *table_item,
           }
           break;
         }
+        case MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE : {
+          DATA_PRINTF("AI_SPLIT_DOCUMENT(");
+          for (int64_t i = 0; OB_SUCC(ret) && i < table_item->json_table_def_->doc_exprs_.count(); ++i) {
+            if (OB_FAIL(expr_printer_.do_print(table_item->json_table_def_->doc_exprs_.at(i), T_FROM_SCOPE))) {
+              LOG_WARN("failed to print ai split document argument", K(ret), K(i));
+            } else if (i != table_item->json_table_def_->doc_exprs_.count() - 1) {
+              DATA_PRINTF(",");
+            } else {
+              DATA_PRINTF(")");
+            }
+          }
+          if (OB_SUCC(ret) && !table_item->alias_name_.empty()) {
+            DATA_PRINTF(" ");
+            PRINT_IDENT_WITH_QUOT(table_item->alias_name_);
+          }
+          break;
+        }
         default : {
           ret = OB_ERR_UNEXPECTED;
           LOG_WARN("unexpected table function type");

--- a/src/sql/resolver/dml/ob_dml_resolver.cpp
+++ b/src/sql/resolver/dml/ob_dml_resolver.cpp
@@ -3242,6 +3242,15 @@ int ObDMLResolver::resolve_table(const ParseNode &parse_tree,
         }
         break;
       }
+      case T_AI_SPLIT_DOCUMENT_EXPRESSION: {
+        if (OB_ISNULL(session_info_)) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_WARN("invalid argument", K(ret));
+        } else if (OB_FAIL(resolve_ai_split_document_item(*table_node, table_item))) {
+          LOG_WARN("failed to resolve ai_split_document item", K(ret));
+        }
+        break;
+      }
       case T_UNNEST_EXPRESSION: {
         if (OB_ISNULL(session_info_)) {
           ret = OB_INVALID_ARGUMENT;
@@ -4405,6 +4414,8 @@ int ObDMLResolver::create_unnest_table_item(TableItem *&table_item, ObItemType i
       table_def->table_type_ = MulModeTableType::OB_RB_ITERATE_TABLE_TYPE;
     } else if (item_type == T_UNNEST_EXPRESSION) {
       table_def->table_type_ = MulModeTableType::OB_UNNEST_TABLE_TYPE;
+    } else if (item_type == T_AI_SPLIT_DOCUMENT_EXPRESSION) {
+      table_def->table_type_ = MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE;
     } else {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("unexpected item_type", K(ret), K(item_type));
@@ -4521,6 +4532,8 @@ int ObDMLResolver::unnest_table_add_column(TableItem *&table_item, ColumnItem *&
     col_type = COL_TYPE_RB_ITERATE;
   } else if (table_item->json_table_def_->table_type_ == MulModeTableType::OB_UNNEST_TABLE_TYPE) {
     col_type = COL_TYPE_UNNEST;
+  } else if (table_item->json_table_def_->table_type_ == MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE) {
+    col_type = COL_TYPE_AI_SPLIT_DOCUMENT;
   }
 
   if (OB_FAIL(ret)) {
@@ -4542,6 +4555,41 @@ int ObDMLResolver::unnest_table_add_column(TableItem *&table_item, ColumnItem *&
     data_type.set_collation_level(CS_LEVEL_IMPLICIT);
     data_type.set_uint64();
     data_type.set_accuracy(ObAccuracy::DDL_DEFAULT_ACCURACY[ObUInt64Type]);
+  } else if (col_type == COL_TYPE_AI_SPLIT_DOCUMENT) {
+    if (0 == col_name.case_compare("CHUNK_ID")
+        || 0 == col_name.case_compare("CHUNK_OFFSET")
+        || 0 == col_name.case_compare("CHUNK_LENGTH")) {
+      data_type.set_collation_level(CS_LEVEL_IMPLICIT);
+      data_type.set_int();
+      data_type.set_accuracy(ObAccuracy::DDL_DEFAULT_ACCURACY[ObInt32Type]);
+    } else if (0 == col_name.case_compare("CHUNK_TEXT")) {
+      if (OB_ISNULL(table_item) || OB_ISNULL(table_item->json_table_def_)
+          || table_item->json_table_def_->doc_exprs_.empty()
+          || OB_ISNULL(table_item->json_table_def_->doc_exprs_.at(0))) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("content expression is missing", K(ret));
+      } else {
+        const ObRawExprResType &res_type =
+            table_item->json_table_def_->doc_exprs_.at(0)->get_result_type();
+        if (!res_type.is_null()
+            && !(res_type.is_string_type() || res_type.is_lob_storage())) {
+          ret = OB_ERR_INVALID_TYPE_FOR_OP;
+          LOG_WARN("invalid content type for ai_split_document", K(ret), K(res_type));
+        } else if (!res_type.is_null()
+                   && ObCharset::charset_type_by_coll(res_type.get_collation_type())
+                          != CHARSET_UTF8MB4) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_WARN("unsupported content charset for ai_split_document", K(ret), K(res_type));
+          FORWARD_USER_ERROR(ret, "ai_split_document content must use utf8mb4");
+        } else {
+          data_type.set_meta_type(res_type.get_obj_meta());
+          data_type.set_accuracy(res_type.get_accuracy());
+        }
+      }
+    } else {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected ai_split_document column", K(ret), K(col_name));
+    }
   } else if (col_type == COL_TYPE_UNNEST) {
     ObRawExpr *value_expr = table_item->json_table_def_->doc_exprs_[col_id - 1];
     uint16_t subschema_id = value_expr->get_subschema_id();
@@ -4597,6 +4645,81 @@ int ObDMLResolver::unnest_table_add_column(TableItem *&table_item, ColumnItem *&
 
   return ret;
 }
+
+int ObDMLResolver::resolve_ai_split_document_item(const ParseNode &parse_tree,
+                                                  TableItem *&tbl_item)
+{
+  int ret = OB_SUCCESS;
+  TableItem *item = NULL;
+  ColumnItem *col_item = NULL;
+  ParseNode *content_node = NULL;
+  ParseNode *parameters_node = NULL;
+  ParseNode *alias_node = NULL;
+  ObRawExpr *content_expr = NULL;
+  ObRawExpr *parameters_expr = NULL;
+  ObString table_name;
+
+  if (parse_tree.type_ != T_AI_SPLIT_DOCUMENT_EXPRESSION || 3 != parse_tree.num_child_) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected ai_split_document parse tree", K(ret), K(parse_tree.type_),
+             K(parse_tree.num_child_));
+  } else if (OB_ISNULL(content_node = parse_tree.children_[0])
+             || OB_ISNULL(parameters_node = parse_tree.children_[1])) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("ai_split_document argument is null", K(ret));
+  } else {
+    alias_node = parse_tree.children_[2];
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(resolve_sql_expr(*content_node, content_expr))) {
+    LOG_WARN("failed to resolve ai_split_document content", K(ret));
+  } else if (OB_ISNULL(content_expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("content expression is null", K(ret));
+  } else if (OB_FAIL(content_expr->deduce_type(session_info_))) {
+    LOG_WARN("failed to deduce ai_split_document content type", K(ret));
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(resolve_sql_expr(*parameters_node, parameters_expr))) {
+    LOG_WARN("failed to resolve ai_split_document parameters", K(ret));
+  } else if (OB_ISNULL(parameters_expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("parameters expression is null", K(ret));
+  } else if (OB_FAIL(parameters_expr->deduce_type(session_info_))) {
+    LOG_WARN("failed to deduce ai_split_document parameter type", K(ret));
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (OB_ISNULL(alias_node)) {
+    table_name = ObString("ai_split_document");
+  } else {
+    table_name.assign_ptr(alias_node->str_value_, alias_node->str_len_);
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(create_unnest_table_item(item, T_AI_SPLIT_DOCUMENT_EXPRESSION,
+                                              table_name))) {
+    LOG_WARN("failed to create ai_split_document table item", K(ret));
+  } else if (OB_FAIL(item->json_table_def_->doc_exprs_.push_back(content_expr))) {
+    LOG_WARN("failed to add ai_split_document content", K(ret));
+  } else if (OB_FAIL(item->json_table_def_->doc_exprs_.push_back(parameters_expr))) {
+    LOG_WARN("failed to add ai_split_document parameters", K(ret));
+  } else if (OB_FAIL(unnest_table_add_column(item, col_item, ObString("CHUNK_ID")))) {
+    LOG_WARN("failed to add CHUNK_ID", K(ret));
+  } else if (OB_FAIL(unnest_table_add_column(item, col_item, ObString("CHUNK_OFFSET")))) {
+    LOG_WARN("failed to add CHUNK_OFFSET", K(ret));
+  } else if (OB_FAIL(unnest_table_add_column(item, col_item, ObString("CHUNK_LENGTH")))) {
+    LOG_WARN("failed to add CHUNK_LENGTH", K(ret));
+  } else if (OB_FAIL(unnest_table_add_column(item, col_item, ObString("CHUNK_TEXT")))) {
+    LOG_WARN("failed to add CHUNK_TEXT", K(ret));
+  } else {
+    tbl_item = item;
+  }
+  return ret;
+}
+
 int ObDMLResolver::resolve_hybrid_search_item(const ParseNode &parse_tree, TableItem *&table_item)
 {
   INIT_SUCC(ret);

--- a/src/sql/resolver/dml/ob_dml_resolver.h
+++ b/src/sql/resolver/dml/ob_dml_resolver.h
@@ -212,6 +212,7 @@ public:
   int resolve_rb_iterate_item(const ParseNode &table_node,
                               TableItem *&table_item);
   int resolve_unnest_item(const ParseNode &table_node, TableItem *&table_item);
+  int resolve_ai_split_document_item(const ParseNode &table_node, TableItem *&table_item);
   int create_rb_iterate_table_item(TableItem *&table_item, ObString alias_name = NULL);
   int create_unnest_table_item(TableItem *&table_item, ObItemType item_type, ObString table_name);
   int rb_iterate_table_add_column(TableItem *&table_item, ColumnItem *&col_item, int64_t col_id = 1);

--- a/src/sql/resolver/dml/ob_dml_stmt.h
+++ b/src/sql/resolver/dml/ob_dml_stmt.h
@@ -46,6 +46,7 @@ enum MulModeTableType {
   OB_ORA_XML_TABLE_TYPE = 2,
   OB_RB_ITERATE_TABLE_TYPE = 3,
   OB_UNNEST_TABLE_TYPE = 4,
+  OB_AI_SPLIT_DOCUMENT_TABLE_TYPE = 5,
 };
 
 typedef struct ObJtColBaseInfo


### PR DESCRIPTION
## Summary

Implement the two DBSchool 2026 Document AI functions requested for seekdb:

- `LOAD_FILE(location_name, filename)`
- `AI_SPLIT_DOCUMENT(content[, params_json])`

The change is limited to the parser/resolver/execution/serialization/registration/build wiring needed by those two functions. It does not modify any official test or result file.

## Implementation

### LOAD_FILE

- Adds scalar expression registration and code generation for `LOAD_FILE`.
- Resolves a named LOCATION, checks access, builds the object path, enforces `document_ai_file_max_size`, reads the file, and returns a BLOB.
- Preserves NULL propagation and reports invalid names, missing files, empty files, access errors, and unsupported sizes through existing seekdb error paths.

Core files:
- `src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.{h,cpp}`
- expression type, factory, evaluator, code-generation, and parameter registration files

### AI_SPLIT_DOCUMENT

- Adds MySQL grammar, resolver, statement printing, serialization, and JSON-table execution wiring for the table function.
- Supports text and Markdown input, sentence/word splitting, `max`, and `overlap`.
- Returns `chunk_id`, `chunk_offset`, `chunk_length`, and `chunk_text`.
- Keeps JSON parsing in the SQL layer and passes plain parameter values to oblib, preserving module-layer boundaries and allocator lifetimes.

Core files:
- `deps/oblib/src/lib/ai_split_document/*`
- `src/sql/engine/basic/ob_json_table_op.{h,cpp}`
- parser/resolver/printer/item-type/build registration files

## Scope review

- Final diff: 25 files, 1,876 insertions, 9 deletions.
- Scope classification: **EXPECTED**.
- No generated source, test/result changes, unrelated formatting, macOS compatibility code, build artifacts, logs, absolute local paths, credentials, or unrelated features are included.
- The file count is consistent with the required end-to-end SQL plumbing and is smaller than the linked upstream Document AI reference implementation.

## Validation

Environment: Ubuntu 22.04, 16 vCPU, targeted build with `-j8`.

### PASS

- `bash build.sh init`
- `bash build.sh debug -DOB_USE_CCACHE=ON -DNEED_PARSER_CACHE=OFF`
- `make -j8 module_layer_check oblib_lib ob_sql`
- `make -j8 observer`
- built binary revision: `17e03803463db1171f7c0682c16c6ad17972f88e`
- observer startup with explicit data-disk resource limits
- `test_utility`: 1/1
- official mysqltest `ai_funcs/load_file`: `ok`
- official mysqltest `ai_funcs/ai_split_document`: `ok`
- result-file SHA-256 values unchanged before and after mysqltest
- supplementary runtime checks:
  - empty, short, and Unicode split input
  - invalid `max=0` rejection
  - empty and missing-file LOAD_FILE error paths
- `git diff --check`
- clean tracked server worktree after exact removal of CMake-generated untracked files

### FAIL

- Generic `test_sql_fast_parser` result comparison failed.
- The exact command and output hashes were reproduced on the untouched `vldb_2026` baseline (`a640cc3`), so this is not caused by this PR. No expected result was modified.

### NOT RUN

- The complete repository-wide mysqltest/unit-test suite was not run because this PR is intentionally limited to the two Document AI functions and the requested workflow prioritizes targeted validation.
- No test requiring unrelated services or modules was represented as passing.

## Remaining validation

Official GitHub Actions are expected to run the repository-wide checks for the PR.