### PR TITLE
feat: implement LOAD_FILE scalar function for Document AI

### DIFF
--- a/deps/oblib/src/CMakeLists.txt
+++ b/deps/oblib/src/CMakeLists.txt
@@ -342,7 +342,7 @@ else()
     ${DEP_DIR}/lib/sqlite/libsqlite3.a
     ${DEP_DIR}/lib/libz.a
     ${DEP_DIR}/lib/libicui18n.a
-    ${DEP_DIR}/lib/libicustubdata.a
+    ${DEP_DIR}/lib/libicudata.a
     ${DEP_DIR}/lib/libicuuc.a
     ${DEP_DIR}/lib/libprotobuf-c.a
     $<$<NOT:$<BOOL:${BUILD_EMBED_MODE}>>:${_LIB_PATH}/libarrow.a>

--- a/deps/oblib/src/lib/ob_name_def.h
+++ b/deps/oblib/src/lib/ob_name_def.h
@@ -1259,4 +1259,5 @@
 #define N_AI_RERANK                         "ai_rerank"
 #define N_AI_PROMPT                         "ai_prompt"
 #define N_CHECK_LOCATION_ACCESS "check_location_access"
+#define N_LOAD_FILE                         "load_file"
 #endif //OCEANBASE_LIB_OB_NAME_DEF_H_

--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -1057,6 +1057,7 @@ typedef enum ObItemType
   T_FUN_SYS_AI_RERANK = 2084,
   T_FUN_MD5_CNN_WS = 2085,
   T_FUN_SYS_BUCKET = 2086,
+  T_FUN_SYS_LOAD_FILE = 2087,
   T_MAX_OP = 3000,
 
   //pseudo column, to mark the group iterator id

--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -2883,6 +2883,7 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_AI_SPLIT_DOCUMENT_EXPRESSION = 4920,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/share/CMakeLists.txt
+++ b/src/share/CMakeLists.txt
@@ -48,6 +48,11 @@ ob_set_subtarget(ob_share vector
   ob_mysql_proc_statement.cpp
 )
 
+ob_set_subtarget(ob_share ai_split_document
+  ai_split_document/ob_ai_split_document.cpp
+  ai_split_document/ob_ai_split_document_util.cpp
+)
+
 ob_set_subtarget(ob_share ALONE
   ob_tenant_timezone.cpp
   ob_tenant_timezone_mgr.cpp

--- a/src/share/ai_split_document/ob_ai_split_document.cpp
+++ b/src/share/ai_split_document/ob_ai_split_document.cpp
@@ -1,0 +1,602 @@
+/**
+ * Copyright (c) 2025 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#define USING_LOG_PREFIX LIB
+
+#include "ob_ai_split_document.h"
+#include "ob_ai_split_document_util.h"
+#include "lib/oblog/ob_log_module.h"
+#include "lib/utility/ob_macro_utils.h"
+#include "lib/json/ob_json.h"
+#include "share/rc/ob_tenant_base.h"
+
+namespace oceanbase
+{
+namespace common
+{
+
+
+#define EXTRACT_JSON_ELEM_STR_WITH_PROCESS(json_key, str_val, process) \
+  if (elem.first.case_compare(json_key) == 0) { \
+    if (elem.second->json_type() != ObJsonNodeType::J_STRING) { \
+      ret = OB_INVALID_ARGUMENT; \
+      LOG_WARN("invalid json type", K(ret), K(elem.first), K(elem.second->json_type())); \
+      FORWARD_USER_ERROR(ret, "invalid parameters type for parameters." #json_key ", " #json_key " must be a string"); \
+    } else { \
+      str_val = ObString(elem.second->get_data_length(), elem.second->get_data()); \
+      process; \
+    } \
+  } else
+
+#define EXTRACT_JSON_ELEM_INT(json_key, int_val) \
+  if (elem.first.case_compare(json_key) == 0) { \
+    if (elem.second->json_type() != ObJsonNodeType::J_INT && elem.second->json_type() != ObJsonNodeType::J_UINT) { \
+      ret = OB_INVALID_ARGUMENT; \
+      LOG_WARN("invalid json type", K(ret), K(elem.first), K(elem.second->json_type())); \
+      FORWARD_USER_ERROR(ret, "invalid parameters type for parameters." #json_key ", " #json_key " must be an integer"); \
+    } else { \
+      int_val = elem.second->get_int(); \
+    } \
+  } else
+
+#define EXTRACT_JSON_ELEM_END() \
+  { \
+    ret = OB_INVALID_ARGUMENT; \
+    LOG_WARN("unknown json key param", K(ret), K(elem.first)); \
+    FORWARD_USER_ERROR_MSG(ret, "unknown parameter key '%.*s'", elem.first.length(), elem.first.ptr()); \
+  }
+
+int ObAiSplitDocInput::init(const ObString &content, const ObIJsonBase *params_node)
+{
+  int ret = OB_SUCCESS;
+  content_ = content;
+  OZ (params_.init(params_node));
+  return ret;
+}
+
+int ObAiSplitDocParams::init(const ObIJsonBase *params_node)
+{
+  int ret = OB_SUCCESS;
+  reset();
+  if (OB_ISNULL(params_node)) {
+    // do nothing
+  } else if (params_node->json_type() != ObJsonNodeType::J_OBJECT) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("parameters should be a JSON object", K(ret), K(params_node->json_type()));
+    FORWARD_USER_ERROR(ret, "parameters should be a JSON object");
+  } else {
+    ObString type_str;
+    ObString by_str;
+    JsonObjectIterator iter = params_node->object_iterator();
+    while (!iter.end() && OB_SUCC(ret)) {
+      ObJsonObjPair elem;
+      OZ(iter.get_elem(elem));
+      if (OB_SUCC(ret)) {
+        EXTRACT_JSON_ELEM_STR_WITH_PROCESS("type", type_str, parse_type(type_str))
+        EXTRACT_JSON_ELEM_STR_WITH_PROCESS("by", by_str, parse_by(by_str))
+        EXTRACT_JSON_ELEM_INT("max", max_)
+        EXTRACT_JSON_ELEM_INT("overlap", overlap_)
+        EXTRACT_JSON_ELEM_END()
+      }
+      iter.next();
+    }
+  }
+  // check validity after init
+  OZ(check_validity());
+  return ret;
+}
+
+int ObAiSplitDocParams::parse_type(const ObString &type_str)
+{
+  int ret = OB_SUCCESS;
+  if (0 == type_str.case_compare("text")) {
+    type_ = ObAiSplitContentType::TEXT;
+  } else if (0 == type_str.case_compare("markdown")) {
+    type_ = ObAiSplitContentType::MARKDOWN;
+  } else {
+    type_ = ObAiSplitContentType::MAX_CONTENT_TYPE;
+  }
+  return ret;
+}
+
+int ObAiSplitDocParams::parse_by(const ObString &by_str)
+{
+  int ret = OB_SUCCESS;
+  if (0 == by_str.case_compare("sentence")) {
+    by_ = ObAiSplitByUnit::SENTENCE;
+  } else if (0 == by_str.case_compare("word")) {
+    by_ = ObAiSplitByUnit::WORD;
+  } else {
+    by_ = ObAiSplitByUnit::MAX_UNIT_TYPE;
+  }
+  return ret;
+}
+
+int ObAiSplitDocParams::check_validity() const
+{
+  int ret = OB_SUCCESS;
+  if (max_ <= 0 || max_ > 1000) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid parameters", K(ret), K(max_), K(overlap_));
+    FORWARD_USER_ERROR_MSG(ret, "invalid value for parameters.max, max must be greater than 0 and less than 1000");
+  } else if (overlap_ < 0 || overlap_ > max_/2) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid parameters", K(ret), K(max_), K(overlap_));
+    FORWARD_USER_ERROR_MSG(ret, "invalid value for parameters.overlap, overlap must be greater than 0 and less than max/2");
+  } else if (by_ == ObAiSplitByUnit::MAX_UNIT_TYPE) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid split by unit", K(ret), K(by_));
+    FORWARD_USER_ERROR(ret, "invalid parameters value for parameters.by, by must be 'sentence' or 'word'");
+  } else if (type_ == ObAiSplitContentType::MAX_CONTENT_TYPE) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid content type", K(ret), K(type_));
+    FORWARD_USER_ERROR(ret, "invalid parameters value for parameters.type, type must be 'text' or 'markdown'");
+  }
+  return ret;
+}
+
+int ObAiSplitDocAdapter::init(ObIAllocator &allocator, const ObString &content, const ObAiSplitDocParams &params)
+{
+  int ret = OB_SUCCESS;
+  if (is_inited_) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("adapter already initialized", K(ret));
+  } else {
+    OX (reset());
+    OX (allocator_ = &allocator);
+    OZ (ObAiSplitDocumentUtil::create_doc_split_iterator(content, params, allocator, iterator_));
+    OZ (iterator_->open(content, allocator, params));
+    OX (is_inited_ = true);
+  }
+  return ret;
+}
+
+int ObAiSplitDocAdapter::get_next_row()
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("adapter not initialized", K(ret));
+  } else {
+    OZ (iterator_->get_next_row(cur_chunk_));
+    OX (cur_idx_++);
+  }
+  return ret;
+}
+
+void ObAiSplitDocAdapter::reset()
+{
+  if (OB_NOT_NULL(iterator_) && OB_NOT_NULL(allocator_)) {
+    OB_DELETEx(ObDocSplitIterator, allocator_, iterator_);
+  }
+  iterator_ = nullptr;
+  allocator_ = nullptr;
+  is_inited_ = false;
+  cur_idx_ = -1;
+  cur_chunk_.reset();
+}
+
+ObDocSplitIterator::~ObDocSplitIterator()
+{
+}
+
+ObTextSplitIterator::~ObTextSplitIterator()
+{
+  close();
+}
+
+int ObTextSplitIterator::open(const ObString &content, ObIAllocator &allocator, const ObAiSplitDocParams &params)
+{
+  int ret = OB_SUCCESS;
+  if (is_inited_) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("word split iterator already initialized", K(ret));
+  } else {
+    content_.assign_ptr(content.ptr(), content.length());
+    params_.assign(params);
+    chunk_id_ = 0;
+    chunk_start_offset_ = 0;
+    next_chunk_start_ = 0;
+    unit_since_window_start_ = 0;
+    current_boundary_ = 0;
+    is_done_ = false;
+    allocator_ = &allocator;
+
+    lib::ObMallocHookAttrGuard malloc_guard(lib::ObMemAttr("AiSplitDoc"));
+    // Create BreakIterator
+    UErrorCode status = U_ZERO_ERROR;
+    if (params.by_ == ObAiSplitByUnit::WORD) {
+      bi_ = icu::BreakIterator::createWordInstance(icu::Locale::getDefault(), status);
+    } else if (params.by_ == ObAiSplitByUnit::SENTENCE) {
+      bi_ = icu::BreakIterator::createSentenceInstance(icu::Locale::getDefault(), status);
+    } else {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("invalid split by unit", K(ret), K(params.by_));
+      FORWARD_USER_ERROR(ret, "invalid parameters value for parameters.by, by must be 'word' or 'sentence'");
+    }
+
+    if (OB_SUCC(ret)) {
+      if (U_FAILURE(status)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("failed to create BreakIterator", K(ret), K(status));
+      } else if (OB_ISNULL(bi_)) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("failed to create BreakIterator", K(ret));
+      }
+    }
+
+    // Create UText
+    if (OB_SUCC(ret)) {
+      utext_ = utext_openUTF8(NULL, content.ptr(), content.length(), &status);
+      if (U_FAILURE(status)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("failed to open UText", K(ret), K(status));
+      } else if (OB_ISNULL(utext_)) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("failed to open UText", K(ret));
+      }
+    }
+
+    // Set UText to BreakIterator
+    if (OB_SUCC(ret)) {
+      status = U_ZERO_ERROR;
+      bi_->setText(utext_, status);
+      if (U_FAILURE(status)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("failed to set UText to BreakIterator", K(ret), K(status));
+      }
+    }
+
+    if (OB_SUCC(ret)) {
+      is_inited_ = true;
+    } else {
+      close();
+    }
+  }
+  return ret;
+}
+
+int ObTextSplitIterator::get_next_row(ObAiSplitDocChunk &chunk)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("text split iterator not initialized", K(ret));
+  } else if (is_done_) {
+    ret = OB_ITER_END;
+  } else {
+    chunk.reset();
+    const int64_t max_unit = params_.max_;
+    const int64_t overlap_unit = params_.overlap_;
+    const int64_t chunk_step = max_unit - overlap_unit;
+    int64_t window_start = chunk_start_offset_;
+    bool chunk_found = false;
+    int64_t unit_count_in_chunk = chunk_start_offset_ == 0 ? 0 : overlap_unit;
+    int64_t boundary = current_boundary_;
+
+    while (boundary != icu::BreakIterator::DONE && !chunk_found) {
+      boundary = bi_->next();
+      if (boundary == icu::BreakIterator::DONE) {
+      } else {
+        if ((params_.by_ == ObAiSplitByUnit::WORD && bi_->getRuleStatus() != UBRK_WORD_NONE) ||
+            (params_.by_ == ObAiSplitByUnit::SENTENCE)) {
+          unit_count_in_chunk++;
+          unit_since_window_start_++;
+        }
+
+        if (unit_count_in_chunk >= max_unit) {
+          while (window_start < boundary && window_start < content_.length() && isspace(content_[window_start])) {
+            window_start++;
+          }
+          if (window_start < boundary) {
+            int64_t window_end = boundary;
+            while (window_end > window_start && isspace(content_[window_end - 1])) {
+              window_end--;
+            }
+            chunk.init(chunk_id_++, window_start, window_end - window_start, ObString(window_end - window_start, content_.ptr() + window_start));
+            chunk_found = true;
+          }
+          unit_count_in_chunk = overlap_unit;
+          if (overlap_unit == 0) {
+            next_chunk_start_ = boundary;
+          }
+          window_start = next_chunk_start_;
+          chunk_start_offset_ = window_start;
+        }
+
+        if (unit_since_window_start_ >= chunk_step) {
+          next_chunk_start_ = boundary;
+          unit_since_window_start_ = 0;
+        }
+      }
+    }
+    current_boundary_ = boundary;
+
+    if (!chunk_found && boundary == icu::BreakIterator::DONE) {
+      if (unit_count_in_chunk > overlap_unit || chunk_id_ == 0) {
+        int64_t end = content_.length();
+        while (window_start < end && isspace(content_[window_start])) {
+          window_start++;
+        }
+        while (end > window_start && isspace(content_[end - 1])) {
+          end--;
+        }
+        if (window_start < end) {
+          chunk.init(chunk_id_++, window_start, end - window_start, ObString(end - window_start, content_.ptr() + window_start));
+          chunk_found = true;
+        }
+      }
+      is_done_ = true;
+    }
+
+    if (!chunk_found) {
+      ret = OB_ITER_END;
+    }
+  }
+  return ret;
+}
+
+int ObTextSplitIterator::close()
+{
+  int ret = OB_SUCCESS;
+
+  is_inited_ = false;
+  content_.reset();
+  params_.reset();
+  chunk_start_offset_ = 0;
+  next_chunk_start_ = 0;
+  unit_since_window_start_ = 0;
+  chunk_id_ = 0;
+  current_boundary_ = 0;
+  is_done_ = false;
+
+  if (OB_NOT_NULL(bi_)) {
+    delete bi_;
+    bi_ = NULL;
+  }
+  if (OB_NOT_NULL(utext_)) {
+    utext_close(utext_);
+    utext_ = NULL;
+  }
+  return ret;
+}
+
+ObMarkdownSplitIterator::~ObMarkdownSplitIterator()
+{
+  close();
+}
+
+int ObMarkdownSplitIterator::open(const ObString &content, ObIAllocator &allocator, const ObAiSplitDocParams &params)
+{
+  int ret = OB_SUCCESS;
+  if (is_inited_) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("markdown split iterator already initialized", K(ret));
+  } else {
+    allocator_ = &allocator;
+    content_.assign_ptr(content.ptr(), content.length());
+    params_.assign(params);
+    chunk_id_ = 0;
+    section_start_offset_ = 0;
+    is_done_ = false;
+    section_title_.reset();
+    section_content_.reset();
+    row_alloc_.clear();
+
+    void *buf = allocator.alloc(sizeof(ObTextSplitIterator));
+    if (OB_ISNULL(buf)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to alloc memory for text iterator", K(ret));
+    } else {
+      iterator_ = new (buf) ObTextSplitIterator();
+    }
+
+    if (OB_SUCC(ret)) {
+      is_inited_ = true;
+    } else {
+      close();
+    }
+  }
+  return ret;
+}
+
+int ObMarkdownSplitIterator::get_next_row(ObAiSplitDocChunk &chunk)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("markdown split iterator not initialized", K(ret));
+  } else if (is_done_) {
+    ret = OB_ITER_END;
+  } else {
+    bool chunk_found = false;
+    if (!section_title_.empty()) {
+      row_alloc_.clear();
+    }
+
+    chunk.reset();
+    ObAiSplitDocChunk temp_chunk;
+    while (OB_SUCC(ret) && !chunk_found) {
+      if (OB_NOT_NULL(iterator_) && iterator_->is_inited()) {
+        if (OB_FAIL(iterator_->get_next_row(temp_chunk))) {
+          if (ret == OB_ITER_END) {
+            iterator_->close();
+            ret = OB_SUCCESS;
+          } else {
+            LOG_WARN("failed to get next chunk from iterator", K(ret));
+          }
+        } else {
+          int64_t section_start_in_content = section_content_.ptr() - content_.ptr();
+          chunk.init(chunk_id_++,
+                    section_start_in_content + temp_chunk.chunk_offset_,
+                    temp_chunk.chunk_length_,
+                    temp_chunk.chunk_text_);
+          if (!section_title_.empty()) {
+            const int64_t total_len = section_title_.length() + temp_chunk.chunk_text_.length();
+            char* buf = static_cast<char*>(row_alloc_.alloc(total_len));
+            CK (OB_NOT_NULL(buf));
+            OX (MEMCPY(buf, section_title_.ptr(), section_title_.length()));
+            OX (MEMCPY(buf + section_title_.length(), temp_chunk.chunk_text_.ptr(), temp_chunk.chunk_text_.length()));
+            OX (chunk.chunk_text_.assign_ptr(buf, total_len));
+          }
+          chunk_found = true;
+        }
+      } else {
+        if (OB_FAIL(get_next_section(section_title_, section_content_))) {
+          if (ret == OB_ITER_END) {
+            is_done_ = true;
+          } else {
+            LOG_WARN("failed to get next section", K(ret));
+          }
+        } else if (!section_title_.empty() && is_empty_section(section_content_)) {
+          int64_t section_start_in_content = section_title_.ptr() - content_.ptr();
+          chunk.init(chunk_id_++,
+                    section_start_in_content,
+                    section_title_.length(),
+                    section_title_);
+          chunk_found = true;
+        } else if (OB_FAIL(iterator_->open(section_content_, *allocator_, params_))) {
+          LOG_WARN("failed to open iterator with section content", K(ret));
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObMarkdownSplitIterator::close()
+{
+  int ret = OB_SUCCESS;
+
+  is_inited_ = false;
+  content_.reset();
+  params_.reset();
+  chunk_id_ = 0;
+  section_start_offset_ = 0;
+  is_done_ = false;
+  section_title_.reset();
+  section_content_.reset();
+
+  if (OB_NOT_NULL(iterator_)) {
+    iterator_->close();
+    ObTextSplitIterator *text_iterator = static_cast<ObTextSplitIterator*>(iterator_);
+    if (OB_NOT_NULL(allocator_) && OB_NOT_NULL(text_iterator)) {
+      OB_DELETEx(ObTextSplitIterator, allocator_, text_iterator);
+      iterator_ = nullptr;
+    }
+  }
+  row_alloc_.clear();
+  allocator_ = nullptr;
+  return ret;
+}
+
+int ObMarkdownSplitIterator::get_next_section(ObString &section_title, ObString &section_content)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("markdown split iterator not initialized", K(ret));
+  } else if (section_start_offset_ >= content_.length()) {
+    ret = OB_ITER_END;
+  } else {
+    section_title.reset();
+    section_content.reset();
+    bool has_title = false;
+    bool section_end = false;
+    int section_content_start = section_start_offset_;
+    int section_content_end = section_content_start;
+    int64_t line_start = section_start_offset_;
+    int64_t line_end = line_start;
+
+    while (OB_SUCC(ret) && line_start < content_.length() && !section_end) {
+      OZ (get_next_line(line_start, line_end));
+      if (OB_SUCC(ret)) {
+        if (is_title_line(ObString(line_end - line_start, content_.ptr() + line_start), DEFAULT_TITLE_LEVEL)) {
+          if (!has_title) {
+            has_title = true;
+            int64_t title_end = (line_end < content_.length()) ? line_end + 1 : content_.length();
+            section_title.assign_ptr(content_.ptr() + line_start, title_end - line_start);
+            section_content_start = title_end;
+          } else {
+            section_end = true;
+            section_content_end = line_start;
+          }
+        }
+      }
+      line_start = line_end + 1;
+    }
+
+    if (OB_SUCC(ret)) {
+      if (!section_end) {
+        section_content_end = line_end < content_.length() ? line_end + 1 : line_end;
+      }
+      section_content.assign_ptr(content_.ptr() + section_content_start,
+                                 section_content_end - section_content_start);
+      section_start_offset_ = section_content_end;
+    }
+  }
+  return ret;
+}
+
+bool ObMarkdownSplitIterator::is_empty_section(const ObString& section_content)
+{
+  int res = true;
+  if (section_content.length() == 0) {
+    res = true;
+  } else {
+    int pos = 0;
+    while (pos < section_content.length() && isspace(section_content[pos])) {
+      pos++;
+    }
+    res = pos == section_content.length();
+  }
+  return res;
+}
+
+bool ObMarkdownSplitIterator::is_title_line(const ObString& line, int title_level)
+{
+  bool res = true;
+  if (line.length() == 0 || line[0] != '#') {
+    res = false;
+  } else {
+    int count = 0;
+    int pos = 0;
+    while (pos < line.length() && line[pos] == '#') {
+      count++;
+      pos++;
+    }
+    if (count != title_level) res = false;
+  }
+  return res;
+}
+
+
+int ObMarkdownSplitIterator::get_next_line(int64_t line_start_offset, int64_t &line_end_offset)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("markdown split iterator not initialized", K(ret));
+  } else if (line_start_offset >= content_.length()) {
+    ret = OB_ITER_END;
+  } else {
+    line_end_offset = line_start_offset;
+    while (line_end_offset < content_.length() && content_[line_end_offset] != '\n') {
+      line_end_offset++;
+    }
+  }
+  return ret;
+}
+
+}
+
+}

--- a/src/share/ai_split_document/ob_ai_split_document.h
+++ b/src/share/ai_split_document/ob_ai_split_document.h
@@ -1,0 +1,274 @@
+/**
+ * Copyright (c) 2025 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#ifndef OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_H_
+#define OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_H_
+
+#include "lib/string/ob_string.h"
+#include "lib/container/ob_se_array.h"
+#include "lib/allocator/ob_allocator.h"
+#include "lib/utility/ob_macro_utils.h"
+#include "common/json_type/ob_json_base.h"
+#include "common/json_type/ob_json_parse.h"
+#include "share/ob_define.h"
+#include <unicode/brkiter.h>
+#include <unicode/utext.h>
+
+namespace oceanbase
+{
+namespace common
+{
+
+enum class ObAiSplitContentType
+{
+  TEXT = 0,
+  MARKDOWN = 1,
+  MAX_CONTENT_TYPE = 2,
+};
+
+enum class ObAiSplitByUnit
+{
+  WORD = 0,
+  SENTENCE = 1,
+  MAX_UNIT_TYPE = 2,
+};
+
+// Parameters structure for AI split document
+struct ObAiSplitDocParams
+{
+  ObAiSplitContentType type_;    // text or markdown, default: markdown
+  ObAiSplitByUnit by_;           // word or sentence, default: word
+  int64_t max_;                  // max words/sentences per chunk, default: 256
+  int64_t overlap_;              // overlap words/sentences between chunks, default: 0
+
+  ObAiSplitDocParams()
+    : type_(ObAiSplitContentType::MARKDOWN),
+      by_(ObAiSplitByUnit::WORD),
+      max_(256),
+      overlap_(0) {}
+
+  void reset()
+  {
+    type_ = ObAiSplitContentType::MARKDOWN;
+    by_ = ObAiSplitByUnit::WORD;
+    max_ = 256;
+    overlap_ = 0;
+  }
+  int init(const ObIJsonBase *params_node);
+  void assign(const ObAiSplitDocParams &other)
+  {
+    type_ = other.type_;
+    by_ = other.by_;
+    max_ = other.max_;
+    overlap_ = other.overlap_;
+  }
+  int check_validity() const;
+private:
+  int parse_type(const ObString &type_str);
+  int parse_by(const ObString &by_str);
+public:
+  TO_STRING_KV(K_(type), K_(by), K_(max), K_(overlap));
+};
+
+// Chunk data structure for AI split document
+struct ObAiSplitDocChunk
+{
+  int64_t chunk_id_;        // Chunk ID (0-based)
+  int64_t chunk_offset_;    // Byte offset in original document
+  int64_t chunk_length_;    // Byte length of chunk
+  ObString chunk_text_;     // Chunk text content
+
+  ObAiSplitDocChunk()
+    : chunk_id_(0),
+      chunk_offset_(0),
+      chunk_length_(0),
+      chunk_text_(){}
+  ~ObAiSplitDocChunk()
+  {
+    chunk_id_ = 0;
+    chunk_offset_ = 0;
+    chunk_length_ = 0;
+    chunk_text_.reset();
+  }
+
+  void init(int64_t id, int64_t offset, int64_t length, const ObString &text)
+  {
+    chunk_id_ = id;
+    chunk_offset_ = offset;
+    chunk_length_ = length;
+    chunk_text_ = text;
+  }
+
+  void reset() {
+    chunk_id_ = 0;
+    chunk_offset_ = 0;
+    chunk_length_ = 0;
+    chunk_text_.reset();
+  }
+  void assign(const ObAiSplitDocChunk &other)
+  {
+    chunk_id_ = other.chunk_id_;
+    chunk_offset_ = other.chunk_offset_;
+    chunk_length_ = other.chunk_length_;
+    chunk_text_ = other.chunk_text_;
+  }
+
+  TO_STRING_KV(K_(chunk_id), K_(chunk_offset), K_(chunk_length), K_(chunk_text));
+};
+
+// Input structure for AI split document (stored in jt.input_)
+struct ObAiSplitDocInput
+{
+  ObString content_;
+  ObAiSplitDocParams params_;
+
+  ObAiSplitDocInput()
+    : content_(),
+      params_() {}
+
+  int init(const ObString &content, const ObIJsonBase *params_node);
+  void reset()
+  {
+    content_.reset();
+    params_.reset();
+  }
+
+  TO_STRING_KV(K_(content), K_(params));
+};
+
+class ObDocSplitIterator
+{
+public:
+	ObDocSplitIterator(){};
+	virtual ~ObDocSplitIterator();
+	virtual int open(const ObString &content, ObIAllocator &allocator, const ObAiSplitDocParams &params) = 0;
+	virtual int get_next_row(ObAiSplitDocChunk &chunk) = 0;
+	virtual int close() = 0;
+};
+
+class ObTextSplitIterator : public ObDocSplitIterator
+{
+public:
+  ObTextSplitIterator() : is_inited_(false),
+                          content_(),
+                          params_(),
+                          chunk_id_(0),
+                          chunk_start_offset_(0),
+                          next_chunk_start_(0),
+                          unit_since_window_start_(0),
+                          current_boundary_(0),
+                          is_done_(false),
+                          allocator_(nullptr),
+                          bi_(NULL),
+                          utext_(NULL) {}
+  virtual ~ObTextSplitIterator() override;
+  inline bool is_inited() const { return is_inited_; }
+  virtual int open(const ObString &content, ObIAllocator &allocator, const ObAiSplitDocParams &params) override;
+  virtual int get_next_row(ObAiSplitDocChunk &chunk) override;
+  virtual int close() override;
+protected:
+  bool is_inited_;
+  ObString content_;
+  ObAiSplitDocParams params_;
+  int64_t chunk_id_;
+  int64_t chunk_start_offset_;
+  int64_t next_chunk_start_;
+  int64_t unit_since_window_start_;
+  int64_t current_boundary_;
+  bool is_done_;
+  ObIAllocator *allocator_;
+  icu::BreakIterator *bi_;
+  UText *utext_;
+public:
+  TO_STRING_KV(K_(is_inited), K_(content), K_(params), K_(chunk_id), K_(chunk_start_offset), K_(next_chunk_start), K_(unit_since_window_start), K_(current_boundary), K_(is_done), KP_(allocator), KP_(bi), KP_(utext));
+};
+
+class ObMarkdownSplitIterator : public ObDocSplitIterator
+{
+public:
+  ObMarkdownSplitIterator() : is_inited_(false),
+                              content_(),
+                              params_(),
+                              chunk_id_(0),
+                              section_start_offset_(0),
+                              section_title_(),
+                              section_content_(),
+                              is_done_(false),
+                              row_alloc_(),
+                              allocator_(nullptr),
+                              iterator_(nullptr){}
+  virtual ~ObMarkdownSplitIterator() override;
+  virtual int open(const ObString &content, ObIAllocator &allocator, const ObAiSplitDocParams &params) override;
+  virtual int get_next_row(ObAiSplitDocChunk &chunk) override;
+  virtual int close() override;
+private:
+  const static int64_t DEFAULT_TITLE_LEVEL = 1;
+  int get_next_section(ObString &section_title, ObString &section_content);
+  int get_next_line(int64_t line_start_offset, int64_t &line_end_offset);
+  bool is_empty_section(const ObString& section_content);
+  bool is_title_line(const ObString& line, int title_level);
+protected:
+  bool is_inited_;
+  ObString content_;
+  ObAiSplitDocParams params_;
+  int64_t chunk_id_;
+  int64_t section_start_offset_;
+  ObString section_title_;
+  ObString section_content_;
+  bool is_done_;
+  common::ObArenaAllocator row_alloc_;
+  ObIAllocator *allocator_;
+  ObTextSplitIterator *iterator_;
+public:
+  TO_STRING_KV(K_(is_inited), K_(content), K_(params), K_(chunk_id), K_(section_start_offset), K_(is_done), K_(section_title), K_(section_content), KP_(allocator), KP_(iterator));
+};
+
+// adapter for ObDocSplitIterator
+class ObAiSplitDocAdapter
+{
+public:
+  ObAiSplitDocAdapter()
+    : is_inited_(false),
+      cur_chunk_(),
+      cur_idx_(-1),
+      allocator_(nullptr),
+      iterator_(nullptr) {}
+  ~ObAiSplitDocAdapter(){ close(); }
+  // useful interface for jsontable op
+  int init(ObIAllocator &allocator, const ObString &content, const ObAiSplitDocParams &params);
+  int get_next_row();
+  inline int64_t get_cur_idx() const { return cur_idx_; }
+  inline const ObAiSplitDocChunk &get_cur_chunk() const { return cur_chunk_; }
+
+  // common interface
+  inline bool is_inited() const { return is_inited_; }
+  void reset();
+  void close()
+  {
+    reset();
+  }
+
+private:
+  bool is_inited_;
+  ObAiSplitDocChunk cur_chunk_;
+  int64_t cur_idx_;
+  ObIAllocator* allocator_;
+  ObDocSplitIterator* iterator_;
+  TO_STRING_KV(K_(is_inited), K_(cur_chunk), K_(cur_idx), KP_(allocator), KP_(iterator));
+};
+
+
+
+} // end namespace common
+} // end namespace oceanbase
+
+#endif /* OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_H_ */

--- a/src/share/ai_split_document/ob_ai_split_document_util.cpp
+++ b/src/share/ai_split_document/ob_ai_split_document_util.cpp
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2025 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#define USING_LOG_PREFIX LIB
+
+#include "ob_ai_split_document_util.h"
+#include "lib/oblog/ob_log_module.h"
+#include <unicode/brkiter.h>
+#include <unicode/utext.h>
+
+namespace oceanbase
+{
+namespace common
+{
+
+int ObAiSplitDocumentUtil::split_text_by_unit(const ObString &content,
+                                              const ObAiSplitDocParams &params,
+                                              ObIAllocator &allocator,
+                                              ObArray<ObAiSplitDocChunk> &chunks)
+{
+  int ret = OB_SUCCESS;
+
+  UText *utext = NULL;
+  icu::BreakIterator *bi = NULL;
+  UErrorCode status = U_ZERO_ERROR;
+  const int64_t max_unit = params.max_;
+  const int64_t overlap_unit = params.overlap_;
+  const int64_t chunk_step = max_unit - overlap_unit;
+  const int64_t chunks_count = chunks.count();
+
+  lib::ObMallocHookAttrGuard malloc_guard(lib::ObMemAttr("AiSplitDoc"));
+  // Create UText
+  if (OB_SUCC(ret)) {
+    utext = utext_openUTF8(NULL, content.ptr(), content.length(), &status);
+    if (U_FAILURE(status)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("failed to open UText", K(ret), K(status));
+    }
+  }
+
+  // Create BreakIterator
+  if (OB_SUCC(ret)) {
+    if (params.by_ == ObAiSplitByUnit::WORD) {
+      bi = icu::BreakIterator::createWordInstance(icu::Locale::getDefault(), status);
+    } else if (params.by_ == ObAiSplitByUnit::SENTENCE) {
+      bi = icu::BreakIterator::createSentenceInstance(icu::Locale::getDefault(), status);
+    } else {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("invalid split by unit", K(ret), K(params.by_));
+    }
+    if (OB_FAIL(ret)) {
+    } else if (OB_ISNULL(bi) || U_FAILURE(status)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("failed to create BreakIterator", K(ret), K(status));
+    }
+  }
+
+  // Set UText to BreakIterator
+  if (OB_SUCC(ret)) {
+    status = U_ZERO_ERROR;
+    bi->setText(utext, status);
+    if (U_FAILURE(status)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("failed to set UText to BreakIterator", K(ret), K(status));
+    }
+  }
+
+  int unit_count_in_chunk = 0;
+  int next_window_start = 0;
+  int window_start = 0;
+  int unit_since_window_start = 0;
+  int boundary = bi->next();
+  int chunk_id = 0;
+
+  while (OB_SUCC(ret) && boundary != icu::BreakIterator::DONE) {
+    if ((params.by_ == ObAiSplitByUnit::WORD && bi->getRuleStatus() != UBRK_WORD_NONE) ||
+        (params.by_ == ObAiSplitByUnit::SENTENCE)) {
+      unit_count_in_chunk++;
+      unit_since_window_start++;
+    }
+    if (unit_count_in_chunk >= max_unit) {
+      while (window_start < boundary && window_start < content.length() && isspace(content[window_start])) {
+        window_start++;
+      }
+      if (window_start < boundary) {
+        // construct chunk if there is meaningful content
+        ObString chunk_text;
+        ObAiSplitDocChunk chunk;
+        int window_end = boundary;
+        // trim space only at the end of the chunk
+        while (window_end > window_start && isspace(content[window_end - 1])) {
+          window_end--;
+        }
+        chunk_text.assign_ptr(content.ptr() + window_start, window_end - window_start);
+        OX (chunk.init(chunk_id++, window_start, window_end - window_start, chunk_text));
+        OZ (chunks.push_back(chunk));
+      }
+      unit_count_in_chunk = overlap_unit;
+      if (overlap_unit == 0) {
+        next_window_start = boundary;
+      }
+      window_start = next_window_start;
+    }
+    if (unit_since_window_start >= chunk_step) {
+      next_window_start = boundary;
+      unit_since_window_start = 0;
+    }
+    boundary = bi->next();
+  }
+
+  if (OB_SUCC(ret)){
+    if (unit_count_in_chunk > overlap_unit || chunks_count == chunks.count()) {
+      int end = content.length();
+      while (window_start < end && isspace(content[window_start])) {
+        window_start++;
+      }
+      while (end > window_start && isspace(content[end - 1])) {
+        end--;
+      }
+      if (window_start < end) {
+        // construct chunk if there is meaningful content
+        ObString chunk_text;
+        ObAiSplitDocChunk chunk;
+        chunk_text.assign_ptr(content.ptr() + window_start, end - window_start);
+        OX (chunk.init(chunk_id++, window_start, end - window_start, chunk_text));
+        OZ (chunks.push_back(chunk));
+      }
+    }
+  }
+
+  if (OB_NOT_NULL(bi)) {
+    delete bi;
+  }
+  if (OB_NOT_NULL(utext)) {
+    utext_close(utext);
+  }
+  return ret;
+}
+
+// Helper template function to create iterator
+template<typename IteratorType>
+static int create_iterator_impl(ObIAllocator &allocator, ObDocSplitIterator *&iterator)
+{
+  int ret = OB_SUCCESS;
+  void *buf = allocator.alloc(sizeof(IteratorType));
+  if (OB_ISNULL(buf)) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to alloc memory for iterator", K(ret));
+  } else {
+    iterator = new (buf) IteratorType();
+  }
+  return ret;
+}
+
+int ObAiSplitDocumentUtil::create_doc_split_iterator(const ObString &content,
+                                                     const ObAiSplitDocParams &params,
+                                                     ObIAllocator &allocator,
+                                                     ObDocSplitIterator *&iterator)
+{
+  int ret = OB_SUCCESS;
+  if (params.type_ == ObAiSplitContentType::TEXT) {
+    OZ (create_iterator_impl<ObTextSplitIterator>(allocator, iterator));
+  } else if (params.type_ == ObAiSplitContentType::MARKDOWN) {
+    OZ (create_iterator_impl<ObMarkdownSplitIterator>(allocator, iterator));
+  } else {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid content type", K(ret), K(params.type_));
+    FORWARD_USER_ERROR(ret, "invalid parameters value for parameters.type, type must be 'text' or 'markdown'");
+  }
+  return ret;
+}
+
+} // namespace common
+} // namespace oceanbase

--- a/src/share/ai_split_document/ob_ai_split_document_util.h
+++ b/src/share/ai_split_document/ob_ai_split_document_util.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2025 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#ifndef OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_UTIL_H_
+#define OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_UTIL_H_
+
+#include "ob_ai_split_document.h"
+#include "share/rc/ob_tenant_base.h"
+#include "lib/alloc/malloc_hook.h"
+
+
+namespace oceanbase
+{
+namespace common
+{
+
+class ObAiSplitDocumentUtil
+{
+public:
+  static int split_text_by_unit(const ObString &content,
+                                const ObAiSplitDocParams &params,
+                                ObIAllocator &allocator,
+                                ObArray<ObAiSplitDocChunk> &chunks);
+  static int create_doc_split_iterator(const ObString &content,
+                                       const ObAiSplitDocParams &params,
+                                       ObIAllocator &allocator,
+                                       ObDocSplitIterator *&iterator);
+};
+} // namespace common
+} // namespace oceanbase
+#endif /* OCEANBASE_LIB_AI_SPLIT_DOCUMENT_OB_AI_SPLIT_DOCUMENT_UTIL_H_ */

--- a/src/sql/CMakeLists.txt
+++ b/src/sql/CMakeLists.txt
@@ -518,6 +518,7 @@ ob_set_subtarget(ob_sql engine_expr
   engine/expr/ob_expr_char_length.cpp
   engine/expr/ob_expr_check_catalog_access.cpp
   engine/expr/ob_expr_check_location_access.cpp
+  engine/expr/ob_expr_ai/ob_expr_load_file.cpp
   engine/expr/ob_expr_cast.cpp
   engine/expr/ob_expr_coalesce.cpp
   engine/expr/ob_expr_coll_pred.cpp

--- a/src/sql/engine/basic/ob_json_table_op.cpp
+++ b/src/sql/engine/basic/ob_json_table_op.cpp
@@ -332,7 +332,8 @@ OB_DEF_SERIALIZE(ObJsonTableSpec)
     OB_UNIS_ENCODE(info);
   }
   if (OB_FAIL(ret)) {
-  } else if (table_type_ == MulModeTableType::OB_RB_ITERATE_TABLE_TYPE
+  } else if (table_type_ == MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE
+             || table_type_ == MulModeTableType::OB_RB_ITERATE_TABLE_TYPE
              || table_type_ == MulModeTableType::OB_UNNEST_TABLE_TYPE) {
     OB_UNIS_ENCODE(table_type_);
     int32_t value_exprs_count = value_exprs_.count() - 1;
@@ -361,7 +362,8 @@ OB_DEF_SERIALIZE_SIZE(ObJsonTableSpec)
     const ObJtColInfo& info = *cols_def_.at(i);
     OB_UNIS_ADD_LEN(info);
   }
-  if (table_type_ == MulModeTableType::OB_RB_ITERATE_TABLE_TYPE
+  if (table_type_ == MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE
+      || table_type_ == MulModeTableType::OB_RB_ITERATE_TABLE_TYPE
       || table_type_ == MulModeTableType::OB_UNNEST_TABLE_TYPE) {
     OB_UNIS_ADD_LEN(table_type_);
     int32_t value_exprs_count = value_exprs_.count() - 1;
@@ -408,12 +410,14 @@ OB_DEF_DESERIALIZE(ObJsonTableSpec)
         table_type_flag = OB_RB_ITERATE_TABLE;
       } else if (col_info->col_type_ == COL_TYPE_UNNEST) {
         table_type_flag = OB_UNNEST_TABLE;
+      } else if (col_info->col_type_ == COL_TYPE_AI_SPLIT_DOCUMENT) {
+        table_type_flag = OB_AI_SPLIT_DOCUMENT_TABLE;
       }
     }
   }
 
   if (OB_FAIL(ret)) {
-  } else if (table_type_flag == OB_RB_ITERATE_TABLE || table_type_flag == OB_UNNEST_TABLE) {
+  } else if (table_type_flag == OB_RB_ITERATE_TABLE || table_type_flag == OB_UNNEST_TABLE || table_type_flag == OB_AI_SPLIT_DOCUMENT_TABLE) {
     OB_UNIS_DECODE(table_type_);
     int32_t value_exprs_count = 0;
     OB_UNIS_DECODE(value_exprs_count);
@@ -734,6 +738,15 @@ int ObJsonTableOp::init()
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("failed to new unnest node", K(ret));
       }
+    } else if (jt_ctx_.is_ai_split_document_table_func()) {
+      table_func_buf = jt_ctx_.op_exec_alloc_->alloc(sizeof(AiSplitDocumentTableFunc));
+      if (OB_ISNULL(table_func_buf)) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("failed to allocate table func buf", K(ret));
+      } else if (OB_ISNULL(jt_ctx_.table_func_ = new (table_func_buf) AiSplitDocumentTableFunc())) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("failed to new ai_split_document node", K(ret));
+      }
     }
   }
   jt_ctx_.is_cover_error_ = false;
@@ -944,6 +957,51 @@ int RegularCol::eval_unnest_col(ObRegCol &col_node, void* in, JtScanCtx* ctx, Ob
     } else {
       res_datum.from_obj(elem_obj);
     }
+  }
+
+  return ret;
+}
+
+int RegularCol::eval_ai_split_document_col(ObRegCol &col_node, void* in, JtScanCtx* ctx, ObExpr* col_expr)
+{
+  INIT_SUCC(ret);
+  ObAiSplitDocAdapter *doc_adapter = reinterpret_cast<ObAiSplitDocAdapter *>(in);
+  ObExpr* expr = ctx->spec_ptr_->column_exprs_.at(col_node.col_info_.output_column_idx_);
+  ObDatum& res_datum = expr->locate_datum_for_write(*ctx->eval_ctx_);
+  int64_t cur_idx = doc_adapter->get_cur_idx();
+  col_node.cur_pos_++;
+
+  if (OB_ISNULL(doc_adapter) || !doc_adapter->is_inited() || cur_idx < 0) {
+    res_datum.set_null();
+  } else {
+    const ObAiSplitDocChunk &chunk = doc_adapter->get_cur_chunk();
+    const ObString &col_name = col_node.col_info_.col_name_;
+    // Determine which column to output based on column name
+    if (0 == col_name.case_compare("CHUNK_ID")) {
+      res_datum.set_int(chunk.chunk_id_);
+    } else if (0 == col_name.case_compare("CHUNK_OFFSET")) {
+      res_datum.set_int(chunk.chunk_offset_);
+    } else if (0 == col_name.case_compare("CHUNK_LENGTH")) {
+      res_datum.set_int(chunk.chunk_length_);
+    } else if (0 == col_name.case_compare("CHUNK_TEXT")) {
+      const ObString &res_str = chunk.chunk_text_;
+      ObTextStringDatumResult text_result(expr->datum_meta_.type_, expr, ctx->eval_ctx_, &res_datum);
+      int64_t res_len = res_str.length();
+      if (OB_FAIL(text_result.init(res_len))) {
+        LOG_WARN("fail to init string result length", K(ret), K(text_result), K(res_len));
+      } else if (OB_FAIL(text_result.append(res_str))) {
+        LOG_WARN("fail to append string", K(ret), K(res_str), K(text_result));
+      } else {
+        text_result.set_result();
+      }
+    } else {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected column name for ai_split_document", K(col_name), K(ret));
+    }
+  }
+
+  if (OB_SUCC(ret)) {
+    col_expr->get_eval_info(*ctx->eval_ctx_).evaluated_ = true;
   }
 
   return ret;
@@ -1198,6 +1256,177 @@ int UnnestTableFunc::get_iter_value(ObRegCol &col_node, JtScanCtx* ctx, bool &is
   return ret;
 }
 
+// AiSplitDocumentTableFunc implementation
+int AiSplitDocumentTableFunc::eval_input(ObJsonTableOp &jt, JtScanCtx &ctx, ObEvalCtx &eval_ctx)
+{
+  INIT_SUCC(ret);
+  ObAiSplitDocInput *doc_input = NULL;
+
+  if (!ctx.is_ai_split_document_table_func()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid table func", K(ret));
+  } else if (ctx.spec_ptr_->value_exprs_.count() < 2) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("ai_split_document requires at least 2 input expressions", K(ret),
+             K(ctx.spec_ptr_->value_exprs_.count()));
+  } else {
+    jt.reset_columns();
+  }
+
+  ObString content;
+  ObIJsonBase *params_node = NULL;
+  if (OB_SUCC(ret)) {
+    ObExpr *content_expr = ctx.spec_ptr_->value_exprs_.at(0);
+    ObDatum *content_datum = NULL;
+    if (OB_ISNULL(content_expr)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("content expr is null", K(ret));
+    } else if (OB_FAIL(content_expr->eval(eval_ctx, content_datum))) {
+      LOG_WARN("failed to eval content expr", K(ret));
+    } else if (content_datum->is_null()) {
+      ret = OB_ITER_END;
+    } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(ctx.row_alloc_, *content_datum, content_expr->datum_meta_, content_expr->obj_meta_.has_lob_header(), content, ctx.exec_ctx_))) {
+      LOG_WARN("failed to read real string data", K(ret));
+    }
+  }
+
+  if (OB_SUCC(ret)) {
+    ObExpr *params_expr = ctx.spec_ptr_->value_exprs_.at(1);
+    ObDatum *params_datum = NULL;
+    if (OB_ISNULL(params_expr)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("parameters expr is null", K(ret));
+    } else if (OB_FAIL(params_expr->eval(eval_ctx, params_datum))) {
+      LOG_WARN("failed to eval parameters expr", K(ret));
+    } else if (!params_datum->is_null()) {
+      ObDatumMeta& params_datum_meta = params_expr->datum_meta_;
+      ObObjType params_type = params_datum_meta.type_;
+      ObCollationType params_cs_type = params_datum_meta.cs_type_;
+      ObString params_str;
+      bool is_null = false;
+      MultimodeAlloctor tmp_allocator(ctx.row_alloc_, T_AI_SPLIT_DOCUMENT_EXPRESSION, ret);
+
+      if (params_type == ObNullType) {
+        is_null = true;
+      } else if (params_type == ObONCharType ||
+                  !(params_type == ObJsonType
+                    || params_type == ObORawType
+                    || ob_is_string_type(params_type))) {
+        ret = OB_ERR_INVALID_TYPE_FOR_OP;
+        LOG_WARN("invalid parameter type for ai_split_document", K(ret), K(params_type));
+      } else if (OB_FAIL(ObJsonExprHelper::get_json_or_str_data(params_expr, eval_ctx,
+                                                                  tmp_allocator, params_str, is_null))) {
+        LOG_WARN("get real data failed", K(ret));
+      } else if (is_null || params_str.empty()) {
+        is_null = true;
+      } else if (OB_FALSE_IT(tmp_allocator.set_baseline_size(params_str.length()))) {
+      } else if ((ob_is_string_type(params_type) || params_type == ObOLobType)
+                  && (params_cs_type != CS_TYPE_BINARY)
+                  && (ObCharset::charset_type_by_coll(params_cs_type) != CHARSET_UTF8MB4)) {
+        char *buf = nullptr;
+        const int64_t factor = 2;
+        int64_t buf_len = params_str.length() * factor;
+        uint32_t result_len = 0;
+
+        if (OB_ISNULL(buf = static_cast<char*>(tmp_allocator.alloc(buf_len)))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          LOG_WARN("alloc memory failed", K(ret));
+        } else if (OB_FAIL(ObCharset::charset_convert(params_cs_type, params_str.ptr(),
+                                                      params_str.length(), CS_TYPE_UTF8MB4_BIN, buf,
+                                                      buf_len, result_len))) {
+          LOG_WARN("charset convert failed", K(ret));
+        } else {
+          params_str.assign_ptr(buf, result_len);
+        }
+      }
+
+      if (OB_SUCC(ret) && !is_null) {
+        ObJsonInType params_in_type = ObJsonExprHelper::get_json_internal_type(params_type);
+        ObJsonInType expect_type = ObJsonInType::JSON_TREE;
+        uint32_t parse_flags = ObJsonParser::JSN_RELAXED_FLAG;
+        parse_flags |= ObJsonParser::JSN_UNIQUE_FLAG;
+
+        if (OB_FAIL(ObJsonBaseFactory::get_json_base(&tmp_allocator, params_str, params_in_type,
+                                                      expect_type, params_node, parse_flags,
+                                                      ObJsonExprHelper::get_json_max_depth_config()))) {
+          LOG_WARN("fail to parse json parameters", K(ret), K(params_str));
+        }
+      }
+    }
+  }
+
+  if (OB_SUCC(ret)) {
+    if (OB_ISNULL(doc_input = static_cast<ObAiSplitDocInput *>(ctx.row_alloc_.alloc(sizeof(ObAiSplitDocInput))))) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to alloc memory for ObAiSplitDocInput", K(ret));
+    } else {
+      OX (doc_input = new (doc_input) ObAiSplitDocInput());
+      OZ (doc_input->init(content, params_node));
+      OX (jt.input_ = doc_input);
+    }
+  }
+
+  return ret;
+}
+
+int AiSplitDocumentTableFunc::reset_ctx(ObRegCol &scan_node, JtScanCtx*& ctx)
+{
+  INIT_SUCC(ret);
+  if (OB_NOT_NULL(scan_node.path_)) {
+    ObAiSplitDocAdapter *doc_adapter = static_cast<ObAiSplitDocAdapter*>(scan_node.path_);
+    OB_DELETEx(ObAiSplitDocAdapter, &ctx->row_alloc_, doc_adapter);
+    scan_node.path_ = NULL;
+    scan_node.iter_ = NULL;
+  }
+  return ret;
+}
+
+int AiSplitDocumentTableFunc::init_ctx(ObRegCol &scan_node, JtScanCtx*& ctx)
+{
+  INIT_SUCC(ret);
+  scan_node.tab_type_ = MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE;
+  return ret;
+}
+
+int AiSplitDocumentTableFunc::reset_path_iter(ObRegCol &scan_node, void* in,
+    JtScanCtx*& ctx, ScanType init_flag, bool &is_null_value)
+{
+  INIT_SUCC(ret);
+
+  ObAiSplitDocInput *doc_input = reinterpret_cast<ObAiSplitDocInput *>(in);
+  CK (OB_NOT_NULL(doc_input));
+
+  ObAiSplitDocAdapter *doc_adapter = NULL;
+  OX (doc_adapter = OB_NEWx(ObAiSplitDocAdapter, &ctx->row_alloc_));
+  CK (OB_NOT_NULL(doc_adapter));
+  OZ (doc_adapter->init(ctx->row_alloc_, doc_input->content_, doc_input->params_));
+  OX (scan_node.iter_ = doc_adapter);
+  OX (scan_node.path_ = doc_adapter);
+
+  OZ (get_iter_value(scan_node, ctx, is_null_value));
+  return ret;
+}
+
+int AiSplitDocumentTableFunc::get_iter_value(ObRegCol &col_node, JtScanCtx* ctx, bool &is_null_value)
+{
+  UNUSED(is_null_value);
+  INIT_SUCC(ret);
+  ObAiSplitDocAdapter *doc_adapter = reinterpret_cast<ObAiSplitDocAdapter *>(col_node.iter_);
+  if (OB_ISNULL(doc_adapter)) {
+    // do nothing
+  } else if (OB_FAIL(doc_adapter->get_next_row())) {
+    if (ret == OB_ITER_END) {
+    } else {
+      LOG_WARN("failed to get next row", K(ret));
+    }
+  }
+
+  if (OB_SUCC(ret)) {
+    col_node.cur_pos_++;
+  }
+  return ret;
+}
+
 // default value cast type check
 bool RegularCol::check_cast_allowed(const ObObjType orig_type,
                                     const ObCollationType orig_cs_type,
@@ -1327,7 +1556,14 @@ void ObRegCol::destroy()
     if (tab_type_ == OB_ORA_JSON_TABLE_TYPE) { // do nothing current
       ObJsonPath* json_path = static_cast<ObJsonPath*>(path_);
       json_path->~ObJsonPath();
+    } else if (tab_type_ == OB_AI_SPLIT_DOCUMENT_TABLE_TYPE && OB_NOT_NULL(path_)) {
+      ObAiSplitDocAdapter *doc_adapter = static_cast<ObAiSplitDocAdapter*>(path_);
+      doc_adapter->~ObAiSplitDocAdapter();
+      path_ = NULL;
     }
+  }
+  if (OB_NOT_NULL(iter_)) {
+    iter_ = NULL;
   }
 }
 
@@ -1382,6 +1618,10 @@ int ObRegCol::eval_regular_col(void *in, JtScanCtx* ctx, bool& is_null_value)
   } else if (col_type == COL_TYPE_UNNEST) {
     if (OB_FAIL(RegularCol::eval_unnest_col(*this, in, ctx, col_expr))) {
       LOG_WARN("fail to eval unnest col", K(ret), K(col_type), K(cur_pos_), K(col_info_.output_column_idx_));
+    }
+  } else if (col_type == COL_TYPE_AI_SPLIT_DOCUMENT) {
+    if (OB_FAIL(RegularCol::eval_ai_split_document_col(*this, in, ctx, col_expr))) {
+      LOG_WARN("fail to eval ai_split_document col", K(ret), K(col_type), K(cur_pos_), K(col_info_.output_column_idx_));
     }
   } else if (col_type == COL_TYPE_ORDINALITY) {
     if (OB_ISNULL(in)) {
@@ -1713,7 +1953,8 @@ int ObJsonTableOp::inner_get_next_row()
   bool is_root_null = false;
   if (!(jt_ctx_.is_json_table_func()
         || jt_ctx_.is_rb_iterate_table_func()
-        || jt_ctx_.is_unnest_table_func())) {
+        || jt_ctx_.is_unnest_table_func()
+        || jt_ctx_.is_ai_split_document_table_func())) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unsupport table function", K(ret));
   } else if (is_evaled_) {

--- a/src/sql/engine/basic/ob_json_table_op.h
+++ b/src/sql/engine/basic/ob_json_table_op.h
@@ -28,6 +28,8 @@
 #include "sql/engine/expr/ob_expr.h"
 #include "sql/engine/expr/ob_json_param_type.h"
 #include "sql/engine/expr/ob_expr_json_utils.h"
+#include "share/ai_split_document/ob_ai_split_document.h"
+#include "share/ai_split_document/ob_ai_split_document_util.h"
 
 namespace oceanbase
 {
@@ -50,6 +52,7 @@ enum table_type : int8_t {
   OB_XML_TABLE = 2,
   OB_RB_ITERATE_TABLE = 3,
   OB_UNNEST_TABLE = 4,
+  OB_AI_SPLIT_DOCUMENT_TABLE = 5,
 };
 
 typedef enum JtNodeType {
@@ -166,6 +169,10 @@ struct JtScanCtx {
 
   bool is_unnest_table_func() {
     return spec_ptr_->table_type_ == OB_UNNEST_TABLE_TYPE;
+  }
+
+  bool is_ai_split_document_table_func() {
+    return spec_ptr_->table_type_ == OB_AI_SPLIT_DOCUMENT_TABLE_TYPE;
   }
 
   ObJsonTableSpec* spec_ptr_;
@@ -324,6 +331,19 @@ public:
   UnnestTableFunc()
   : MulModeTableFunc() {}
   ~UnnestTableFunc() {}
+
+  int init_ctx(ObRegCol &scan_node, JtScanCtx*& ctx);
+  int eval_input(ObJsonTableOp &jt, JtScanCtx& ctx, ObEvalCtx &eval_ctx);
+  int reset_path_iter(ObRegCol &scan_node, void* in, JtScanCtx*& ctx, ScanType init_flag, bool &is_null_value);
+  int get_iter_value(ObRegCol &col_node, JtScanCtx* ctx, bool &is_null_value);
+  int reset_ctx(ObRegCol &scan_node, JtScanCtx*& ctx);
+};
+
+class AiSplitDocumentTableFunc : public MulModeTableFunc {
+public:
+  AiSplitDocumentTableFunc()
+  : MulModeTableFunc() {}
+  ~AiSplitDocumentTableFunc() {}
 
   int init_ctx(ObRegCol &scan_node, JtScanCtx*& ctx);
   int eval_input(ObJsonTableOp &jt, JtScanCtx& ctx, ObEvalCtx &eval_ctx);
@@ -513,6 +533,7 @@ public:
   static int eval_value_col(ObRegCol &col_node, JtScanCtx* ctx, ObExpr* col_expr, bool& is_null);
   static int eval_exist_col(ObRegCol &col_node, JtScanCtx* ctx, ObExpr* col_expr, bool& is_null);
   static int eval_unnest_col(ObRegCol &col_node, void* in, JtScanCtx* ctx, ObExpr* col_expr);
+  static int eval_ai_split_document_col(ObRegCol &col_node, void* in, JtScanCtx* ctx, ObExpr* col_expr);
   static void proc_query_on_error(JtScanCtx* ctx, ObRegCol &col_node, int& ret, bool& is_null);
   static int check_default_val_cast_allowed(JtScanCtx* ctx, ObMultiModeTableNode &col_node, ObExpr* expr)  { return 0; }  // check type of default value
   static int set_val_on_empty(JtScanCtx* ctx, ObRegCol &col_node, bool& need_cast_res, bool& is_null);

--- a/src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.cpp
+++ b/src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.cpp
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2025 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+#include "ob_expr_load_file.h"
+#include "sql/engine/expr/ob_expr_lob_utils.h"
+#include "sql/engine/ob_physical_plan_ctx.h"
+#include "lib/oblog/ob_log_module.h"
+#include "sql/engine/ob_exec_context.h"
+#include "share/schema/ob_schema_getter_guard.h"
+#include "lib/string/ob_sql_string.h"
+#include "lib/utility/utility.h"
+#include "lib/file/ob_file.h"
+#include "sql/engine/expr/ob_expr_ai/ob_ai_func_utils.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+using namespace oceanbase::common;
+using namespace oceanbase::sql;
+using namespace oceanbase::share::schema;
+
+namespace oceanbase
+{
+namespace sql
+{
+
+ObExprLoadFile::ObExprLoadFile(ObIAllocator &alloc)
+    : ObFuncExprOperator(alloc, T_FUN_SYS_LOAD_FILE, N_LOAD_FILE, 2,
+                         NOT_VALID_FOR_GENERATED_COL, NOT_ROW_DIMENSION)
+{
+}
+
+ObExprLoadFile::~ObExprLoadFile()
+{
+}
+
+int ObExprLoadFile::calc_result_type2(ObExprResType &type,
+                                      ObExprResType &type1,
+                                      ObExprResType &type2,
+                                      ObExprTypeCtx &type_ctx) const
+{
+  int ret = OB_SUCCESS;
+  bool is_null_res = false;
+  if (type1.is_null() || type2.is_null()) {
+    is_null_res = true;
+  } else {
+    if (!ob_is_string_type(type1.get_type())) {
+      ret = OB_ERR_INVALID_TYPE_FOR_OP;
+      LOG_WARN("invalid template type", K(ret), K(type1.get_type()));
+    } else {
+      type1.set_calc_type(ObVarcharType);
+      type1.set_calc_collation_type(CS_TYPE_UTF8MB4_BIN);
+    }
+
+    if (OB_FAIL(ret)) {
+    } else if (!ob_is_string_type(type2.get_type())) {
+      ret = OB_ERR_INVALID_TYPE_FOR_OP;
+      LOG_WARN("invalid template type", K(ret), K(type2.get_type()));
+    } else {
+      type2.set_calc_type(ObVarcharType);
+      type2.set_calc_collation_type(CS_TYPE_UTF8MB4_BIN);
+    }
+  }
+  if (OB_FAIL(ret)) {
+  } else if (is_null_res) {
+    type.set_null();
+  } else {
+    type.set_blob();
+    type.set_length(OB_MAX_LONGTEXT_LENGTH);
+  }
+  return ret;
+}
+
+int ObExprLoadFile::eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum)
+{
+  int ret = OB_SUCCESS;
+  ObDatum *location_name_datum = nullptr;
+  ObDatum *filename_datum = nullptr;
+  bool is_null_res = false;
+  ObString file_data;
+
+  if (ob_is_null(expr.obj_meta_.get_type())) {
+    is_null_res = true;
+  } else if (OB_FAIL(expr.eval_param_value(ctx, location_name_datum, filename_datum))) {
+    LOG_WARN("evaluate parameters failed", K(ret));
+  } else if (location_name_datum->is_null() || filename_datum->is_null()) {
+    is_null_res = true;
+  } else {
+    const ObString location_name = location_name_datum->get_string();
+    const ObString filename = filename_datum->get_string();
+    ObEvalCtx::TempAllocGuard tmp_alloc_g(ctx);
+    ObIAllocator &tmp_alloc = tmp_alloc_g.get_allocator();
+    if (OB_FAIL(read_file_from_location(location_name, filename, ctx.exec_ctx_, tmp_alloc, file_data))) {
+      LOG_WARN("fail to read file from location", K(ret), K(location_name), K(filename));
+    }
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (is_null_res) {
+    expr_datum.set_null();
+  } else {
+    ObTextStringDatumResult blob_res(ObLongTextType, &expr, &ctx, &expr_datum);
+    if (OB_FAIL(blob_res.init(file_data.length()))) {
+      LOG_WARN("fail to init blob result", K(ret), K(file_data.length()));
+    } else if (OB_FAIL(blob_res.append(file_data))) {
+      LOG_WARN("fail to append file data", K(ret), K(file_data.length()));
+    } else {
+      blob_res.set_result();
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::read_file_from_location(const ObString &location_name,
+                                            const ObString &filename,
+                                            ObExecContext &exec_ctx,
+                                            ObIAllocator &alloc,
+                                            ObString &file_data)
+{
+  int ret = OB_SUCCESS;
+  ObSchemaGetterGuard schema_guard;
+  const ObLocationSchema *location_schema = nullptr;
+  ObString file_url;
+  const ObSQLSessionInfo *session_info = exec_ctx.get_my_session();
+  share::schema::ObSessionPrivInfo session_priv;
+
+  if (location_name.empty() || filename.empty()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("location name or filename is empty", K(ret));
+  } else if (OB_ISNULL(GCTX.schema_service_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("schema service is null", K(ret));
+  } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+    LOG_WARN("fail to get tenant schema guard", K(ret));
+  } else if (OB_FAIL(schema_guard.get_location_schema_by_name(location_name, location_schema))) {
+    LOG_WARN("fail to get location schema by name", K(ret), K(location_name));
+  } else if (OB_ISNULL(location_schema)) {
+    ret = OB_LOCATION_OBJ_NOT_EXIST;
+    LOG_WARN("location object does't exist", K(ret), K(location_name));
+  } else if (OB_ISNULL(session_info)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("session info is null", K(ret));
+  } else if (OB_FAIL(session_info->get_session_priv_info(session_priv))) {
+    LOG_WARN("fail to get session priv info", K(ret));
+  } else if (OB_FAIL(schema_guard.check_location_access(session_priv,
+                                                        session_info->get_enable_role_array(),
+                                                        location_name,
+                                                        false /* is_need_write_priv: read only */))) {
+    LOG_WARN("location access denied", K(ret), K(location_name));
+  } else {
+    const ObString &location_url = location_schema->get_location_url_str();
+    if (OB_FAIL(build_file_path(location_url, filename, alloc, file_url))) {
+      LOG_WARN("fail to build full file path", K(ret), K(location_url), K(filename));
+    } else {
+      // strip "file://" prefix (7 bytes) to get POSIX path
+      const ObString file_prefix("file://");
+      ObString posix_path;
+      if (file_url.length() > file_prefix.length() && file_url.prefix_match(file_prefix)) {
+        posix_path.assign_ptr(file_url.ptr() + file_prefix.length(),
+                              file_url.length() - file_prefix.length());
+      } else {
+        // not a file:// URL, treat as plain path
+        posix_path = file_url;
+      }
+
+      int64_t file_size = get_file_size(posix_path.ptr());
+      if (file_size < 0) {
+        ret = OB_OBJECT_NAME_NOT_EXIST;
+        LOG_WARN("file does not exist", K(ret), K(posix_path));
+      } else if (file_size == 0) {
+        ret = OB_INVALID_DATA;
+        LOG_WARN("invalid file size (empty file)", K(ret), K(file_size));
+        FORWARD_USER_ERROR(ret, "invalid file size (empty file)");
+      } else {
+        char *buffer = nullptr;
+        if (OB_ISNULL(buffer = static_cast<char *>(alloc.alloc(file_size)))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          LOG_WARN("fail to allocate memory", K(ret), K(file_size));
+        } else {
+          int fd = -1;
+          if ((fd = open(posix_path.ptr(), O_RDONLY)) < 0) {
+            ret = OB_FILE_NOT_EXIST;
+            LOG_WARN("fail to open file", K(ret), K(posix_path), K(errno), KERRMSG);
+          } else {
+            int64_t read_bytes = unintr_pread(fd, buffer, file_size, 0);
+            if (read_bytes != file_size) {
+              ret = OB_ERR_UNEXPECTED;
+              LOG_WARN("read bytes mismatch", K(ret), K(read_bytes), K(file_size));
+            } else {
+              file_data.assign_ptr(buffer, static_cast<int32_t>(read_bytes));
+            }
+            close(fd);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::build_file_path(const ObString &location_url, const ObString &filename, ObIAllocator &alloc, ObString &full_path)
+{
+  int ret = OB_SUCCESS;
+  ObStringBuffer path_builder(&alloc);
+  if (location_url.empty() || filename.empty()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("location url or filename is empty", K(ret));
+  } else if (OB_FAIL(path_builder.reserve(location_url.length() + filename.length() + 2))) {
+    LOG_WARN("fail to reserve memory", K(ret), K(location_url.length()), K(filename.length()));
+  } else if (OB_FAIL(path_builder.append(location_url))) {
+    LOG_WARN("fail to append location url", K(ret), K(location_url));
+  } else {
+    const char *url_ptr = location_url.ptr();
+    int64_t url_len = location_url.length();
+    bool need_separator = true;
+    ObString path_str;
+    char *buf = nullptr;
+    if ((url_len > 0 && url_ptr[url_len - 1] == '/') || (filename.length() > 0 && filename.ptr()[0] == '/')) {
+      need_separator = false;
+    }
+    if (need_separator && OB_FAIL(path_builder.append("/"))) {
+      LOG_WARN("fail to append separator", K(ret));
+    } else if (OB_FAIL(path_builder.append(filename))) {
+      LOG_WARN("fail to append filename", K(ret), K(filename));
+    } else if (OB_FALSE_IT(path_str = path_builder.string())) {
+    } else if (OB_ISNULL(buf = static_cast<char *>(alloc.alloc(path_str.length())))) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("fail to allocate memory", K(ret), K(path_str.length()));
+    } else {
+      MEMCPY(buf, path_str.ptr(), path_str.length());
+      full_path.assign_ptr(buf, path_str.length());
+    }
+  }
+  return ret;
+}
+
+int ObExprLoadFile::cg_expr(ObExprCGCtx &op_cg_ctx, const ObRawExpr &raw_expr, ObExpr &rt_expr) const
+{
+  UNUSED(raw_expr);
+  UNUSED(op_cg_ctx);
+  rt_expr.eval_func_ = eval_load_file;
+  return OB_SUCCESS;
+}
+
+} // namespace sql
+} // namespace oceanbase

--- a/src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.h
+++ b/src/sql/engine/expr/ob_expr_ai/ob_expr_load_file.h
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2025 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_
+#define OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_
+
+#include "sql/engine/expr/ob_expr_operator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+class ObExprLoadFile : public ObFuncExprOperator
+{
+public:
+  explicit ObExprLoadFile(common::ObIAllocator &alloc);
+  virtual ~ObExprLoadFile();
+  virtual int calc_result_type2(ObExprResType &type,
+                                ObExprResType &type1,
+                                ObExprResType &type2,
+                                common::ObExprTypeCtx &type_ctx) const override;
+  static int eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum);
+  virtual int cg_expr(ObExprCGCtx &op_cg_ctx, const ObRawExpr &raw_expr, ObExpr &rt_expr) const override;
+  static const int64_t DEFAULT_DOCUMENT_AI_FILE_MAX_SIZE = 100 * 1024 * 1024; // 100MB
+private:
+  static int read_file_from_location(const common::ObString &location_name,
+                                     const common::ObString &filename,
+                                     ObExecContext &exec_ctx,
+                                     common::ObIAllocator &alloc,
+                                     common::ObString &file_data);
+  static int build_file_path(const common::ObString &location_url,
+                             const common::ObString &filename,
+                             common::ObIAllocator &alloc,
+                             common::ObString &full_path);
+  DISALLOW_COPY_AND_ASSIGN(ObExprLoadFile);
+};
+}
+}
+#endif /*OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_*/

--- a/src/sql/engine/expr/ob_expr_eval_functions.cpp
+++ b/src/sql/engine/expr/ob_expr_eval_functions.cpp
@@ -388,6 +388,7 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
 #include "ob_expr_vector_similarity.h"
 #include "ob_expr_check_location_access.h"
+#include "sql/engine/expr/ob_expr_ai/ob_expr_load_file.h"
 
 namespace oceanbase
 {
@@ -1341,6 +1342,7 @@ static ObExpr::EvalFunc g_expr_eval_functions[] = {
   ObExprVectorCosineSimilarity::calc_cosine_similarity,                /* 872 */
   ObExprVectorIPSimilarity::calc_ip_similarity,                        /* 873 */
   ObExprVectorSimilarity::calc_similarity,                             /* 874 */
+  ObExprLoadFile::eval_load_file,                                     /* 875 */
 };
 
 static ObExpr::EvalBatchFunc g_expr_eval_batch_functions[] = {

--- a/src/sql/engine/expr/ob_expr_operator_factory.cpp
+++ b/src/sql/engine/expr/ob_expr_operator_factory.cpp
@@ -442,6 +442,7 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
 #include "sql/engine/expr/ob_expr_vector_similarity.h"
 #include "sql/engine/expr/ob_expr_check_location_access.h"
+#include "sql/engine/expr/ob_expr_ai/ob_expr_load_file.h"
 
 
 #include "sql/engine/expr/ob_expr_lock_func.h"
@@ -1148,6 +1149,7 @@ void ObExprOperatorFactory::register_expr_operators()
     REG_OP(ObExprAIRerank);
     REG_OP(ObExprAIPrompt);
     REG_OP(ObExprCheckLocationAccess);
+    REG_OP(ObExprLoadFile);
   }();
 }
 

--- a/src/sql/ob_sql_define.h
+++ b/src/sql/ob_sql_define.h
@@ -129,6 +129,7 @@ enum JtColType {
   COL_TYPE_ORDINALITY_XML = 9,
   COL_TYPE_RB_ITERATE = 10,
   COL_TYPE_UNNEST = 11,
+  COL_TYPE_AI_SPLIT_DOCUMENT = 12,
 };
 
 enum ObNameTypeClass

--- a/src/sql/parser/non_reserved_keywords_mysql_mode.c
+++ b/src/sql/parser/non_reserved_keywords_mysql_mode.c
@@ -1162,6 +1162,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"INCONSISTENT", INCONSISTENT},
   {"INDIVIDUAL", INDIVIDUAL},
   {"hybrid_search", HYBRID_SEARCH},
+  {"ai_split_document", AI_SPLIT_DOCUMENT},
 };
 
 /** https://dev.mysql.com/doc/refman/5.7/en/sql-syntax-prepared-statements.html

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -2882,6 +2882,7 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_AI_SPLIT_DOCUMENT_EXPRESSION = 4920,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -1057,6 +1057,7 @@ typedef enum ObItemType
   T_FUN_SYS_AI_RERANK = 2084,
   T_FUN_MD5_CNN_WS = 2085,
   T_FUN_SYS_BUCKET = 2086,
+  T_FUN_SYS_LOAD_FILE = 2087,
   T_MAX_OP = 3000,
 
   //pseudo column, to mark the group iterator id

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -274,7 +274,7 @@ END_P SET_VAR DELIMITER
 //-----------------------------reserved keyword end-------------------------------------------------
 %token <non_reserved_keyword>
 //-----------------------------non_reserved keyword begin-------------------------------------------
-        ACCESS ACCESS_INFO ACCESSID ACCESSKEY ACCESSTYPE ACCOUNT ACTION ACTIVE ADDDATE AFTER AGAINST AGGREGATE AI ALGORITHM ALL_META ALL_USER ALWAYS ALLOW ANALYSE ANY
+        ACCESS ACCESS_INFO ACCESSID ACCESSKEY ACCESSTYPE ACCOUNT ACTION ACTIVE ADDDATE AFTER AGAINST AGGREGATE AI AI_SPLIT_DOCUMENT ALGORITHM ALL_META ALL_USER ALWAYS ALLOW ANALYSE ANY
         APPID APPROX_COUNT_DISTINCT APPROX_COUNT_DISTINCT_SYNOPSIS APPROX_COUNT_DISTINCT_SYNOPSIS_MERGE
         ARRAY ASCII ASIS AT ATTRIBUTE AUTHORS AUTO AUTOEXTEND_SIZE AUTO_INCREMENT AUTO_INCREMENT_MODE AUTO_INCREMENT_CACHE_SIZE
         AVG AVG_ROW_LENGTH ACTIVATE AVAILABILITY ARCHIVELOG ASYNCHRONOUS AUDIT ADMIN AUTO_REFRESH API_MODE APPROX APPROXIMATE ARRAY_AGG ARRAY_FILTER ARRAY_FIRST ARRAY_MAP ARRAY_SORTBY 
@@ -537,7 +537,7 @@ END_P SET_VAR DELIMITER
 %type <node> skip_index_type opt_skip_index_type_list
 %type <node> opt_rebuild_column_store
 %type <node> vec_index_params vec_index_param vec_index_param_value opt_with_vector_index_parameters
-%type <node> json_table_expr rb_iterate_expr unnest_expr mock_jt_on_error_on_empty jt_column_list json_table_column_def 
+%type <node> json_table_expr rb_iterate_expr ai_split_document_expr unnest_expr mock_jt_on_error_on_empty jt_column_list json_table_column_def
 %type <node> json_table_ordinality_column_def json_table_exists_column_def json_table_value_column_def json_table_nested_column_def
 %type <node> opt_value_on_empty_or_error_or_mismatch opt_on_mismatch
 %type <node> table_values_clause table_values_clause_with_order_by_and_limit values_row_list row_value
@@ -12991,6 +12991,10 @@ tbl_name
 {
   $$ = $1;
 }
+| ai_split_document_expr
+{
+  $$ = $1;
+}
 ;
 
 tbl_name:
@@ -21821,6 +21825,47 @@ RB_ITERATE '(' simple_expr ')'
 }
 ;
 
+ai_split_document_expr:
+
+AI_SPLIT_DOCUMENT '(' simple_expr ')'
+{
+  ParseNode *node = NULL;
+  malloc_terminal_node(node, result->malloc_pool_, T_VARCHAR);
+  node->str_value_ = "";
+  node->str_len_ = 0;
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION, 3, $3, node, NULL);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ')' relation_name
+{
+  ParseNode *node = NULL;
+  malloc_terminal_node(node, result->malloc_pool_, T_VARCHAR);
+  node->str_value_ = "";
+  node->str_len_ = 0;
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION, 3, $3, node, $5);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ')' AS relation_name
+{
+  ParseNode *node = NULL;
+  malloc_terminal_node(node, result->malloc_pool_, T_VARCHAR);
+  node->str_value_ = "";
+  node->str_len_ = 0;
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION, 3, $3, node, $6);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ','  simple_expr')'
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION, 3, $3, $5, NULL);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ','  simple_expr')' relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION, 3, $3, $5, $7);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ','  simple_expr')' AS relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_AI_SPLIT_DOCUMENT_EXPRESSION, 3, $3, $5, $8);
+}
+;
+
+
 unnest_expr:
 UNNEST '(' simple_expr_list ')' 
 {
@@ -22004,6 +22049,7 @@ ACCESS_INFO
 |       ADMIN
 |       AFTER
 |       AI
+|       AI_SPLIT_DOCUMENT
 |       AGAINST
 |       AGGREGATE
 |       ALGORITHM

--- a/src/sql/resolver/dml/ob_dml_resolver.cpp
+++ b/src/sql/resolver/dml/ob_dml_resolver.cpp
@@ -3251,6 +3251,15 @@ int ObDMLResolver::resolve_table(const ParseNode &parse_tree,
         }
         break;
       }
+      case T_AI_SPLIT_DOCUMENT_EXPRESSION: {
+        if (OB_ISNULL(session_info_)) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_WARN("invalid argument", K(ret));
+        } else if (OB_FAIL(resolve_ai_split_document_item(*table_node, table_item))) {
+          LOG_WARN("failed to resolve ai split document item", K(ret));
+        }
+        break;
+      }
       case T_HYBRID_SEARCH_EXPRESSION: {
         if (OB_ISNULL(session_info_)) {
           ret = OB_INVALID_ARGUMENT;
@@ -4405,6 +4414,8 @@ int ObDMLResolver::create_unnest_table_item(TableItem *&table_item, ObItemType i
       table_def->table_type_ = MulModeTableType::OB_RB_ITERATE_TABLE_TYPE;
     } else if (item_type == T_UNNEST_EXPRESSION) {
       table_def->table_type_ = MulModeTableType::OB_UNNEST_TABLE_TYPE;
+    } else if (item_type == T_AI_SPLIT_DOCUMENT_EXPRESSION) {
+      table_def->table_type_ = MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE;
     } else {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("unexpected item_type", K(ret), K(item_type));
@@ -4521,6 +4532,8 @@ int ObDMLResolver::unnest_table_add_column(TableItem *&table_item, ColumnItem *&
     col_type = COL_TYPE_RB_ITERATE;
   } else if (table_item->json_table_def_->table_type_ == MulModeTableType::OB_UNNEST_TABLE_TYPE) {
     col_type = COL_TYPE_UNNEST;
+  } else if (table_item->json_table_def_->table_type_ == MulModeTableType::OB_AI_SPLIT_DOCUMENT_TABLE_TYPE) {
+    col_type = COL_TYPE_AI_SPLIT_DOCUMENT;
   }
 
   if (OB_FAIL(ret)) {
@@ -4542,6 +4555,41 @@ int ObDMLResolver::unnest_table_add_column(TableItem *&table_item, ColumnItem *&
     data_type.set_collation_level(CS_LEVEL_IMPLICIT);
     data_type.set_uint64();
     data_type.set_accuracy(ObAccuracy::DDL_DEFAULT_ACCURACY[ObUInt64Type]);
+  } else if (col_type == COL_TYPE_AI_SPLIT_DOCUMENT) {
+    // For ai_split_document, set data type based on column name
+    if (0 == col_name.case_compare("CHUNK_ID") ||
+        0 == col_name.case_compare("CHUNK_OFFSET") ||
+        0 == col_name.case_compare("CHUNK_LENGTH")) {
+      // Integer columns: CHUNK_ID, CHUNK_OFFSET, CHUNK_LENGTH
+      data_type.set_collation_level(CS_LEVEL_IMPLICIT);
+      data_type.set_int();
+      data_type.set_accuracy(ObAccuracy::DDL_DEFAULT_ACCURACY[ObInt32Type]);
+    } else if (0 == col_name.case_compare("CHUNK_TEXT")) {
+      // Keep the same type as content_expr
+      if (OB_ISNULL(table_item) || OB_ISNULL(table_item->json_table_def_)
+          || table_item->json_table_def_->doc_exprs_.count() < 1) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("invalid table item or content_exprs for CHUNK_TEXT", K(ret));
+      } else {
+        ObRawExpr *content_expr = table_item->json_table_def_->doc_exprs_[0];
+        const ObRawExprResType &res_type = content_expr->get_result_type();
+        ObCollationType coll_type = res_type.get_collation_type();
+        if (!res_type.is_null() && coll_type != CS_TYPE_UTF8MB4_BIN && coll_type != CS_TYPE_UTF8MB4_GENERAL_CI) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_WARN("unsupported collation type for CHUNK_TEXT", K(ret), K(coll_type));
+          FORWARD_USER_ERROR(ret, "unsupported collation type for ai_split_document");
+        } else if (OB_ISNULL(content_expr)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("content_expr is null", K(ret));
+        } else {
+          data_type.set_meta_type(res_type.get_obj_meta());
+          data_type.set_accuracy(res_type.get_accuracy());
+        }
+      }
+    } else {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected column name for ai_split_document", K(col_name), K(ret));
+    }
   } else if (col_type == COL_TYPE_UNNEST) {
     ObRawExpr *value_expr = table_item->json_table_def_->doc_exprs_[col_id - 1];
     uint16_t subschema_id = value_expr->get_subschema_id();
@@ -4597,6 +4645,85 @@ int ObDMLResolver::unnest_table_add_column(TableItem *&table_item, ColumnItem *&
 
   return ret;
 }
+
+int ObDMLResolver::resolve_ai_split_document_item(const ParseNode &parse_tree, TableItem *&tbl_item)
+{
+  int ret = OB_SUCCESS;
+  TableItem *item = NULL;
+  ColumnItem *col_item = NULL;
+  ParseNode *content_expr_node = NULL;
+  ParseNode *parameters_expr_node = NULL;
+  ParseNode *table_name_node = NULL;
+  ObRawExpr *content_expr = NULL;
+  ObRawExpr *parameters_expr = NULL;
+  ObString table_name;
+
+  if (T_AI_SPLIT_DOCUMENT_EXPRESSION != parse_tree.type_ || 3 != parse_tree.num_child_) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("table type not support or param num mismatch", K(parse_tree.type_), K(parse_tree.num_child_), K(ret));
+  } else if (OB_ISNULL(content_expr_node = parse_tree.children_[0])) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("content expr node is null", K(ret));
+  } else if (OB_ISNULL(parameters_expr_node = parse_tree.children_[1])) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("parameters expr node is null", K(ret));
+  } else {
+    table_name_node = parse_tree.children_[2];
+  }
+
+  // resolve content expression
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(resolve_sql_expr(*(content_expr_node), content_expr))) {
+    LOG_WARN("fail to resolve doc sql expr", K(ret));
+  } else if (OB_ISNULL(content_expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("content expr is null", K(ret));
+  } else {
+    OZ (content_expr->deduce_type(session_info_));
+  }
+
+  // resolve parameters expression
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(resolve_sql_expr(*(parameters_expr_node), parameters_expr))) {
+    LOG_WARN("fail to resolve parameters sql expr", K(ret));
+  } else if (OB_ISNULL(parameters_expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("parameters expr is null", K(ret));
+  } else {
+    OZ (parameters_expr->deduce_type(session_info_));
+  }
+
+  // resolve table name
+  if (OB_FAIL(ret)) {
+  } else if (OB_ISNULL(table_name_node)) {
+    table_name = ObString("ai_split_document");
+  } else {
+    table_name.assign_ptr(table_name_node->str_value_, table_name_node->str_len_);
+  }
+
+  // create table item
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(create_unnest_table_item(item, T_AI_SPLIT_DOCUMENT_EXPRESSION, table_name))) {
+    LOG_WARN("failed to create ai split document table item", K(ret));
+  } else if (OB_FAIL(item->json_table_def_->doc_exprs_.push_back(content_expr))) {
+    LOG_WARN("failed to push back content expr", K(ret));
+  } else if (OB_FAIL(item->json_table_def_->doc_exprs_.push_back(parameters_expr))) {
+    LOG_WARN("failed to push back parameters expr", K(ret));
+  } else if (OB_FAIL(unnest_table_add_column(item, col_item, ObString("CHUNK_ID")))) {
+    LOG_WARN("failed to add CHUNK_ID column", K(ret));
+  } else if (OB_FAIL(unnest_table_add_column(item, col_item, ObString("CHUNK_OFFSET")))) {
+    LOG_WARN("failed to add CHUNK_OFFSET column", K(ret));
+  } else if (OB_FAIL(unnest_table_add_column(item, col_item, ObString("CHUNK_LENGTH")))) {
+    LOG_WARN("failed to add CHUNK_LENGTH column", K(ret));
+  } else if (OB_FAIL(unnest_table_add_column(item, col_item, ObString("CHUNK_TEXT")))) {
+    LOG_WARN("failed to add CHUNK_TEXT column", K(ret));
+  } else {
+    tbl_item = item;
+  }
+
+  return ret;
+}
+
 int ObDMLResolver::resolve_hybrid_search_item(const ParseNode &parse_tree, TableItem *&table_item)
 {
   INIT_SUCC(ret);

--- a/src/sql/resolver/dml/ob_dml_resolver.h
+++ b/src/sql/resolver/dml/ob_dml_resolver.h
@@ -212,6 +212,7 @@ public:
   int resolve_rb_iterate_item(const ParseNode &table_node,
                               TableItem *&table_item);
   int resolve_unnest_item(const ParseNode &table_node, TableItem *&table_item);
+  int resolve_ai_split_document_item(const ParseNode &table_node, TableItem *&table_item);
   int create_rb_iterate_table_item(TableItem *&table_item, ObString alias_name = NULL);
   int create_unnest_table_item(TableItem *&table_item, ObItemType item_type, ObString table_name);
   int rb_iterate_table_add_column(TableItem *&table_item, ColumnItem *&col_item, int64_t col_id = 1);

--- a/src/sql/resolver/dml/ob_dml_stmt.h
+++ b/src/sql/resolver/dml/ob_dml_stmt.h
@@ -46,6 +46,7 @@ enum MulModeTableType {
   OB_ORA_XML_TABLE_TYPE = 2,
   OB_RB_ITERATE_TABLE_TYPE = 3,
   OB_UNNEST_TABLE_TYPE = 4,
+  OB_AI_SPLIT_DOCUMENT_TABLE_TYPE = 5,
 };
 
 typedef struct ObJtColBaseInfo


### PR DESCRIPTION
Implements BLOB LOAD_FILE(location_name, file_name) that reads a local file via a file:// LOCATION. Registered as T_FUN_SYS_LOAD_FILE=2087.

Adapted from OceanBase commit 28c25842 with seekdb-specific changes:
- Use POSIX open/pread instead of ObExternalDataAccessDriver (not in seekdb)
- Use 1-arg get_tenant_schema_guard (seekdb signature)
- Use 2-arg get_location_schema_by_name (seekdb signature)
- Drop MultimodeAlloctor (not needed for simple file read)
- Use ObString::prefix_match instead of 3-arg compare

Local verification: mysqltest ai_funcs/load_file.test PASS

<!--
Thank you for contributing to **OceanBase SeekDB**!

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
