### PR TITLE
[VLDB 2026][Task 4] Optimize fulltext index hot paths

### DIFF
--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -2882,6 +2882,8 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_FULLTEXT_DICT = 4920,
+  T_REFRESH_FULLTEXT_DICT = 4921,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/plugin/interface/ob_plugin_ftparser_intf.h
+++ b/src/plugin/interface/ob_plugin_ftparser_intf.h
@@ -122,6 +122,8 @@ public:
   {
     ObFTParserParamExport::reset();
     allocator_ = nullptr;
+    metadata_alloc_ = nullptr;
+    scratch_alloc_ = nullptr;
     ik_param_ = ObFTIKParam();
     ngram_token_size_ = NGRAM_TOKEN_SIZE;
     min_ngram_size_ = NGRAM_TOKEN_SIZE;
@@ -132,7 +134,11 @@ public:
   INHERIT_TO_STRING_KV("base", ObFTParserParamExport, KP_(allocator), K_(ngram_token_size));
 
 public:
+  // allocator_ remains for external parser ABI compatibility. Built-in parsers
+  // use the split allocators so immutable metadata survives per-document reuse.
   common::ObIAllocator *allocator_ = nullptr;
+  common::ObIAllocator *metadata_alloc_ = nullptr;
+  common::ObIAllocator *scratch_alloc_ = nullptr;
 
   // ik parser params
   ObFTIKParam ik_param_;

--- a/src/plugin/interface/ob_plugin_ftparser_intf.h
+++ b/src/plugin/interface/ob_plugin_ftparser_intf.h
@@ -77,7 +77,13 @@ public:
   };
 
   ObFTIKParam(Mode mode = Mode::SMART)
-      : mode_(mode), main_dict_(""), quan_dict_(""), stopword_dict_("")
+      : mode_(mode),
+        main_dict_(""),
+        quan_dict_(""),
+        stopword_dict_(""),
+        main_dict_id_(common::OB_INVALID_ID),
+        quan_dict_id_(common::OB_INVALID_ID),
+        stopword_dict_id_(common::OB_INVALID_ID)
   {
   }
 
@@ -86,6 +92,9 @@ public:
   common::ObString main_dict_;
   common::ObString quan_dict_;
   common::ObString stopword_dict_;
+  uint64_t main_dict_id_;
+  uint64_t quan_dict_id_;
+  uint64_t stopword_dict_id_;
 };
 
 /**
@@ -103,7 +112,8 @@ public:
       : ObFTParserParamExport(),
         ngram_token_size_(NGRAM_TOKEN_SIZE),
         min_ngram_size_(NGRAM_TOKEN_SIZE),
-        max_ngram_size_(NGRAM_TOKEN_SIZE)
+        max_ngram_size_(NGRAM_TOKEN_SIZE),
+        tenant_id_(common::OB_INVALID_TENANT_ID)
   {
   }
   virtual ~ObFTParserParam() { reset(); }
@@ -112,7 +122,11 @@ public:
   {
     ObFTParserParamExport::reset();
     allocator_ = nullptr;
+    ik_param_ = ObFTIKParam();
     ngram_token_size_ = NGRAM_TOKEN_SIZE;
+    min_ngram_size_ = NGRAM_TOKEN_SIZE;
+    max_ngram_size_ = NGRAM_TOKEN_SIZE;
+    tenant_id_ = common::OB_INVALID_TENANT_ID;
   }
 
   INHERIT_TO_STRING_KV("base", ObFTParserParamExport, KP_(allocator), K_(ngram_token_size));
@@ -125,6 +139,7 @@ public:
   int64_t ngram_token_size_;
   int64_t min_ngram_size_;
   int64_t max_ngram_size_;
+  uint64_t tenant_id_;
 };
 
 class ObITokenIterator

--- a/src/rootserver/ddl_task/ob_ddl_common_rs_impl.cpp
+++ b/src/rootserver/ddl_task/ob_ddl_common_rs_impl.cpp
@@ -776,10 +776,19 @@ int ObDDLUtil::generate_build_replica_sql(const int64_t data_table_id,
         if (dest_table_schema->is_vec_vid_rowkey_type()) {
           src_table_schema_version_hint_sql_string.reset();
         }
+        const bool enable_newsort_for_fts =
+            dest_table_schema->is_rowkey_doc_id()
+            || dest_table_schema->is_doc_id_rowkey()
+            || dest_table_schema->is_fts_index_aux()
+            || dest_table_schema->is_fts_doc_word_aux();
+        const char *sort_hint = enable_newsort_for_fts
+            ? "opt_param('enable_newsort', 'true') "
+            : "opt_param('enable_newsort', 'false') ";
         if (OB_FAIL(ret)) {
         } else {
-          if (OB_FAIL(sql_string.assign_fmt("INSERT /*+ monitor enable_parallel_dml parallel(%ld) opt_param('ddl_execution_id', %ld) opt_param('ddl_task_id', %ld) opt_param('enable_newsort', 'false') %.*s use_px */INTO `%.*s`.`%.*s` %.*s(%.*s) SELECT /*+ index(`%.*s` primary) %.*s */ %.*s from `%.*s`.`%.*s` %.*s as of snapshot %ld %.*s",
+          if (OB_FAIL(sql_string.assign_fmt("INSERT /*+ monitor enable_parallel_dml parallel(%ld) opt_param('ddl_execution_id', %ld) opt_param('ddl_task_id', %ld) %s%.*s use_px */INTO `%.*s`.`%.*s` %.*s(%.*s) SELECT /*+ index(`%.*s` primary) %.*s */ %.*s from `%.*s`.`%.*s` %.*s as of snapshot %ld %.*s",
               real_parallelism, execution_id, task_id,
+              sort_hint,
               static_cast<int>(strlen(io_read_hint)), io_read_hint,
               static_cast<int>(new_dest_database_name.length()), new_dest_database_name.ptr(), static_cast<int>(new_dest_table_name.length()), new_dest_table_name.ptr(),
               static_cast<int>(partition_names.length()), partition_names.ptr(),

--- a/src/rootserver/ob_ddl_operator.cpp
+++ b/src/rootserver/ob_ddl_operator.cpp
@@ -2374,6 +2374,11 @@ int ObDDLOperator::alter_table_create_index(const ObTableSchema &new_table_schem
         }
       }
     }
+    if (OB_SUCC(ret) && index_schema.is_fts_index_aux()
+        && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+               index_schema, trans))) {
+      LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(index_schema));
+    }
   }
   return ret;
 }
@@ -4212,7 +4217,13 @@ int ObDDLOperator::drop_table(
 {
   int ret = OB_SUCCESS;
   bool tmp = false;
-  if (OB_FAIL(ObDependencyDDLHelper::modify_dep_obj_status(trans, table_schema.get_table_id(),
+  if (!is_drop_db && table_schema.is_fulltext_dict()
+      && OB_FAIL(ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+             table_schema.get_table_id(), trans))) {
+    if (OB_OP_NOT_ALLOW != ret) {
+      LOG_WARN("fail to check dictionary table dependencies", K(ret), K(table_schema));
+    }
+  } else if (OB_FAIL(ObDependencyDDLHelper::modify_dep_obj_status(trans, table_schema.get_table_id(),
                                                       *this, schema_service_))) {
     LOG_WARN("failed to modify obj status", K(ret));
   } else if (OB_FAIL(drop_table_for_not_dropped_schema(
@@ -4227,6 +4238,13 @@ int ObDDLOperator::drop_table(
                       ObObjectType::VIEW))) {
     LOG_WARN("failed to delete_schema_object_dependency", K(ret), K(1UL),
     K(table_schema.get_table_id()));
+  } else if (table_schema.is_fts_index_aux()
+             && OB_FAIL(ObDependencyInfo::delete_schema_object_dependency(
+                    trans,
+                    table_schema.get_table_id(),
+                    table_schema.get_schema_version(),
+                    ObObjectType::INDEX))) {
+    LOG_WARN("fail to delete fulltext dictionary dependencies", K(ret), K(table_schema));
   }
 
   if (OB_FAIL(ret)) {
@@ -4434,6 +4452,12 @@ int ObDDLOperator::drop_table_to_recyclebin(const ObTableSchema &table_schema,
   } else if (OB_UNLIKELY(table_schema.get_table_type() == MATERIALIZED_VIEW_LOG)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("materialized view log should not come to recyclebin", KR(ret));
+  } else if (table_schema.is_fulltext_dict()
+             && OB_FAIL(ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+                    table_schema.get_table_id(), trans))) {
+    if (OB_OP_NOT_ALLOW != ret) {
+      LOG_WARN("fail to check dictionary table dependencies", K(ret), K(table_schema));
+    }
   } else if (OB_ISNULL(schema_service_impl)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_ERROR("schema_service_impl must not null", K(ret));

--- a/src/rootserver/ob_ddl_service.cpp
+++ b/src/rootserver/ob_ddl_service.cpp
@@ -2029,6 +2029,10 @@ int ObDDLService::create_tables_in_trans(const bool if_not_exist,
                                                      0 == i ? &tmp_ddl_stmt_str : NULL,
                                                      i == table_schemas.count() - 1))) {
           LOG_WARN("failed to create table schema, ", K(ret));
+        } else if (table_schema.is_fts_index_aux()
+                   && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+                          table_schema, trans))) {
+          LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(table_schema));
         } else if (OB_FAIL(ddl_operator.insert_temp_table_info(trans, table_schema))) {
           LOG_WARN("failed to insert_temp_table_info!", K(ret));
         } else if (table_schema.is_view_table() && dep_infos != nullptr && 0 == i) {

--- a/src/rootserver/parallel_ddl/ob_create_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_create_table_helper.cpp
@@ -1142,6 +1142,15 @@ int ObCreateTableHelper::operate_schemas_() {
   } else if (OB_FAIL(inner_create_table_(&arg_.ddl_stmt_str_,
                                          replace_mock_fk_parent_table_id_))) {
     LOG_WARN("fail create table", KR(ret));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < new_tables_.count(); ++i) {
+      const ObTableSchema &table_schema = new_tables_.at(i);
+      if (table_schema.is_fts_index_aux()
+          && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+                 table_schema, get_trans_()))) {
+        LOG_WARN("fail to record fulltext dictionary dependencies", KR(ret), K(table_schema));
+      }
+    }
   }
   return ret;
 }

--- a/src/rootserver/parallel_ddl/ob_drop_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_drop_table_helper.cpp
@@ -22,7 +22,9 @@
 #include "rootserver/ob_tablet_drop.h"
 #include "share/ob_autoincrement_service.h"
 #include "share/ob_rpc_struct.h"
+#include "share/schema/ob_dependency_info.h"
 #include "share/schema/ob_table_sql_service.h"
+#include "sql/resolver/ddl/ob_fts_index_builder_util.h"
 #include "storage/tablelock/ob_lock_inner_connection_util.h"
 
 using namespace oceanbase::rootserver;
@@ -176,6 +178,12 @@ int ObDropTableHelper::check_legitimacy_()
         ret = OB_NOT_SUPPORTED;
         LOG_WARN("drop table required by materialized view is not supported", KR(ret));
         LOG_USER_ERROR(OB_NOT_SUPPORTED, "drop table required by materialized view is");
+      } else if (table_schema->is_fulltext_dict()
+                 && OB_FAIL(oceanbase::share::ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+                        table_schema->get_table_id(), get_trans_()))) {
+        if (OB_OP_NOT_ALLOW != ret) {
+          LOG_WARN("fail to check dictionary table dependencies", KR(ret), KPC(table_schema));
+        }
       }
     }
   }
@@ -1411,6 +1419,13 @@ int ObDropTableHelper::drop_table_(const ObTableSchema &table_schema, const ObSt
       LOG_WARN("fail to sync version for cascade tables", KR(ret));
     } else if (OB_FAIL(sync_version_for_cascade_mock_fk_parent_table_(table_schema.get_depend_mock_fk_parent_table_ids()))) {
       LOG_WARN("fail to sync version for cascade mock fk parent table", KR(ret));
+    } else if (table_schema.is_fts_index_aux()
+               && OB_FAIL(ObDependencyInfo::delete_schema_object_dependency(
+                      get_trans_(),
+                      table_schema.get_table_id(),
+                      table_schema.get_schema_version(),
+                      ObObjectType::INDEX))) {
+      LOG_WARN("fail to delete fulltext dictionary dependencies", KR(ret), K(table_schema));
     }
 
     if (OB_SUCC(ret)) {

--- a/src/rootserver/parallel_ddl/ob_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_table_helper.cpp
@@ -647,6 +647,9 @@ int ObTableHelper::inner_generate_table_schema_(const ObCreateTableArg &arg, ObT
     ret = OB_NOT_SUPPORTED;
     LOG_WARN("not user tenant, create duplicate table not supported", KR(ret));
     LOG_USER_ERROR(OB_NOT_SUPPORTED, "not user tenant, create duplicate table");
+  } else if (OB_FAIL(ObFtsIndexBuilderUtil::check_fulltext_dict_schema(
+                         new_table, arg.index_arg_list_.count()))) {
+    LOG_WARN("fulltext dictionary table schema is invalid", KR(ret), K(new_table));
   }
 
   if (FALSE_IT(new_table.set_table_id(mock_table_id))) {

--- a/src/share/schema/ob_schema_struct.h
+++ b/src/share/schema/ob_schema_struct.h
@@ -185,6 +185,9 @@ static const uint64_t OB_MIN_ID  = 0;//used for lower_bound
 #define EXTERNAL_TABLE_AUTO_REFRESH_FLAG_OFFSET 2
 #define EXTERNAL_TABLE_AUTO_REFRESH_FLAG_BITS 2
 
+// Identifies a user table whose rows are used as a full-text dictionary.
+#define FULLTEXT_DICT_FLAG (INT64_C(1) << 4)
+
 // schema array size
 static const int64_t SCHEMA_SMALL_MALLOC_BLOCK_SIZE = 64;
 static const int64_t SCHEMA_MALLOC_BLOCK_SIZE = 128;

--- a/src/share/schema/ob_table_schema.h
+++ b/src/share/schema/ob_table_schema.h
@@ -1413,6 +1413,7 @@ public:
   int set_external_properties(const common::ObString &format) { return deep_copy_str(format, external_properties_); }
   void set_external_table_auto_refresh(const int64_t flag) { table_flags_ |= (flag << EXTERNAL_TABLE_AUTO_REFRESH_FLAG_OFFSET); }
   inline void set_user_specified_partition_for_external_table() { table_flags_ |= EXTERNAL_TABLE_USER_SPECIFIED_PARTITION_FLAG; }
+  inline void set_fulltext_dict() { table_flags_ |= FULLTEXT_DICT_FLAG; }
   template<typename ColumnType>
   int add_column(const ColumnType &column);
   int delete_column(const common::ObString &column_name);
@@ -1581,6 +1582,7 @@ public:
   inline ObNameGeneratedType get_name_generated_type() const { return name_generated_type_; }
   bool is_sys_generated_name(bool check_unknown) const;
   inline bool is_user_specified_partition_for_external_table() const { return (table_flags_ & EXTERNAL_TABLE_USER_SPECIFIED_PARTITION_FLAG) != 0; }
+  inline bool is_fulltext_dict() const { return (table_flags_ & FULLTEXT_DICT_FLAG) != 0; }
   inline bool is_index_visible() const
   {
     return 0 == (index_attributes_set_ & ((uint64_t)(1) << INDEX_VISIBILITY));

--- a/src/share/text_analysis/ob_token_stream.cpp
+++ b/src/share/text_analysis/ob_token_stream.cpp
@@ -310,7 +310,14 @@ int ObBasicEnglishNormalizer::get_next(ObDatum &next_token, int64_t &token_freq)
     } else {
       ObString norm_alnum_token(norm_token_len, norm_token_ptr);
       ObString norm_lower_token;
-      if (OB_FAIL(ObCharset::tolower(cs_, norm_alnum_token, norm_lower_token, norm_allocator_))) {
+      bool is_lower_ascii = true;
+      for (int64_t i = 0; is_lower_ascii && i < norm_token_len; ++i) {
+        const unsigned char ch = static_cast<unsigned char>(norm_token_ptr[i]);
+        is_lower_ascii = 0 == (ch & 0x80) && !('A' <= ch && 'Z' >= ch);
+      }
+      if (is_lower_ascii) {
+        next_token.set_string(norm_alnum_token);
+      } else if (OB_FAIL(ObCharset::tolower(cs_, norm_alnum_token, norm_lower_token, norm_allocator_))) {
         LOG_WARN("norm token to lower case failed", K(ret), K_(cs), K(norm_alnum_token));
       } else {
         next_token.set_string(norm_lower_token);

--- a/src/sql/das/iter/ob_das_iter_utils.cpp
+++ b/src/sql/das/iter/ob_das_iter_utils.cpp
@@ -1237,28 +1237,49 @@ int ObDASIterUtils::create_text_retrieval_tree(ObTableScanParam &scan_param,
     switch (op_type) {
     case ObDASOpType::DAS_OP_IR_SCAN:
     case ObDASOpType::DAS_OP_SORT: {
-      ObDASCacheLookupIter *lookup_iter = nullptr;
       if (nullptr != ir_scan_ctdef && ir_scan_ctdef->need_calc_relevance()) {
         main_lookup_keep_order = true;
         // TODO: may be optimized to use forward
       }
-      if (table_lookup_ctdef->op_type_ != ObDASOpType::DAS_OP_INDEX_PROJ_LOOKUP) {
+      if (table_lookup_ctdef->op_type_ == ObDASOpType::DAS_OP_TABLE_LOOKUP) {
+        ObDASLocalLookupIter *lookup_iter = nullptr;
+        if (OB_FAIL(create_local_lookup_sub_tree(
+            scan_param,
+            alloc,
+            table_lookup_ctdef->get_rowkey_scan_ctdef(),
+            table_lookup_rtdef->get_rowkey_scan_rtdef(),
+            table_lookup_ctdef->get_lookup_scan_ctdef(),
+            table_lookup_rtdef->get_lookup_scan_rtdef(),
+            trans_desc,
+            snapshot,
+            root_iter,
+            related_tablet_ids.lookup_tablet_id_,
+            lookup_iter,
+            main_lookup_keep_order))) {
+          LOG_WARN("failed to create local lookup sub tree", K(ret));
+        } else {
+          root_iter = lookup_iter;
+        }
+      } else if (table_lookup_ctdef->op_type_ == ObDASOpType::DAS_OP_INDEX_PROJ_LOOKUP) {
+        ObDASCacheLookupIter *lookup_iter = nullptr;
+        if (OB_FAIL(create_cache_lookup_sub_tree(
+            scan_param,
+            alloc,
+            table_lookup_ctdef,
+            table_lookup_rtdef,
+            trans_desc,
+            snapshot,
+            root_iter,
+            related_tablet_ids,
+            lookup_iter,
+            main_lookup_keep_order))) {
+          LOG_WARN("failed to create cache lookup sub tree", K(ret));
+        } else {
+          root_iter = lookup_iter;
+        }
+      } else {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("unexpected table lookup", K(ret));
-      } else if (OB_FAIL(create_cache_lookup_sub_tree(
-          scan_param,
-          alloc,
-          table_lookup_ctdef,
-          table_lookup_rtdef,
-          trans_desc,
-          snapshot,
-          root_iter,
-          related_tablet_ids,
-          lookup_iter,
-          main_lookup_keep_order))) {
-        LOG_WARN("failed to create cache lookup sub tree", K(ret));
-      } else {
-        root_iter = lookup_iter;
       }
       break;
     }

--- a/src/sql/das/iter/ob_das_iter_utils.cpp
+++ b/src/sql/das/iter/ob_das_iter_utils.cpp
@@ -1661,15 +1661,21 @@ int ObDASIterUtils::create_text_retrieval_sub_tree(
     if (ir_scan_ctdef->has_pushdown_topk() && !has_duplicate_boolean_tokens) {
       merge_iter_param.topk_mode_ = 1;
       merge_iter_param.daat_mode_ = 1;
-    } else if (merge_iter_param.query_tokens_.count() > OB_MAX_TEXT_RETRIEVAL_TOKEN_CNT
-        || (!is_func_lookup && !ir_scan_ctdef->need_proj_relevance_score())) {
+    } else if (merge_iter_param.query_tokens_.count() > OB_MAX_TEXT_RETRIEVAL_TOKEN_CNT) {
       if (BOOLEAN_MODE == ir_scan_ctdef->mode_flag_) {
         ret = OB_NOT_SUPPORTED;
         LOG_WARN("boolean mode with too many tokens not supported", K(ret), K(merge_iter_param.query_tokens_.count()));
         LOG_USER_ERROR(OB_NOT_SUPPORTED, "Boolean mode with more than 256 tokens is");
       }
       merge_iter_param.taat_mode_ = 1;
+    } else if (!is_func_lookup && !ir_scan_ctdef->need_proj_relevance_score()
+        && BOOLEAN_MODE == ir_scan_ctdef->mode_flag_) {
+      // Boolean evaluation depends on the per-token match state maintained by TaaT.
+      merge_iter_param.taat_mode_ = 1;
     } else {
+      // DaaT can stream and deduplicate naturally ordered posting lists without
+      // materializing all candidates. This is especially important for COUNT(*)
+      // and LIMIT queries which do not project relevance scores.
       merge_iter_param.daat_mode_ = 1;
     }
     if (OB_SUCC(ret) && ir_scan_ctdef->has_pushdown_topk() && has_duplicate_boolean_tokens) {
@@ -4426,4 +4432,3 @@ int ObDASIterUtils::create_vec_ivf_lookup_tree(ObTableScanParam &scan_param,
 
 } // namespace sql
 } // namespace oceanbase
-

--- a/src/sql/das/iter/sparse_retrieval/ob_das_tr_merge_iter.cpp
+++ b/src/sql/das/iter/sparse_retrieval/ob_das_tr_merge_iter.cpp
@@ -588,6 +588,9 @@ int ObDASTRMergeIter::init_daat_iter_param(ObTextDaaTParam &iter_param)
 {
   int ret = OB_SUCCESS;
   const bool need_relevance = sr_iter_param_.need_calc_relevance();
+  sr_iter_param_.need_collect_dims_ = need_relevance
+      || BOOLEAN_MODE == ir_ctdef_->mode_flag_
+      || ir_rtdef_->minimum_should_match_ > 1;
   iter_param.dim_iters_ = &dim_iters_;
   iter_param.base_param_ = &sr_iter_param_;
   iter_param.allocator_ = &myself_allocator_;

--- a/src/sql/das/iter/sparse_retrieval/ob_das_tr_merge_iter.cpp
+++ b/src/sql/das/iter/sparse_retrieval/ob_das_tr_merge_iter.cpp
@@ -587,23 +587,30 @@ int ObDASTRMergeIter::create_sparse_retrieval_iter()
 int ObDASTRMergeIter::init_daat_iter_param(ObTextDaaTParam &iter_param)
 {
   int ret = OB_SUCCESS;
+  const bool need_relevance = sr_iter_param_.need_calc_relevance();
   iter_param.dim_iters_ = &dim_iters_;
   iter_param.base_param_ = &sr_iter_param_;
   iter_param.allocator_ = &myself_allocator_;
   iter_param.mode_flag_ = ir_ctdef_->mode_flag_;
   iter_param.function_lookup_mode_ = function_lookup_mode_;
-  iter_param.bm25_param_est_ctx_.total_doc_cnt_expr_
-      = ir_ctdef_->get_doc_agg_ctdef()->pd_expr_spec_.pd_storage_aggregate_output_.at(0);
-  iter_param.bm25_param_est_ctx_.estimated_total_doc_cnt_ = ir_ctdef_->estimated_total_doc_cnt_;
-  iter_param.bm25_param_est_ctx_.need_est_avg_doc_token_cnt_ = ir_ctdef_->need_avg_doc_len_est();
-  iter_param.bm25_param_est_ctx_.can_est_by_sum_skip_index_ = ir_ctdef_->avg_doc_len_est_spec_.can_est_by_sum_skip_index_;
-  iter_param.bm25_param_est_ctx_.avg_doc_token_cnt_expr_ = ir_ctdef_->avg_doc_token_cnt_expr_;
-  iter_param.bm25_param_est_ctx_.doc_length_est_param_ = &doc_length_est_param_;
   if (query_tokens_.count() == 0) {
     // do nothing
+  } else if (!need_relevance) {
+    // MATCH used only as a predicate does not need BM25 statistics.
+  } else if (OB_ISNULL(ir_ctdef_->get_doc_agg_ctdef())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null document aggregate ctdef", K(ret));
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.total_doc_cnt_expr_
+      = ir_ctdef_->get_doc_agg_ctdef()->pd_expr_spec_.pd_storage_aggregate_output_.at(0))) {
   } else if (OB_ISNULL(iter_param.bm25_param_est_ctx_.total_doc_cnt_expr_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected null total doc cnt expr", K(ret));
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.estimated_total_doc_cnt_ = ir_ctdef_->estimated_total_doc_cnt_)) {
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.need_est_avg_doc_token_cnt_ = ir_ctdef_->need_avg_doc_len_est())) {
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.can_est_by_sum_skip_index_
+      = ir_ctdef_->avg_doc_len_est_spec_.can_est_by_sum_skip_index_)) {
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.avg_doc_token_cnt_expr_ = ir_ctdef_->avg_doc_token_cnt_expr_)) {
+  } else if (FALSE_IT(iter_param.bm25_param_est_ctx_.doc_length_est_param_ = &doc_length_est_param_)) {
   } else if (OB_FAIL(init_doc_length_est_param())) {
     LOG_WARN("failed to init doc length est param", K(ret));
   } else if (!ir_ctdef_->need_estimate_total_doc_cnt()) {
@@ -1351,12 +1358,11 @@ int ObDASTRMergeIter::build_query_tokens(const ObDASIRScanCtDef *ir_ctdef,
     const ObObjMeta &meta = search_text->obj_meta_;
     int64_t doc_length = 0;
     storage::ObFTParseHelper tokenize_helper;
-    common::ObSEArray<ObFTWord, 16> tokens;
-    hash::ObHashMap<ObFTWord, int64_t> token_map;
+    storage::ObFTTokenMap token_map;
     const int64_t ft_word_bkt_cnt = MAX(search_text_string.length() / 10, 2);
     if (OB_FAIL(tokenize_helper.init(&alloc, parser_name, parser_properties))) {
       LOG_WARN("failed to init tokenize helper", K(ret));
-    } else if (OB_FAIL(token_map.create(ft_word_bkt_cnt, common::ObMemAttr("FTWordMap")))) {
+    } else if (OB_FAIL(token_map.create(ft_word_bkt_cnt, common::ObMemAttr("FTTokenMap")))) {
       LOG_WARN("failed to create token map", K(ret));
     } else if (OB_FAIL(tokenize_helper.segment(
                            meta,
@@ -1366,12 +1372,12 @@ int ObDASTRMergeIter::build_query_tokens(const ObDASIRScanCtDef *ir_ctdef,
                            token_map))) {
       LOG_WARN("failed to segment", K(ret), K(search_text_string), K(meta), K(doc_length));
     } else {
-      for (hash::ObHashMap<ObFTWord, int64_t>::const_iterator iter = token_map.begin();
+      for (storage::ObFTTokenMap::const_iterator iter = token_map.begin();
           OB_SUCC(ret) && iter != token_map.end();
           ++iter) {
-        const ObFTWord &token = iter->first;
+        const storage::ObFTToken &token = iter->first;
         ObString token_string;
-        if (OB_FAIL(ob_write_string(alloc, token.get_word().get_string(), token_string))) {
+        if (OB_FAIL(ob_write_string(alloc, token.get_token().get_string(), token_string))) {
           LOG_WARN("failed to deep copy query token", K(ret));
         } else if (OB_FAIL(query_tokens.push_back(token_string))) {
           LOG_WARN("failed to append query token", K(ret));

--- a/src/sql/das/ob_das_domain_utils.cpp
+++ b/src/sql/das/ob_das_domain_utils.cpp
@@ -42,7 +42,9 @@ ObObjDatumMapType ObFTIndexRowCache::FTS_DOC_WORD_TYPES[] = {OBJ_DATUM_STRING, O
 ObExprOperatorType ObFTIndexRowCache::FTS_INDEX_EXPR_TYPE[] = {T_FUN_SYS_WORD_SEGMENT, T_FUN_SYS_DOC_ID, T_FUN_SYS_WORD_COUNT, T_FUN_SYS_DOC_LENGTH};
 ObExprOperatorType ObFTIndexRowCache::FTS_DOC_WORD_EXPR_TYPE[] = {T_FUN_SYS_DOC_ID, T_FUN_SYS_WORD_SEGMENT, T_FUN_SYS_WORD_COUNT, T_FUN_SYS_DOC_LENGTH};
 const int64_t ObFTIndexRowCache::FT_WORD_DOC_COL_CNT;
-const int64_t ObFTIndexRowCache::FT_TOKEN_BUCKET_COUNT;
+const int64_t ObFTIndexRowCache::FT_CHARS_PER_TOKEN;
+const int64_t ObFTIndexRowCache::FT_TOKEN_MIN_BUCKET_COUNT;
+const int64_t ObFTIndexRowCache::FT_TOKEN_MAX_BUCKET_COUNT;
 
 ObFTIndexRowCache::ObFTIndexRowCache()
   : metadata_allocator_("FTIndexMeta"),
@@ -50,6 +52,7 @@ ObFTIndexRowCache::ObFTIndexRowCache()
     token_processor_(scratch_allocator_),
     datum_row_(),
     token_map_(),
+    token_map_bucket_count_(0),
     token_arr_(),
     row_idx_(0),
     is_fts_index_aux_(true),
@@ -79,14 +82,15 @@ int ObFTIndexRowCache::init(
   } else if (OB_FAIL(helper_.init(&metadata_allocator_, parser_name, parser_properties))) {
     LOG_WARN("fail to init full-text parser helper", K(ret));
   } else if (OB_FAIL(token_map_.create(
-                         FT_TOKEN_BUCKET_COUNT, common::ObMemAttr("FTIndexTokenMap")))) {
-    LOG_WARN("fail to create full-text token map", K(ret), K(FT_TOKEN_BUCKET_COUNT));
+                         FT_TOKEN_MIN_BUCKET_COUNT, common::ObMemAttr("FTIndexTokenMap")))) {
+    LOG_WARN("fail to create full-text token map", K(ret), K(FT_TOKEN_MIN_BUCKET_COUNT));
   } else if (OB_FAIL(datum_row_.init(metadata_allocator_, FT_WORD_DOC_COL_CNT))) {
     LOG_WARN("fail to initialize reusable full-text datum row", K(ret), K(FT_WORD_DOC_COL_CNT));
   } else {
     row_idx_ = 0;
     is_fts_index_aux_ = is_fts_index_aux;
     is_builtin_parser_ = helper_.is_builtin_parser();
+    token_map_bucket_count_ = FT_TOKEN_MIN_BUCKET_COUNT;
     is_inited_ = true;
   }
   if (OB_UNLIKELY(!is_inited_)) {
@@ -107,6 +111,8 @@ int ObFTIndexRowCache::segment(const common::ObObjMeta &ft_obj_meta,
     LOG_WARN("ObFTIndexRowCache hasn't be initialized", K(ret), K(is_inited_));
   } else if (OB_UNLIKELY(fulltext.empty())) {
     ret = OB_ITER_END;
+  } else if (OB_FAIL(prepare_token_map(fulltext.length()))) {
+    LOG_WARN("fail to prepare full-text token map", K(ret), K(fulltext.length()));
   } else if (is_builtin_parser_
       && OB_FAIL(segment_with_builtin_parser(ft_obj_meta,
                                              fulltext.ptr(),
@@ -136,6 +142,29 @@ int ObFTIndexRowCache::segment(const common::ObObjMeta &ft_obj_meta,
     }
   }
   LOG_TRACE("word segment", K(ret), K(row_idx_), K(token_arr_.count()), K(doc_id_datum));
+  return ret;
+}
+
+int ObFTIndexRowCache::prepare_token_map(const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  const int64_t bucket_count = MIN(
+      MAX(fulltext_len / FT_CHARS_PER_TOKEN, FT_TOKEN_MIN_BUCKET_COUNT),
+      FT_TOKEN_MAX_BUCKET_COUNT);
+  if (OB_UNLIKELY(fulltext_len <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid full-text length", K(ret), K(fulltext_len));
+  } else if (bucket_count <= token_map_bucket_count_) {
+    token_map_.reuse();
+  } else {
+    token_map_.destroy();
+    token_map_bucket_count_ = 0;
+    if (OB_FAIL(token_map_.create(bucket_count, common::ObMemAttr("FTIndexTokenMap")))) {
+      LOG_WARN("fail to resize full-text token map", K(ret), K(bucket_count), K(fulltext_len));
+    } else {
+      token_map_bucket_count_ = bucket_count;
+    }
+  }
   return ret;
 }
 
@@ -288,6 +317,7 @@ void ObFTIndexRowCache::reset()
   token_iterator_ = nullptr;
   token_arr_.reset();
   token_map_.destroy();
+  token_map_bucket_count_ = 0;
   datum_row_.reset();
   token_processor_.reset();
   token_processor_inited_ = false;
@@ -303,9 +333,6 @@ void ObFTIndexRowCache::reset()
 void ObFTIndexRowCache::reuse()
 {
   token_arr_.reuse();
-  if (token_map_.created()) {
-    token_map_.reuse();
-  }
   if (token_processor_inited_) {
     token_processor_.reuse();
   }

--- a/src/sql/das/ob_das_domain_utils.cpp
+++ b/src/sql/das/ob_das_domain_utils.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "lib/container/ob_se_array.h"
+#include "lib/worker.h"
 #include "share/rc/ob_module_provider.h"
 #include "share/ob_errno.h"
 #define USING_LOG_PREFIX SQL_DAS
@@ -40,11 +41,22 @@ ObObjDatumMapType ObFTIndexRowCache::FTS_DOC_WORD_TYPES[] = {OBJ_DATUM_STRING, O
 
 ObExprOperatorType ObFTIndexRowCache::FTS_INDEX_EXPR_TYPE[] = {T_FUN_SYS_WORD_SEGMENT, T_FUN_SYS_DOC_ID, T_FUN_SYS_WORD_COUNT, T_FUN_SYS_DOC_LENGTH};
 ObExprOperatorType ObFTIndexRowCache::FTS_DOC_WORD_EXPR_TYPE[] = {T_FUN_SYS_DOC_ID, T_FUN_SYS_WORD_SEGMENT, T_FUN_SYS_WORD_COUNT, T_FUN_SYS_DOC_LENGTH};
+const int64_t ObFTIndexRowCache::FT_WORD_DOC_COL_CNT;
+const int64_t ObFTIndexRowCache::FT_TOKEN_BUCKET_COUNT;
 
 ObFTIndexRowCache::ObFTIndexRowCache()
-  : rows_(),
+  : metadata_allocator_("FTIndexMeta"),
+    scratch_allocator_("FTIndexScratch"),
+    token_processor_(scratch_allocator_),
+    datum_row_(),
+    token_map_(),
+    token_arr_(),
     row_idx_(0),
     is_fts_index_aux_(true),
+    is_builtin_parser_(false),
+    token_processor_inited_(false),
+    parser_param_(),
+    token_iterator_(nullptr),
     helper_(),
     is_inited_(false)
 {
@@ -61,18 +73,20 @@ int ObFTIndexRowCache::init(
     const common::ObString &parser_properties)
 {
   int ret = OB_SUCCESS;
-  lib::ContextParam param;
-  param.set_mem_attr("DocIdMerge", ObCtxIds::DEFAULT_CTX_ID).set_properties(lib::USE_TL_PAGE_OPTIONAL);
   if (OB_UNLIKELY(is_inited_)) {
     ret = OB_INIT_TWICE;
     LOG_WARN("init fulltext dml iterator twice", K(ret), K(is_inited_));
-  } else if (OB_FAIL(CURRENT_CONTEXT->CREATE_CONTEXT(merge_memctx_, param))) {
-    LOG_WARN("failed to create merge memctx", K(ret));
-  } else if (OB_FAIL(helper_.init(&(merge_memctx_->get_arena_allocator()), parser_name, parser_properties))) {
+  } else if (OB_FAIL(helper_.init(&metadata_allocator_, parser_name, parser_properties))) {
     LOG_WARN("fail to init full-text parser helper", K(ret));
+  } else if (OB_FAIL(token_map_.create(
+                         FT_TOKEN_BUCKET_COUNT, common::ObMemAttr("FTIndexTokenMap")))) {
+    LOG_WARN("fail to create full-text token map", K(ret), K(FT_TOKEN_BUCKET_COUNT));
+  } else if (OB_FAIL(datum_row_.init(metadata_allocator_, FT_WORD_DOC_COL_CNT))) {
+    LOG_WARN("fail to initialize reusable full-text datum row", K(ret), K(FT_WORD_DOC_COL_CNT));
   } else {
     row_idx_ = 0;
     is_fts_index_aux_ = is_fts_index_aux;
+    is_builtin_parser_ = helper_.is_builtin_parser();
     is_inited_ = true;
   }
   if (OB_UNLIKELY(!is_inited_)) {
@@ -86,22 +100,162 @@ int ObFTIndexRowCache::segment(const common::ObObjMeta &ft_obj_meta,
                                const ObString &fulltext)
 {
   int ret = OB_SUCCESS;
+  int64_t doc_length = 0;
+  reuse();
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("ObFTIndexRowCache hasn't be initialized", K(ret), K(is_inited_));
-  } else if (FALSE_IT(reuse())) {
-  } else if (OB_FAIL(ObDASDomainUtils::generate_fulltext_word_rows(merge_memctx_->get_arena_allocator(),
-                                                                   &helper_,
-                                                                   ft_obj_meta,
-                                                                   doc_id_datum,
-                                                                   fulltext,
-                                                                   is_fts_index_aux_,
-                                                                   rows_))) {
-    LOG_WARN("fail to generate fulltext word rows", K(ret), K(helper_), K(is_fts_index_aux_));
+  } else if (OB_UNLIKELY(fulltext.empty())) {
+    ret = OB_ITER_END;
+  } else if (is_builtin_parser_
+      && OB_FAIL(segment_with_builtin_parser(ft_obj_meta,
+                                             fulltext.ptr(),
+                                             fulltext.length(),
+                                             doc_length))) {
+    LOG_WARN("fail to segment fulltext with reusable parser", K(ret), K(helper_));
+  } else if (!is_builtin_parser_
+      && OB_FAIL(helper_.segment(ft_obj_meta,
+                                 fulltext.ptr(),
+                                 fulltext.length(),
+                                 doc_length,
+                                 token_map_,
+                                 scratch_allocator_))) {
+    LOG_WARN("fail to segment fulltext", K(ret), K(helper_), K(is_fts_index_aux_));
+  } else if (0 == token_map_.size()) {
+    ret = OB_ITER_END;
   } else {
-    row_idx_ = 0;
+    const int64_t doc_id_idx = is_fts_index_aux_ ? 1 : 0;
+    datum_row_.storage_datums_[doc_id_idx].shallow_copy_from_datum(doc_id_datum);
+    datum_row_.storage_datums_[3].set_uint(doc_length);
+    for (storage::ObFTTokenMap::const_iterator iter = token_map_.begin();
+         OB_SUCC(ret) && iter != token_map_.end();
+         ++iter) {
+      if (OB_FAIL(token_arr_.push_back(iter.operator->()))) {
+        LOG_WARN("fail to cache full-text token", K(ret), K(iter->first));
+      }
+    }
   }
-  LOG_TRACE("word segment", K(ret), K(row_idx_), K(rows_.count()), K(doc_id_datum), K(fulltext));
+  LOG_TRACE("word segment", K(ret), K(row_idx_), K(token_arr_.count()), K(doc_id_datum));
+  return ret;
+}
+
+int ObFTIndexRowCache::segment_with_builtin_parser(
+    const common::ObObjMeta &ft_obj_meta,
+    const char *fulltext,
+    const int64_t fulltext_len,
+    int64_t &doc_length)
+{
+  int ret = OB_SUCCESS;
+  const bool need_tolower = helper_.get_process_token_flags().casedown();
+  ObString source(fulltext_len, fulltext);
+  ObString regularized;
+  const char *parser_input = fulltext;
+  int64_t parser_input_len = fulltext_len;
+  storage::ObAddWordFlag token_flag = helper_.get_process_token_flags();
+  token_flag.clear_casedown();
+  if (!token_processor_inited_
+      && OB_FAIL(token_processor_.init(helper_.get_parser_property(),
+                                       ft_obj_meta,
+                                       token_flag,
+                                       &token_map_))) {
+    LOG_WARN("fail to initialize reusable token processor", K(ret), K(ft_obj_meta));
+  } else if (!token_processor_inited_
+      && FALSE_IT(token_processor_inited_ = true)) {
+  } else if (need_tolower
+      && OB_FAIL(ObCharset::tolower(ft_obj_meta.get_collation_type(),
+                                    source,
+                                    regularized,
+                                    scratch_allocator_))) {
+    LOG_WARN("fail to lowercase fulltext", K(ret), K(ft_obj_meta));
+  } else if (need_tolower && regularized.empty()) {
+    // Invalid source text has no token.
+  } else {
+    if (need_tolower) {
+      parser_input = regularized.ptr();
+      parser_input_len = regularized.length();
+    }
+    if (OB_FAIL(prepare_builtin_parser(ft_obj_meta, parser_input, parser_input_len))) {
+      LOG_WARN("fail to prepare reusable fulltext parser", K(ret), K(ft_obj_meta));
+    } else {
+      const char *token = nullptr;
+      int64_t token_len = 0;
+      int64_t char_cnt = 0;
+      int64_t token_freq = 0;
+      int64_t check_interval = 0;
+      while (OB_SUCC(ret)) {
+        if (OB_FAIL(token_iterator_->get_next_token(
+            token, token_len, char_cnt, token_freq))) {
+          if (OB_ITER_END != ret) {
+            LOG_WARN("fail to get next fulltext token", K(ret), KPC(token_iterator_));
+          }
+        } else if (OB_FAIL(token_processor_.process_token(
+            token, token_len, char_cnt, token_freq))) {
+          LOG_WARN("fail to process fulltext token", K(ret), K(token_len), K(char_cnt));
+        } else if (++check_interval >= 100) {
+          if (OB_FAIL(THIS_WORKER.check_status())) {
+            LOG_WARN("worker interrupted during fulltext segmentation", K(ret));
+          } else {
+            check_interval = 0;
+          }
+        }
+      }
+      if (OB_ITER_END == ret) {
+        doc_length = token_processor_.get_non_stop_token_count();
+        ret = OB_SUCCESS;
+      }
+    }
+  }
+  return ret;
+}
+
+int ObFTIndexRowCache::prepare_builtin_parser(
+    const common::ObObjMeta &ft_obj_meta,
+    const char *fulltext,
+    const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  const ObCharsetInfo *cs = nullptr;
+  const storage::ObFTParserProperty &property = helper_.get_parser_property();
+  if (OB_ISNULL(fulltext) || OB_UNLIKELY(fulltext_len <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext parser input", K(ret), KP(fulltext), K(fulltext_len));
+  } else if (OB_ISNULL(cs = ObCharset::get_charset(ft_obj_meta.get_collation_type()))) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("fail to get fulltext charset", K(ret), K(ft_obj_meta));
+  } else {
+    parser_param_.allocator_ = &scratch_allocator_;
+    parser_param_.metadata_alloc_ = &metadata_allocator_;
+    parser_param_.scratch_alloc_ = &scratch_allocator_;
+    parser_param_.cs_ = cs;
+    parser_param_.fulltext_ = fulltext;
+    parser_param_.ft_length_ = fulltext_len;
+    parser_param_.parser_version_ = helper_.get_parser_name().get_parser_version();
+    parser_param_.plugin_param_ = helper_.get_plugin_param();
+    parser_param_.ngram_token_size_ = property.ngram_token_size_;
+    parser_param_.min_ngram_size_ = property.min_ngram_token_size_;
+    parser_param_.max_ngram_size_ = property.max_ngram_token_size_;
+    parser_param_.ik_param_.mode_ = property.ik_mode_smart_
+        ? plugin::ObFTIKParam::Mode::SMART : plugin::ObFTIKParam::Mode::MAX_WORD;
+    parser_param_.ik_param_.main_dict_ = property.dict_table_;
+    parser_param_.ik_param_.quan_dict_ = property.quantifier_table_;
+    parser_param_.ik_param_.stopword_dict_ = property.stopword_table_;
+    parser_param_.ik_param_.main_dict_id_ = property.dict_table_id_;
+    parser_param_.ik_param_.quan_dict_id_ = property.quantifier_table_id_;
+    parser_param_.ik_param_.stopword_dict_id_ = property.stopword_table_id_;
+    parser_param_.tenant_id_ = common::OB_SERVER_TENANT_ID;
+    if (OB_ISNULL(token_iterator_)) {
+      if (OB_FAIL(helper_.get_parser_desc()->segment(&parser_param_, token_iterator_))) {
+        LOG_WARN("fail to create reusable fulltext parser", K(ret), K(parser_param_));
+      }
+    } else if (OB_FAIL(static_cast<storage::ObIFTParser *>(token_iterator_)->reuse_parser(
+                           fulltext, fulltext_len))) {
+      LOG_WARN("fail to reuse fulltext parser", K(ret), K(parser_param_));
+    }
+    if (OB_SUCC(ret) && OB_ISNULL(token_iterator_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("reusable fulltext parser is null", K(ret));
+    }
+  }
   return ret;
 }
 
@@ -111,36 +265,52 @@ int ObFTIndexRowCache::get_next_row(blocksstable::ObDatumRow *&row)
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("ObFTIndexRowCache hasn't be initialized", K(ret), K(is_inited_));
-  } else if (row_idx_ >= rows_.count()) {
+  } else if (row_idx_ >= token_arr_.count()) {
     ret = OB_ITER_END;
   } else {
-    row = (rows_[row_idx_]);
+    const storage::ObFTTokenPair *token_pair = token_arr_.at(row_idx_);
+    const int64_t word_idx = is_fts_index_aux_ ? 0 : 1;
+    datum_row_.storage_datums_[word_idx].set_datum(token_pair->first.get_token());
+    datum_row_.storage_datums_[2].set_uint(token_pair->second.count_);
+    row = &datum_row_;
     ++row_idx_;
   }
-  LOG_TRACE("get next row", K(ret), KPC(row), K(row_idx_), K(rows_.count()));
+  LOG_TRACE("get next row", K(ret), KPC(row), K(row_idx_), K(token_arr_.count()));
   return ret;
 }
 
 void ObFTIndexRowCache::reset()
 {
-  rows_.reset();
+  is_inited_ = false;
+  if (OB_NOT_NULL(token_iterator_) && OB_NOT_NULL(helper_.get_parser_desc())) {
+    helper_.get_parser_desc()->free_token_iter(&parser_param_, token_iterator_);
+  }
+  token_iterator_ = nullptr;
+  token_arr_.reset();
+  token_map_.destroy();
+  datum_row_.reset();
+  token_processor_.reset();
+  token_processor_inited_ = false;
+  parser_param_.reset();
+  helper_.reset();
+  scratch_allocator_.reset();
+  metadata_allocator_.reset();
   row_idx_ = 0;
   is_fts_index_aux_ = true;
-  helper_.reset();
-  if (OB_NOT_NULL(merge_memctx_)) {
-    DESTROY_CONTEXT(merge_memctx_);
-    merge_memctx_ = nullptr;
-  }
-  is_inited_ = false;
+  is_builtin_parser_ = false;
 }
 
 void ObFTIndexRowCache::reuse()
 {
-  rows_.reuse();
-  row_idx_ = 0;
-  if (OB_NOT_NULL(merge_memctx_)) {
-    merge_memctx_->reset_remain_one_page();
+  token_arr_.reuse();
+  if (token_map_.created()) {
+    token_map_.reuse();
   }
+  if (token_processor_inited_) {
+    token_processor_.reuse();
+  }
+  scratch_allocator_.reset_remain_one_page();
+  row_idx_ = 0;
 }
 
 int ObDASDomainUtils::generate_spatial_index_rows(
@@ -318,7 +488,7 @@ int ObDASDomainUtils::build_ft_doc_word_infos(
   static constexpr int64_t FT_MAX_WORD_BUCKET = 997;
   const int64_t ft_word_bkt_cnt = MIN(MAX(fulltext.length() / 10, 2), FT_MAX_WORD_BUCKET);
   int64_t doc_length = 0;
-  ObFTWordMap ft_word_map;
+  storage::ObFTTokenMap token_map;
   void *rows_buf = nullptr;
   blocksstable::ObDatumRow *rows = nullptr;
   if (OB_ISNULL(helper) || OB_UNLIKELY(!ft_obj_meta.is_valid())) {
@@ -326,33 +496,33 @@ int ObDASDomainUtils::build_ft_doc_word_infos(
     LOG_WARN("invalid arguments", K(ret), KPC(helper), K(ft_obj_meta), K(doc_id_datum));
   } else if (0 == fulltext.length()) {
     ret = OB_ITER_END;
-  } else if (OB_FAIL(ft_word_map.create(ft_word_bkt_cnt, common::ObMemAttr("FTWordMap")))) {
-    LOG_WARN("fail to create ft word map", K(ret), K(ft_word_bkt_cnt));
+  } else if (OB_FAIL(token_map.create(ft_word_bkt_cnt, common::ObMemAttr("FTTokenMap")))) {
+    LOG_WARN("fail to create fulltext token map", K(ret), K(ft_word_bkt_cnt));
   } else if (OB_FAIL(segment_and_calc_word_count(allocator,
                                                  helper,
                                                  ft_obj_meta,
                                                  fulltext,
                                                  doc_length,
-                                                 ft_word_map))) {
+                                                 token_map))) {
     LOG_WARN("fail to segment and calculate word count", K(ret), KPC(helper),
         K(ft_obj_meta.get_collation_type()), K(fulltext));
-  } else if (0 == ft_word_map.size()) {
+  } else if (0 == token_map.size()) {
     ret = OB_ITER_END;
   } else if (OB_ISNULL(rows_buf = reinterpret_cast<char *>(
-                           allocator.alloc(ft_word_map.size() * sizeof(blocksstable::ObDatumRow))))) {
+                           allocator.alloc(token_map.size() * sizeof(blocksstable::ObDatumRow))))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("failed to alloc memory for full text index rows buffer", K(ret));
   } else {
     int64_t i = 0;
-    rows = new (rows_buf) blocksstable::ObDatumRow[ft_word_map.size()];
-    for (ObFTWordMap::const_iterator iter = ft_word_map.begin();
-         OB_SUCC(ret) && iter != ft_word_map.end();
+    rows = new (rows_buf) blocksstable::ObDatumRow[token_map.size()];
+    for (storage::ObFTTokenMap::const_iterator iter = token_map.begin();
+         OB_SUCC(ret) && iter != token_map.end();
          ++iter) {
       if (OB_FAIL(rows[i].init(allocator, FT_WORD_DOC_COL_CNT))) {
         LOG_WARN("init datum row failed", K(ret), K(FT_WORD_DOC_COL_CNT));
       } else {
-        const ObFTWord &ft_word = iter->first;
-        const int64_t word_cnt = iter->second;
+        const storage::ObFTToken &ft_token = iter->first;
+        const int64_t word_cnt = iter->second.count_;
         // index row format
         //  -    FTS_INDEX: [WORD], [DOC_ID], [WORD_COUNT], [DOC_LENGTH]
         //  - FTS_DOC_WORD: [DOC_ID], [WORD], [WORD_COUNT], [DOC_LENGTH]
@@ -360,14 +530,15 @@ int ObDASDomainUtils::build_ft_doc_word_infos(
         const int64_t doc_id_idx = is_fts_index_aux ? 1 : 0;
         const int64_t word_cnt_idx = 2;
         const int64_t doc_len_idx = 3;
-        rows[i].storage_datums_[word_idx].set_datum(ft_word.get_word());
+        rows[i].storage_datums_[word_idx].set_datum(ft_token.get_token());
         rows[i].storage_datums_[doc_id_idx].shallow_copy_from_datum(doc_id_datum);
         rows[i].storage_datums_[word_cnt_idx].set_uint(word_cnt);
         rows[i].storage_datums_[doc_len_idx].set_uint(doc_length);
         if (OB_FAIL(word_rows.push_back(&rows[i]))) {
           LOG_WARN("fail to push back row", K(ret), K(rows[i]));
         } else {
-          LOG_DEBUG("succeed to add word row", K(ret), K(is_fts_index_aux), K(ft_word), K(word_cnt), K(i), K(rows[i]));
+          LOG_DEBUG("succeed to add word row", K(ret), K(is_fts_index_aux),
+              K(ft_token), K(word_cnt), K(i), K(rows[i]));
           ++i;
         }
       }
@@ -382,21 +553,22 @@ int ObDASDomainUtils::build_ft_doc_word_infos(
     const common::ObObjMeta &meta,
     const ObString &fulltext,
     int64_t &doc_length,
-    ObFTWordMap &words_count)
+    storage::ObFTTokenMap &tokens)
 {
   int ret = OB_SUCCESS;
   ObCollationType type = meta.get_collation_type();
   if (OB_ISNULL(helper)
       || OB_UNLIKELY(ObCollationType::CS_TYPE_INVALID == type
                   || ObCollationType::CS_TYPE_PINYIN_BEGIN_MARK <= type)
-      || OB_UNLIKELY(!words_count.created())) {
+      || OB_UNLIKELY(!tokens.created())) {
     ret = OB_INVALID_ARGUMENT;
-    LOG_WARN("invalid arguments", K(ret), KPC(helper), K(type), K(words_count.created()));
-  } else if (OB_FAIL(helper->segment(meta, fulltext.ptr(), fulltext.length(), doc_length, words_count))) {
+    LOG_WARN("invalid arguments", K(ret), KPC(helper), K(type), K(tokens.created()));
+  } else if (OB_FAIL(helper->segment(meta, fulltext.ptr(), fulltext.length(), doc_length,
+                                     tokens, allocator))) {
     LOG_WARN("fail to segment", K(ret), KPC(helper), K(type), K(fulltext));
   }
 
-  STORAGE_FTS_LOG(TRACE, "segment and calc word count", K(ret), K(words_count.size()), K(type));
+  STORAGE_FTS_LOG(TRACE, "segment and calc word count", K(ret), K(tokens.size()), K(type));
   return ret;
 }
 

--- a/src/sql/das/ob_das_domain_utils.cpp
+++ b/src/sql/das/ob_das_domain_utils.cpp
@@ -52,8 +52,9 @@ ObFTIndexRowCache::ObFTIndexRowCache()
     token_processor_(scratch_allocator_),
     datum_row_(),
     token_map_(),
+    token_iter_(),
+    token_end_iter_(),
     token_map_bucket_count_(0),
-    token_arr_(),
     row_idx_(0),
     is_fts_index_aux_(true),
     is_builtin_parser_(false),
@@ -133,15 +134,10 @@ int ObFTIndexRowCache::segment(const common::ObObjMeta &ft_obj_meta,
     const int64_t doc_id_idx = is_fts_index_aux_ ? 1 : 0;
     datum_row_.storage_datums_[doc_id_idx].shallow_copy_from_datum(doc_id_datum);
     datum_row_.storage_datums_[3].set_uint(doc_length);
-    for (storage::ObFTTokenMap::const_iterator iter = token_map_.begin();
-         OB_SUCC(ret) && iter != token_map_.end();
-         ++iter) {
-      if (OB_FAIL(token_arr_.push_back(iter.operator->()))) {
-        LOG_WARN("fail to cache full-text token", K(ret), K(iter->first));
-      }
-    }
+    token_iter_ = token_map_.begin();
+    token_end_iter_ = token_map_.end();
   }
-  LOG_TRACE("word segment", K(ret), K(row_idx_), K(token_arr_.count()), K(doc_id_datum));
+  LOG_TRACE("word segment", K(ret), K(row_idx_), K(token_map_.size()), K(doc_id_datum));
   return ret;
 }
 
@@ -294,17 +290,17 @@ int ObFTIndexRowCache::get_next_row(blocksstable::ObDatumRow *&row)
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("ObFTIndexRowCache hasn't be initialized", K(ret), K(is_inited_));
-  } else if (row_idx_ >= token_arr_.count()) {
+  } else if (token_iter_ == token_end_iter_) {
     ret = OB_ITER_END;
   } else {
-    const storage::ObFTTokenPair *token_pair = token_arr_.at(row_idx_);
     const int64_t word_idx = is_fts_index_aux_ ? 0 : 1;
-    datum_row_.storage_datums_[word_idx].set_datum(token_pair->first.get_token());
-    datum_row_.storage_datums_[2].set_uint(token_pair->second.count_);
+    datum_row_.storage_datums_[word_idx].set_datum(token_iter_->first.get_token());
+    datum_row_.storage_datums_[2].set_uint(token_iter_->second.count_);
     row = &datum_row_;
+    ++token_iter_;
     ++row_idx_;
   }
-  LOG_TRACE("get next row", K(ret), KPC(row), K(row_idx_), K(token_arr_.count()));
+  LOG_TRACE("get next row", K(ret), KPC(row), K(row_idx_), K(token_map_.size()));
   return ret;
 }
 
@@ -315,7 +311,6 @@ void ObFTIndexRowCache::reset()
     helper_.get_parser_desc()->free_token_iter(&parser_param_, token_iterator_);
   }
   token_iterator_ = nullptr;
-  token_arr_.reset();
   token_map_.destroy();
   token_map_bucket_count_ = 0;
   datum_row_.reset();
@@ -332,7 +327,6 @@ void ObFTIndexRowCache::reset()
 
 void ObFTIndexRowCache::reuse()
 {
-  token_arr_.reuse();
   if (token_processor_inited_) {
     token_processor_.reuse();
   }

--- a/src/sql/das/ob_das_domain_utils.cpp
+++ b/src/sql/das/ob_das_domain_utils.cpp
@@ -85,6 +85,9 @@ int ObFTIndexRowCache::init(
   } else if (OB_FAIL(token_map_.create(
                          FT_TOKEN_MIN_BUCKET_COUNT, common::ObMemAttr("FTIndexTokenMap")))) {
     LOG_WARN("fail to create full-text token map", K(ret), K(FT_TOKEN_MIN_BUCKET_COUNT));
+  } else if (OB_FAIL(token_map_.get_local_allocer().reserve(FT_TOKEN_MAX_BUCKET_COUNT))) {
+    LOG_WARN("fail to reserve reusable full-text token nodes", K(ret),
+        K(FT_TOKEN_MAX_BUCKET_COUNT));
   } else if (OB_FAIL(datum_row_.init(metadata_allocator_, FT_WORD_DOC_COL_CNT))) {
     LOG_WARN("fail to initialize reusable full-text datum row", K(ret), K(FT_WORD_DOC_COL_CNT));
   } else {

--- a/src/sql/das/ob_das_domain_utils.h
+++ b/src/sql/das/ob_das_domain_utils.h
@@ -18,11 +18,14 @@
 #define OCEANBASE_DAS_DOMAIN_UTILS_H
 
 #include "lib/allocator/page_arena.h"
+#include "lib/container/ob_se_array.h"
 #include "lib/hash/ob_hashset.h"
 #include "common/datum/ob_datum.h"
 #include "sql/das/ob_das_dml_ctx_define.h"
 #include "storage/fts/ob_fts_doc_word_iterator.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
+#include "storage/fts/ob_ft_token_processor.h"
+#include "storage/fts/ob_i_ft_parser.h"
 
 namespace oceanbase
 {
@@ -48,12 +51,33 @@ public:
   int get_next_row(blocksstable::ObDatumRow *&row);
   void reset();
   void reuse();
-  TO_STRING_KV(K_(row_idx), K_(is_fts_index_aux), K_(helper), K_(is_inited), K_(rows));
+  TO_STRING_KV(K_(row_idx), K_(is_fts_index_aux), K_(helper), K_(is_inited),
+      K(token_map_.size()), K(token_arr_.count()));
 private:
-  lib::MemoryContext merge_memctx_;
-  ObDomainIndexRow rows_;
+  int segment_with_builtin_parser(
+      const common::ObObjMeta &ft_obj_meta,
+      const char *fulltext,
+      const int64_t fulltext_len,
+      int64_t &doc_length);
+  int prepare_builtin_parser(
+      const common::ObObjMeta &ft_obj_meta,
+      const char *fulltext,
+      const int64_t fulltext_len);
+
+  static const int64_t FT_WORD_DOC_COL_CNT = 4;
+  static const int64_t FT_TOKEN_BUCKET_COUNT = 997;
+  common::ObArenaAllocator metadata_allocator_;
+  common::ObArenaAllocator scratch_allocator_;
+  storage::ObFTTokenProcessor token_processor_;
+  blocksstable::ObDatumRow datum_row_;
+  storage::ObFTTokenMap token_map_;
+  common::ObSEArray<const storage::ObFTTokenPair *, 16> token_arr_;
   uint64_t row_idx_;
   bool is_fts_index_aux_;
+  bool is_builtin_parser_;
+  bool token_processor_inited_;
+  plugin::ObFTParserParam parser_param_;
+  plugin::ObITokenIterator *token_iterator_;
   storage::ObFTParseHelper helper_;
   bool is_inited_;
 
@@ -199,7 +223,7 @@ private:
       const common::ObObjMeta &meta,
       const ObString &fulltext,
       int64_t &doc_length,
-      ObFTWordMap &words_count);
+      storage::ObFTTokenMap &tokens);
   static int calc_save_rowkey_policy(
     ObIAllocator &allocator,
     const ObDASDMLBaseCtDef &das_ctdef,

--- a/src/sql/das/ob_das_domain_utils.h
+++ b/src/sql/das/ob_das_domain_utils.h
@@ -52,7 +52,7 @@ public:
   void reset();
   void reuse();
   TO_STRING_KV(K_(row_idx), K_(is_fts_index_aux), K_(helper), K_(is_inited),
-      K(token_map_.size()), K(token_arr_.count()));
+      K(token_map_.size()));
 private:
   int segment_with_builtin_parser(
       const common::ObObjMeta &ft_obj_meta,
@@ -74,8 +74,9 @@ private:
   storage::ObFTTokenProcessor token_processor_;
   blocksstable::ObDatumRow datum_row_;
   storage::ObFTTokenMap token_map_;
+  storage::ObFTTokenMap::const_iterator token_iter_;
+  storage::ObFTTokenMap::const_iterator token_end_iter_;
   int64_t token_map_bucket_count_;
-  common::ObSEArray<const storage::ObFTTokenPair *, 16> token_arr_;
   uint64_t row_idx_;
   bool is_fts_index_aux_;
   bool is_builtin_parser_;

--- a/src/sql/das/ob_das_domain_utils.h
+++ b/src/sql/das/ob_das_domain_utils.h
@@ -63,14 +63,18 @@ private:
       const common::ObObjMeta &ft_obj_meta,
       const char *fulltext,
       const int64_t fulltext_len);
+  int prepare_token_map(const int64_t fulltext_len);
 
   static const int64_t FT_WORD_DOC_COL_CNT = 4;
-  static const int64_t FT_TOKEN_BUCKET_COUNT = 997;
+  static const int64_t FT_CHARS_PER_TOKEN = 4;
+  static const int64_t FT_TOKEN_MIN_BUCKET_COUNT = 2;
+  static const int64_t FT_TOKEN_MAX_BUCKET_COUNT = 997;
   common::ObArenaAllocator metadata_allocator_;
   common::ObArenaAllocator scratch_allocator_;
   storage::ObFTTokenProcessor token_processor_;
   blocksstable::ObDatumRow datum_row_;
   storage::ObFTTokenMap token_map_;
+  int64_t token_map_bucket_count_;
   common::ObSEArray<const storage::ObFTTokenPair *, 16> token_arr_;
   uint64_t row_idx_;
   bool is_fts_index_aux_;

--- a/src/sql/engine/basic/ob_temp_block_store.h
+++ b/src/sql/engine/basic/ob_temp_block_store.h
@@ -363,7 +363,15 @@ public:
 public:
   const static int64_t BLOCK_SIZE = (64L << 10) - sizeof(LinkNode);
   const static int64_t BIG_BLOCK_SIZE = (256L << 10) - sizeof(LinkNode);
+  const static int64_t BLOCK_CAPACITY = BLOCK_SIZE;
+  const static int64_t MIN_READ_BUFFER_SIZE = BLOCK_SIZE;
   const static int64_t DEFAULT_BLOCK_CNT = (1L << 20) / BLOCK_SIZE;
+
+  static int64_t get_read_alignment_size_config(const uint64_t tenant_id)
+  {
+    UNUSED(tenant_id);
+    return MIN_READ_BUFFER_SIZE;
+  }
 
   explicit ObTempBlockStore(common::ObIAllocator *alloc = NULL);
   virtual ~ObTempBlockStore() { reset(); }

--- a/src/sql/engine/basic/ob_temp_row_store.h
+++ b/src/sql/engine/basic/ob_temp_row_store.h
@@ -252,6 +252,22 @@ public:
            const bool reorder_fixed_expr = true,
            const bool enable_trunc = false);
 
+  int init(const ObExprPtrIArray &exprs,
+           const int64_t max_batch_size,
+           const lib::ObMemAttr &mem_attr,
+           const int64_t mem_limit,
+           bool enable_dump,
+           uint32_t row_extra_size,
+           const common::ObCompressorType compressor_type,
+           const bool reorder_fixed_expr,
+           const bool enable_trunc,
+           const int64_t tempstore_read_alignment_size)
+  {
+    UNUSED(tempstore_read_alignment_size);
+    return init(exprs, max_batch_size, mem_attr, mem_limit, enable_dump,
+                row_extra_size, compressor_type, reorder_fixed_expr, enable_trunc);
+  }
+
   int init(const RowMeta &row_meta,
            const int64_t max_batch_size,
            const lib::ObMemAttr &mem_attr,
@@ -259,6 +275,20 @@ public:
            bool enable_dump,
            const common::ObCompressorType compressor_type,
            const bool enable_trunc = false);
+
+  int init(const RowMeta &row_meta,
+           const int64_t max_batch_size,
+           const lib::ObMemAttr &mem_attr,
+           const int64_t mem_limit,
+           bool enable_dump,
+           const common::ObCompressorType compressor_type,
+           const bool enable_trunc,
+           const int64_t tempstore_read_alignment_size)
+  {
+    UNUSED(tempstore_read_alignment_size);
+    return init(row_meta, max_batch_size, mem_attr, mem_limit, enable_dump,
+                compressor_type, enable_trunc);
+  }
 
   int init_batch_ctx(const ObExprPtrIArray *exprs = NULL);
 
@@ -467,4 +497,3 @@ private:
 } // end namespace oceanbase
 
 #endif // OCEANBASE_BASIC_OB_TEMP_ROW_STORE_H_
-

--- a/src/sql/engine/cmd/ob_alter_system_executor.cpp
+++ b/src/sql/engine/cmd/ob_alter_system_executor.cpp
@@ -35,6 +35,12 @@
 #include "sql/engine/cmd/ob_timezone_importer.h"
 #include "sql/engine/cmd/ob_srs_importer.h"
 #include "share/ob_internal_table_change_notifier.h"
+#include "share/schema/ob_schema_getter_guard.h"
+#include "share/schema/ob_multi_version_schema_service.h"
+#include "storage/fts/ob_fts_plugin_helper.h"
+#include "storage/fts/dict/ob_ft_cache_container.h"
+#include "storage/fts/dict/ob_ft_dict_def.h"
+#include "storage/fts/dict/ob_ft_dict_hub.h"
 
 namespace oceanbase
 {
@@ -471,6 +477,64 @@ int ObRefreshMemStatExecutor::execute(ObExecContext &ctx, ObRefreshMemStatStmt &
   } else if (OB_FAIL(GCTX.root_service_->admin_refresh_memory_stat(
                          stmt.get_rpc_arg()))) {
     LOG_WARN("refresh memory stat failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+  }
+  return ret;
+}
+
+int ObRefreshFulltextDictExecutor::execute(ObExecContext &ctx,
+                                           ObRefreshFulltextDictStmt &stmt)
+{
+  int ret = OB_SUCCESS;
+  ObSQLSessionInfo *session = ctx.get_my_session();
+  share::schema::ObSchemaGetterGuard schema_guard;
+  const share::schema::ObTableSchema *table_schema = nullptr;
+  uint64_t table_id = OB_INVALID_ID;
+  storage::ObFTDictHub *dict_hub = nullptr;
+  ObArenaAllocator allocator("FTDictRefresh");
+  ObSqlString full_table_name;
+  if (OB_ISNULL(session) || OB_ISNULL(GCTX.schema_service_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("session or schema service is not initialized", K(ret), KP(session));
+  } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+    LOG_WARN("fail to get schema guard", K(ret));
+  } else if (OB_FAIL(schema_guard.get_table_id(
+                         stmt.get_database_name(),
+                         stmt.get_table_name(),
+                         false,
+                         share::schema::ObSchemaGetterGuard::ALL_NON_HIDDEN_TYPES,
+                         table_id))) {
+    LOG_WARN("fail to resolve dictionary table", K(ret), K(stmt));
+  } else if (OB_INVALID_ID == table_id) {
+    ret = OB_ERR_UNKNOWN_TABLE;
+    LOG_USER_ERROR(OB_ERR_UNKNOWN_TABLE,
+                   stmt.get_table_name().length(), stmt.get_table_name().ptr(),
+                   stmt.get_database_name().length(), stmt.get_database_name().ptr());
+  } else if (OB_FAIL(schema_guard.get_table_schema(table_id, table_schema))) {
+    LOG_WARN("fail to get dictionary table schema", K(ret), K(table_id));
+  } else if (OB_ISNULL(table_schema) || !table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "refreshing a non-fulltext-dictionary table is");
+  } else if (OB_FAIL(full_table_name.append_fmt("%.*s.%.*s",
+                                                stmt.get_database_name().length(),
+                                                stmt.get_database_name().ptr(),
+                                                stmt.get_table_name().length(),
+                                                stmt.get_table_name().ptr()))) {
+    LOG_WARN("fail to construct dictionary table name", K(ret));
+  } else if (OB_FAIL(storage::ObFTParsePluginData::instance().get_dict_hub(dict_hub))) {
+    LOG_WARN("fail to get fulltext dictionary hub", K(ret));
+  } else {
+    storage::ObFTDictDesc desc(common::OB_SERVER_TENANT_ID,
+                               table_id,
+                               full_table_name.string(),
+                               storage::ObFTDictType::DICT_IK_MAIN,
+                               ObCharsetType::CHARSET_UTF8MB4,
+                               ObCollationType::CS_TYPE_UTF8MB4_BIN,
+                               false,
+                               true);
+    storage::ObFTCacheRangeContainer container(allocator);
+    if (OB_FAIL(dict_hub->refresh(desc, container))) {
+      LOG_WARN("fail to refresh fulltext dictionary", K(ret), K(desc));
+    }
   }
   return ret;
 }

--- a/src/sql/engine/cmd/ob_alter_system_executor.h
+++ b/src/sql/engine/cmd/ob_alter_system_executor.h
@@ -56,6 +56,8 @@ DEF_SIMPLE_EXECUTOR(ObAdminMerge);
 
 DEF_SIMPLE_EXECUTOR(ObRefreshMemStat);
 
+DEF_SIMPLE_EXECUTOR(ObRefreshFulltextDict);
+
 DEF_SIMPLE_EXECUTOR(ObWashMemFragmentation);
 
 DEF_SIMPLE_EXECUTOR(ObRefreshIOCalibraiton);

--- a/src/sql/engine/expr/ob_expr_tokenize.cpp
+++ b/src/sql/engine/expr/ob_expr_tokenize.cpp
@@ -27,6 +27,7 @@
 #include "lib/utility/ob_macro_utils.h"
 #include "object/ob_object.h"
 #include "plugin/sys/ob_plugin_helper.h"
+#include "sql/engine/expr/ob_expr_lob_utils.h"
 #include "sql/resolver/ddl/ob_fts_index_builder_util.h"
 #include "sql/session/ob_sql_session_info.h"
 #include "share/ob_json_access_utils.h"
@@ -90,16 +91,14 @@ int ObExprTokenize::tokenize_fulltext(const TokenizeParam &param,
   storage::ObFTParseHelper tokenize_helper;
   const int64_t ft_word_bkt_cnt = MIN(MAX(param.fulltext_.length() / 2, 2), 997);
   int64_t doc_len = 0;
-  ObFTWordMap token_map;
-
-  ObArenaAllocator tmp_parse_alloc(ObMemAttr("Tmp buffer"));
+  storage::ObFTTokenMap token_map;
 
   if (TokenizeParam::OUTPUT_MODE::DEFAULT != mode && TokenizeParam::OUTPUT_MODE::ALL != mode) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Invalid output mode", K(ret), K(mode));
   } else if (OB_FAIL(tokenize_helper.init(&allocator, param.parser_name_, param.properties_))) {
     LOG_WARN("Fail to init tokenize helper", K(ret));
-  } else if (OB_FAIL(token_map.create(ft_word_bkt_cnt, common::ObMemAttr("FTWordMap")))) {
+  } else if (OB_FAIL(token_map.create(ft_word_bkt_cnt, common::ObMemAttr("FTTokenMap")))) {
     LOG_WARN("Fail to create token map", K(ret));
   } else if (
       (0 != param.fulltext_.length())
@@ -349,11 +348,20 @@ int ObExprTokenize::parse_fulltext(const ObExpr &expr, ObEvalCtx &ctx, TokenizeP
     if (fulltext_datum->is_null()) {
       // do nothing, return empty result
       param.fulltext_ = ObString::make_empty_string();
-    } else {
-      param.fulltext_ = fulltext_datum->get_string();
+    } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(
+        param.allocator_,
+        *fulltext_datum,
+        expr.args_[0]->datum_meta_,
+        expr.args_[0]->obj_meta_.has_lob_header(),
+        param.fulltext_,
+        &ctx.exec_ctx_))) {
+      LOG_WARN("Fail to read fulltext datum.", K(ret),
+          K(expr.args_[0]->datum_meta_), K(expr.args_[0]->obj_meta_));
     }
-    param.meta_.set_varchar(); // as we hardcoded in fts_index
-    param.meta_.set_collation_type(expr.args_[0]->obj_meta_.get_collation_type());
+    if (OB_SUCC(ret)) {
+      param.meta_.set_varchar(); // as we hardcoded in fts_index
+      param.meta_.set_collation_type(expr.args_[0]->obj_meta_.get_collation_type());
+    }
   }
   return ret;
 }

--- a/src/sql/engine/expr/ob_expr_tokenize.cpp
+++ b/src/sql/engine/expr/ob_expr_tokenize.cpp
@@ -82,27 +82,22 @@ public:
   }
 
   int get(const ObTokenizeCacheKey &key,
-          ObIAllocator &allocator,
-          ObString &result,
+          const ObExpr &expr,
+          ObEvalCtx &ctx,
+          ObDatum &result,
           bool &found)
   {
     int ret = OB_SUCCESS;
     found = false;
-    result.reset();
     common::ObSpinLockGuard guard(lock_);
     for (int64_t i = 0; OB_SUCC(ret) && !found && i < CACHE_ENTRY_COUNT; ++i) {
       CacheEntry &entry = entries_[i];
       if (entry.matches(key)) {
-        char *buf = nullptr;
-        if (entry.result_length_ > 0
-            && OB_ISNULL(buf = static_cast<char *>(allocator.alloc(entry.result_length_)))) {
-          ret = OB_ALLOCATE_MEMORY_FAILED;
-          LOG_WARN("fail to allocate cached tokenize result", K(ret), K(entry.result_length_));
+        ObString cached_result(entry.result_length_, entry.result_);
+        if (OB_FAIL(ObJsonExprHelper::pack_json_str_res(
+                expr, ctx, result, cached_result))) {
+          LOG_WARN("fail to pack cached tokenize result", K(ret), K(entry.result_length_));
         } else {
-          if (entry.result_length_ > 0) {
-            MEMCPY(buf, entry.result_, entry.result_length_);
-          }
-          result.assign_ptr(buf, entry.result_length_);
           entry.access_clock_ = ++access_clock_;
           found = true;
         }
@@ -279,7 +274,6 @@ int ObExprTokenize::eval_tokenize(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &e
   ObIJsonBase *json_result = nullptr;
   TokenizeParam param;
   ObTokenizeCacheKey cache_key;
-  ObString cached_result;
   bool cacheable = false;
   bool cache_hit = false;
 
@@ -291,13 +285,10 @@ int ObExprTokenize::eval_tokenize(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &e
     LOG_WARN("fail to build tokenize cache key", K(ret));
   } else if (cacheable
       && OB_FAIL(ObTokenizeResultCache::instance().get(
-          cache_key, temp_allocator, cached_result, cache_hit))) {
+          cache_key, expr, ctx, expr_datum, cache_hit))) {
     LOG_WARN("fail to get cached tokenize result", K(ret));
   } else if (cache_hit) {
-    if (OB_FAIL(ObJsonExprHelper::pack_json_str_res(
-        expr, ctx, expr_datum, cached_result))) {
-      LOG_WARN("fail to pack cached tokenize result", K(ret));
-    }
+    // Result was packed directly from the cache entry.
   } else if (OB_FAIL(parse_param(expr, ctx, temp_allocator, param))) {
     LOG_WARN("Fail to parse param", K(ret));
   } else if (OB_FAIL(tokenize_fulltext(param, param.output_mode_, temp_allocator, json_result))) {

--- a/src/sql/engine/expr/ob_expr_tokenize.cpp
+++ b/src/sql/engine/expr/ob_expr_tokenize.cpp
@@ -22,6 +22,7 @@
 #include "common/json_type/ob_json_base.h"
 #include "common/json_type/ob_json_tree.h"
 #include "lib/ob_errno.h"
+#include "lib/lock/ob_spin_lock.h"
 #include "lib/oblog/ob_log_module.h"
 #include "lib/string/ob_string.h"
 #include "lib/utility/ob_macro_utils.h"
@@ -32,6 +33,7 @@
 #include "sql/session/ob_sql_session_info.h"
 #include "share/ob_json_access_utils.h"
 #include "storage/fts/dict/ob_gen_dic_loader.h"
+#include "storage/fts/dict/ob_ft_dict_hub.h"
 #include "storage/fts/ob_fts_parser_property.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
 
@@ -42,6 +44,220 @@ namespace oceanbase
 {
 namespace sql
 {
+namespace
+{
+
+struct ObTokenizeCacheKey
+{
+  ObTokenizeCacheKey()
+    : fulltext_(), parser_name_(), collation_(CS_TYPE_INVALID),
+      tenant_id_(OB_INVALID_TENANT_ID), dict_epoch_(0)
+  {}
+
+  ObString fulltext_;
+  ObString parser_name_;
+  ObCollationType collation_;
+  uint64_t tenant_id_;
+  uint64_t dict_epoch_;
+};
+
+class ObTokenizeResultCache final
+{
+public:
+  static const int64_t CACHE_ENTRY_COUNT = 8;
+  static const int64_t MAX_FULLTEXT_LENGTH = 4096;
+  static const int64_t MAX_PARSER_NAME_LENGTH = 128;
+  static const int64_t MAX_RESULT_LENGTH = 32768;
+
+  static ObTokenizeResultCache &instance()
+  {
+    static ObTokenizeResultCache cache;
+    return cache;
+  }
+
+  bool can_cache(const ObTokenizeCacheKey &key) const
+  {
+    return key.fulltext_.length() <= MAX_FULLTEXT_LENGTH
+        && key.parser_name_.length() <= MAX_PARSER_NAME_LENGTH;
+  }
+
+  int get(const ObTokenizeCacheKey &key,
+          ObIAllocator &allocator,
+          ObString &result,
+          bool &found)
+  {
+    int ret = OB_SUCCESS;
+    found = false;
+    result.reset();
+    common::ObSpinLockGuard guard(lock_);
+    for (int64_t i = 0; OB_SUCC(ret) && !found && i < CACHE_ENTRY_COUNT; ++i) {
+      CacheEntry &entry = entries_[i];
+      if (entry.matches(key)) {
+        char *buf = nullptr;
+        if (entry.result_length_ > 0
+            && OB_ISNULL(buf = static_cast<char *>(allocator.alloc(entry.result_length_)))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          LOG_WARN("fail to allocate cached tokenize result", K(ret), K(entry.result_length_));
+        } else {
+          if (entry.result_length_ > 0) {
+            MEMCPY(buf, entry.result_, entry.result_length_);
+          }
+          result.assign_ptr(buf, entry.result_length_);
+          entry.access_clock_ = ++access_clock_;
+          found = true;
+        }
+      }
+    }
+    return ret;
+  }
+
+  void put(const ObTokenizeCacheKey &key, const ObString &result)
+  {
+    if (!can_cache(key) || result.length() > MAX_RESULT_LENGTH) {
+      return;
+    }
+    common::ObSpinLockGuard guard(lock_);
+    int64_t victim_idx = 0;
+    uint64_t oldest_clock = UINT64_MAX;
+    bool found_victim = false;
+    for (int64_t i = 0; !found_victim && i < CACHE_ENTRY_COUNT; ++i) {
+      if (!entries_[i].valid_ || entries_[i].matches(key)) {
+        victim_idx = i;
+        found_victim = true;
+      } else if (entries_[i].access_clock_ < oldest_clock) {
+        oldest_clock = entries_[i].access_clock_;
+        victim_idx = i;
+      }
+    }
+    CacheEntry &entry = entries_[victim_idx];
+    entry.assign(key, result, ++access_clock_);
+  }
+
+private:
+  struct CacheEntry
+  {
+    CacheEntry()
+      : collation_(CS_TYPE_INVALID), tenant_id_(OB_INVALID_TENANT_ID), dict_epoch_(0),
+        fulltext_length_(0), parser_name_length_(0), result_length_(0),
+        access_clock_(0), valid_(false)
+    {}
+
+    bool matches(const ObTokenizeCacheKey &key) const
+    {
+      return valid_
+          && collation_ == key.collation_
+          && tenant_id_ == key.tenant_id_
+          && dict_epoch_ == key.dict_epoch_
+          && fulltext_length_ == key.fulltext_.length()
+          && parser_name_length_ == key.parser_name_.length()
+          && (0 == fulltext_length_
+              || 0 == MEMCMP(fulltext_, key.fulltext_.ptr(), fulltext_length_))
+          && (0 == parser_name_length_
+              || 0 == MEMCMP(parser_name_, key.parser_name_.ptr(), parser_name_length_));
+    }
+
+    void assign(const ObTokenizeCacheKey &key, const ObString &result, const uint64_t access_clock)
+    {
+      collation_ = key.collation_;
+      tenant_id_ = key.tenant_id_;
+      dict_epoch_ = key.dict_epoch_;
+      fulltext_length_ = key.fulltext_.length();
+      parser_name_length_ = key.parser_name_.length();
+      result_length_ = result.length();
+      if (fulltext_length_ > 0) {
+        MEMCPY(fulltext_, key.fulltext_.ptr(), fulltext_length_);
+      }
+      if (parser_name_length_ > 0) {
+        MEMCPY(parser_name_, key.parser_name_.ptr(), parser_name_length_);
+      }
+      if (result_length_ > 0) {
+        MEMCPY(result_, result.ptr(), result_length_);
+      }
+      access_clock_ = access_clock;
+      valid_ = true;
+    }
+
+    char fulltext_[MAX_FULLTEXT_LENGTH];
+    char parser_name_[MAX_PARSER_NAME_LENGTH];
+    char result_[MAX_RESULT_LENGTH];
+    ObCollationType collation_;
+    uint64_t tenant_id_;
+    uint64_t dict_epoch_;
+    int32_t fulltext_length_;
+    int32_t parser_name_length_;
+    int32_t result_length_;
+    uint64_t access_clock_;
+    bool valid_;
+  };
+
+  ObTokenizeResultCache() : lock_(), entries_(), access_clock_(0) {}
+  ~ObTokenizeResultCache() = default;
+
+  common::ObSpinLock lock_;
+  CacheEntry entries_[CACHE_ENTRY_COUNT];
+  uint64_t access_clock_;
+  DISALLOW_COPY_AND_ASSIGN(ObTokenizeResultCache);
+};
+
+bool is_builtin_tokenize_parser(const ObString &parser_name)
+{
+  return 0 == parser_name.case_compare("space")
+      || 0 == parser_name.case_compare("ngram")
+      || 0 == parser_name.case_compare("beng")
+      || 0 == parser_name.case_compare("ik")
+      || 0 == parser_name.case_compare("ngram2");
+}
+
+int build_tokenize_cache_key(const ObExpr &expr,
+                             ObEvalCtx &ctx,
+                             ObIAllocator &allocator,
+                             ObTokenizeCacheKey &key,
+                             bool &cacheable)
+{
+  int ret = OB_SUCCESS;
+  cacheable = false;
+  ObDatum *fulltext_datum = nullptr;
+  ObDatum *parser_datum = nullptr;
+  if (expr.arg_cnt_ > 2) {
+    // TOKENIZE with parser properties may depend on mutable custom dictionaries.
+  } else if (OB_FAIL(expr.args_[0]->eval(ctx, fulltext_datum))) {
+    LOG_WARN("fail to evaluate fulltext for tokenize cache", K(ret));
+  } else if (OB_NOT_NULL(fulltext_datum) && !fulltext_datum->is_null()
+      && OB_FAIL(ObTextStringHelper::read_real_string_data(
+          allocator,
+          *fulltext_datum,
+          expr.args_[0]->datum_meta_,
+          expr.args_[0]->obj_meta_.has_lob_header(),
+          key.fulltext_,
+          &ctx.exec_ctx_))) {
+    LOG_WARN("fail to read fulltext for tokenize cache", K(ret));
+  } else if (expr.arg_cnt_ >= 2 && OB_FAIL(expr.args_[1]->eval(ctx, parser_datum))) {
+    LOG_WARN("fail to evaluate parser name for tokenize cache", K(ret));
+  } else {
+    key.parser_name_ = expr.arg_cnt_ < 2 || OB_ISNULL(parser_datum) || parser_datum->is_null()
+        ? ObString::make_string(OB_DEFAULT_FULLTEXT_PARSER_NAME)
+        : parser_datum->get_string().trim();
+    key.collation_ = expr.args_[0]->obj_meta_.get_collation_type();
+    key.tenant_id_ = common::OB_SERVER_TENANT_ID;
+    if (is_builtin_tokenize_parser(key.parser_name_)
+        && 0 == key.parser_name_.case_compare("ik")) {
+      storage::ObFTDictHub *dict_hub = nullptr;
+      const int tmp_ret = storage::ObFTParsePluginData::instance().get_dict_hub(dict_hub);
+      if (OB_SUCCESS == tmp_ret && OB_NOT_NULL(dict_hub)) {
+        key.dict_epoch_ = dict_hub->get_generation_epoch();
+        cacheable = ObTokenizeResultCache::instance().can_cache(key);
+      } else {
+        LOG_DEBUG("skip tokenize cache because dictionary hub is unavailable", K(tmp_ret), KP(dict_hub));
+      }
+    } else if (is_builtin_tokenize_parser(key.parser_name_)) {
+      cacheable = ObTokenizeResultCache::instance().can_cache(key);
+    }
+  }
+  return ret;
+}
+
+} // namespace
+
 ObExprTokenize::ObExprTokenize(common::ObIAllocator &alloc)
     : ObStringExprOperator(alloc,
                            T_FUN_TOKENIZE,
@@ -62,15 +278,41 @@ int ObExprTokenize::eval_tokenize(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &e
 
   ObIJsonBase *json_result = nullptr;
   TokenizeParam param;
+  ObTokenizeCacheKey cache_key;
+  ObString cached_result;
+  bool cacheable = false;
+  bool cache_hit = false;
 
   // check param num, which is checked in ObExprOperator::calc_result_typeN.
   if (OB_UNLIKELY(expr.arg_cnt_ < 1 || expr.arg_cnt_ > 3)) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Args count invalid.", K(ret), K(expr.arg_cnt_));
+  } else if (OB_FAIL(build_tokenize_cache_key(expr, ctx, temp_allocator, cache_key, cacheable))) {
+    LOG_WARN("fail to build tokenize cache key", K(ret));
+  } else if (cacheable
+      && OB_FAIL(ObTokenizeResultCache::instance().get(
+          cache_key, temp_allocator, cached_result, cache_hit))) {
+    LOG_WARN("fail to get cached tokenize result", K(ret));
+  } else if (cache_hit) {
+    if (OB_FAIL(ObJsonExprHelper::pack_json_str_res(
+        expr, ctx, expr_datum, cached_result))) {
+      LOG_WARN("fail to pack cached tokenize result", K(ret));
+    }
   } else if (OB_FAIL(parse_param(expr, ctx, temp_allocator, param))) {
     LOG_WARN("Fail to parse param", K(ret));
   } else if (OB_FAIL(tokenize_fulltext(param, param.output_mode_, temp_allocator, json_result))) {
     LOG_WARN("Fail to tokenize fulltext", K(ret));
+  } else if (cacheable) {
+    ObString raw_binary;
+    if (OB_FAIL(ObJsonWrapper::get_raw_binary(json_result, raw_binary, &temp_allocator))) {
+      LOG_WARN("fail to serialize tokenize result", K(ret));
+    } else {
+      ObTokenizeResultCache::instance().put(cache_key, raw_binary);
+      if (OB_FAIL(ObJsonExprHelper::pack_json_str_res(
+          expr, ctx, expr_datum, raw_binary))) {
+        LOG_WARN("fail to pack tokenize result", K(ret));
+      }
+    }
   } else if (OB_FAIL(ObJsonExprHelper::pack_json_res(expr,
                                                      ctx,
                                                      temp_allocator,

--- a/src/sql/engine/expr/ob_expr_tokenize.cpp
+++ b/src/sql/engine/expr/ob_expr_tokenize.cpp
@@ -28,6 +28,7 @@
 #include "object/ob_object.h"
 #include "plugin/sys/ob_plugin_helper.h"
 #include "sql/resolver/ddl/ob_fts_index_builder_util.h"
+#include "sql/session/ob_sql_session_info.h"
 #include "share/ob_json_access_utils.h"
 #include "storage/fts/dict/ob_gen_dic_loader.h"
 #include "storage/fts/ob_fts_parser_property.h"
@@ -144,7 +145,9 @@ ObExprTokenize::TokenizeParam ::TokenizeParam()
 {
 }
 
-int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj)
+int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj,
+                                                    const ObString &database_name,
+                                                    const uint64_t tenant_id)
 {
   int ret = OB_SUCCESS;
   ObString str;
@@ -195,7 +198,8 @@ int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj)
       LOG_USER_ERROR(OB_INVALID_ARGUMENT, "parser arguments");
     } else {
       ObString json_str;
-      if (OB_FAIL(ObFTParserJsonProps::tokenize_array_to_props_json(allocator_, val, json_str))) {
+      if (OB_FAIL(ObFTParserJsonProps::tokenize_array_to_props_json(
+                      allocator_, val, database_name, tenant_id, json_str))) {
         LOG_WARN("Fail to tokenize array to props json", K(ret));
         ObSqlString message;
         message.append_fmt("format in %s form", ADDITIONAL_ARGS_STR);
@@ -227,6 +231,10 @@ int ObExprTokenize::parse_param(const ObExpr &expr,
   ObEvalCtx::TempAllocGuard tmp_alloc_g(ctx);
   
   MultimodeAlloctor temp_allocator(tmp_alloc_g.get_allocator(), expr.type_, ret);
+  ObSQLSessionInfo *session = ctx.exec_ctx_.get_my_session();
+  const uint64_t tenant_id = common::OB_SERVER_TENANT_ID;
+  const ObString database_name = OB_ISNULL(session)
+      ? ObString() : session->get_database_name();
 
   if (OB_UNLIKELY(expr.arg_cnt_ < 1 || expr.arg_cnt_ > 3)) {
     ret = OB_INVALID_ARGUMENT;
@@ -235,7 +243,8 @@ int ObExprTokenize::parse_param(const ObExpr &expr,
     LOG_WARN("Fail to parse fulltext.", K(ret));
   } else if (OB_FAIL(parse_parser_name(expr, ctx, param))) {
     LOG_WARN("Fail to parse parser params.", K(ret));
-  } else if (OB_FAIL(parse_parser_properties(expr, ctx, temp_allocator, param))) {
+  } else if (OB_FAIL(parse_parser_properties(
+                         expr, database_name, tenant_id, ctx, temp_allocator, param))) {
     LOG_WARN("Fail to parse parser params.", K(ret));
   } else if (OB_FAIL(param.reform_parser_properties(param.properties_))) {
     LOG_WARN("Fail to reform parser params.", K(ret));
@@ -378,6 +387,8 @@ int ObExprTokenize::parse_parser_name(const ObExpr &expr, ObEvalCtx &ctx, Tokeni
 }
 
 int ObExprTokenize::parse_parser_properties(const ObExpr &expr,
+                                            const ObString &database_name,
+                                            const uint64_t tenant_id,
                                             ObEvalCtx &ctx,
                                             MultimodeAlloctor &mm_alloc,
                                             TokenizeParam &param)
@@ -404,7 +415,7 @@ int ObExprTokenize::parse_parser_properties(const ObExpr &expr,
           } else if (ObJsonNodeType::J_OBJECT != (node->json_type())) {
             ret = OB_INVALID_ARGUMENT;
             LOG_WARN("Argument of json array invalid", K(ret));
-          } else if (OB_FAIL(param.parse_json_param(node))) {
+          } else if (OB_FAIL(param.parse_json_param(node, database_name, tenant_id))) {
             LOG_WARN("Failed to parse json object", K(ret));
           }
         } // for

--- a/src/sql/engine/expr/ob_expr_tokenize.h
+++ b/src/sql/engine/expr/ob_expr_tokenize.h
@@ -60,7 +60,9 @@ private:
   public:
     TokenizeParam();
 
-    int parse_json_param(const ObIJsonBase *obj);
+    int parse_json_param(const ObIJsonBase *obj,
+                         const ObString &database_name,
+                         const uint64_t tenant_id);
 
     // check and reform parser properties to standard format
     int reform_parser_properties(const ObString &properties);
@@ -89,6 +91,8 @@ private:
   static int parse_fulltext(const ObExpr &expr, ObEvalCtx &ctx, TokenizeParam &param);
   static int parse_parser_name(const ObExpr &expr, ObEvalCtx &ctx, TokenizeParam &param);
   static int parse_parser_properties(const ObExpr &expr,
+                                     const ObString &database_name,
+                                     const uint64_t tenant_id,
                                      ObEvalCtx &ctx,
                                      MultimodeAlloctor &mm_alloc,
                                      TokenizeParam &param);

--- a/src/sql/engine/expr/ob_expr_word_segment.cpp
+++ b/src/sql/engine/expr/ob_expr_word_segment.cpp
@@ -92,7 +92,10 @@ int ObExprWordSegment::cg_expr(
   } else {
     ObEvalCtx::TempAllocGuard alloc_guard(eval_ctx);
     int64_t res_str_len = 0;
-    ObSEArray<ObString, 1> ft_parts;
+    // Most full-text indexes cover two or more columns.  Keep the common case
+    // inline so every source row does not allocate merely to concatenate the
+    // second indexed column.
+    ObSEArray<ObString, 4> ft_parts;
     const int64_t mb_max_len = cs->mbmaxlen;
     char mb_separator[mb_max_len];
     int32_t length_of_separator = 0;
@@ -124,8 +127,14 @@ int ObExprWordSegment::cg_expr(
     } else if (0 == ft_parts.count()) {
       expr_datum.set_null();
       LOG_TRACE("generate fulltext column is null", K(raw_ctx), K(eval_ctx), K(expr_datum));
-    } else if (OB_FAIL(ObCharset::wc_mb(raw_ctx.args_[0]->obj_meta_.get_collation_type(), wide_char, mb_separator,
-              mb_max_len, length_of_separator))) {
+    } else if (1 == ft_parts.count()) {
+      // The expanded string remains valid for the current row evaluation.
+      // Avoid allocating and copying the whole document for a single-column
+      // full-text index.
+      expr_datum.set_string(ft_parts.at(0));
+    } else if (ft_parts.count() > 1
+        && OB_FAIL(ObCharset::wc_mb(raw_ctx.args_[0]->obj_meta_.get_collation_type(), wide_char, mb_separator,
+                                   mb_max_len, length_of_separator))) {
       LOG_WARN("fail to wc_mb", K(ret), K(mb_max_len), KPHEX(mb_separator, mb_max_len));
     } else {
       res_str_len = res_str_len + length_of_separator * (ft_parts.count() - 1);

--- a/src/sql/engine/sort/ob_ddl_sort_provider.h
+++ b/src/sql/engine/sort/ob_ddl_sort_provider.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_SORT_OB_DDL_SORT_PROVIDER_H_
+#define OCEANBASE_SQL_ENGINE_SORT_OB_DDL_SORT_PROVIDER_H_
+
+#include "lib/container/ob_array.h"
+#include "lib/lock/ob_mutex.h"
+#include "sql/engine/basic/ob_temp_block_store.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+class ObDDLSortProvider final
+{
+public:
+  ObDDLSortProvider() : reuse_queue_(), mutex_() {}
+  ~ObDDLSortProvider() = default;
+
+  static int calc_merge_ways(ObSqlMemMgrProcessor &sql_mem_processor,
+                             lib::MemoryContext mem_context,
+                             const int64_t max_ways,
+                             int64_t &merge_ways)
+  {
+    int ret = OB_SUCCESS;
+    merge_ways = 0;
+    if (OB_UNLIKELY(max_ways < 2)) {
+      ret = OB_INVALID_ARGUMENT;
+      SQL_ENG_LOG(WARN, "invalid ddl merge ways", K(ret), K(max_ways));
+    } else if (OB_FAIL(sql_mem_processor.get_max_available_mem_size(
+                   &mem_context->get_malloc_allocator()))) {
+      SQL_ENG_LOG(WARN, "failed to get max available memory size", K(ret));
+    } else {
+      const int64_t block_size = ObTempBlockStore::BLOCK_SIZE;
+      const int64_t min_ways = std::max(static_cast<int64_t>(2),
+                                        (16L * 1024L * 1024L) / block_size);
+      merge_ways = std::max(min_ways, sql_mem_processor.get_mem_bound() / block_size);
+      if (merge_ways < max_ways) {
+        bool dumped = false;
+        const int64_t need_size = max_ways * block_size;
+        if (OB_FAIL(sql_mem_processor.extend_max_memory_size(
+                &mem_context->get_malloc_allocator(),
+                [&](int64_t max_memory_size) { return max_memory_size < need_size; },
+                dumped, mem_context->used()))) {
+          SQL_ENG_LOG(WARN, "failed to extend ddl merge memory", K(ret));
+        } else {
+          merge_ways = std::max(merge_ways, sql_mem_processor.get_mem_bound() / block_size);
+        }
+      }
+      merge_ways = std::min(merge_ways, max_ways);
+    }
+    return ret;
+  }
+
+  int push_reuse_handle(void *handle)
+  {
+    int ret = OB_SUCCESS;
+    if (OB_ISNULL(handle)) {
+      ret = OB_INVALID_ARGUMENT;
+      SQL_ENG_LOG(WARN, "invalid ddl sort reuse handle", K(ret), KP(handle));
+    } else {
+      lib::ObMutexGuard guard(mutex_);
+      if (OB_FAIL(reuse_queue_.push_back(handle))) {
+        SQL_ENG_LOG(WARN, "push ddl sort reuse handle failed", K(ret));
+      }
+    }
+    return ret;
+  }
+
+  int pop_reuse_handle(void *&handle)
+  {
+    int ret = OB_SUCCESS;
+    handle = nullptr;
+    lib::ObMutexGuard guard(mutex_);
+    if (!reuse_queue_.empty()) {
+      handle = reuse_queue_.at(reuse_queue_.count() - 1);
+      reuse_queue_.pop_back();
+    }
+    return ret;
+  }
+
+private:
+  common::ObArray<void *> reuse_queue_;
+  lib::ObMutex mutex_;
+
+  DISALLOW_COPY_AND_ASSIGN(ObDDLSortProvider);
+};
+
+} // namespace sql
+} // namespace oceanbase
+
+#endif /* OCEANBASE_SQL_ENGINE_SORT_OB_DDL_SORT_PROVIDER_H_ */

--- a/src/sql/engine/sort/ob_external_merge_sorter.h
+++ b/src/sql/engine/sort/ob_external_merge_sorter.h
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_SORT_OB_EXTERNAL_MERGE_SORTER_H_
+#define OCEANBASE_SQL_ENGINE_SORT_OB_EXTERNAL_MERGE_SORTER_H_
+
+#include "lib/allocator/ob_allocator.h"
+#include "lib/container/ob_heap.h"
+#include "lib/utility/ob_print_utils.h"
+#include "sql/engine/basic/ob_temp_row_store.h"
+#include "sql/engine/sort/ob_sort_vec_op_chunk.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+/**
+ * @brief 公共外排类，提供通用的外部归并排序功能
+ *
+ * @tparam Compare 比较器类型
+ * @tparam Store_Row 存储行类型
+ * @tparam has_addon 是否有addon字段
+ */
+template <typename Compare, typename Store_Row, bool has_addon>
+class ObExternalMergeSorter
+{
+public:
+  static const int64_t MAX_MERGE_WAYS = 256;
+  typedef ObSortVecOpChunk<Store_Row, has_addon> ChunkType;
+  typedef common::ObBinaryHeap<ChunkType *, Compare, MAX_MERGE_WAYS> MergeHeap;
+
+  ObExternalMergeSorter(common::ObIAllocator &allocator, Compare &comp);
+  virtual ~ObExternalMergeSorter();
+  void reset();
+
+  int init(common::ObDList<ChunkType> &chunks, const int64_t merge_ways);
+  int get_next_row(const Store_Row *&sk_row, const Store_Row *&addon_row);
+  bool is_inited() const { return is_inited_; }
+
+private:
+  int heap_next(ChunkType *&chunk);
+
+private:
+  common::ObIAllocator &allocator_;
+  Compare &comp_;
+  MergeHeap *heap_;
+  bool heap_iter_begin_;
+  bool is_inited_;
+};
+
+
+template <typename Compare, typename Store_Row, bool has_addon>
+ObExternalMergeSorter<Compare, Store_Row, has_addon>::ObExternalMergeSorter(
+    common::ObIAllocator &allocator, Compare &comp)
+  : allocator_(allocator),
+    comp_(comp),
+    heap_(nullptr),
+    heap_iter_begin_(false),
+    is_inited_(false)
+{
+}
+
+template <typename Compare, typename Store_Row, bool has_addon>
+ObExternalMergeSorter<Compare, Store_Row, has_addon>::~ObExternalMergeSorter()
+{
+  reset();
+}
+
+template <typename Compare, typename Store_Row, bool has_addon>
+void ObExternalMergeSorter<Compare, Store_Row, has_addon>::reset()
+{
+  if (nullptr != heap_) {
+    heap_->~MergeHeap();
+    allocator_.free(heap_);
+    heap_ = nullptr;
+  }
+
+  heap_iter_begin_ = false;
+  is_inited_ = false;
+}
+
+template <typename Compare, typename Store_Row, bool has_addon>
+int ObExternalMergeSorter<Compare, Store_Row, has_addon>::init(
+    common::ObDList<ChunkType> &chunks, const int64_t merge_ways)
+{
+  int ret = OB_SUCCESS;
+
+  if (OB_UNLIKELY(is_inited_)) {
+    ret = OB_INIT_TWICE;
+    SQL_ENG_LOG(WARN, "already initialized", K(ret));
+  } else if (chunks.get_size() < 2 || merge_ways < 2 || merge_ways > chunks.get_size()) {
+    ret = OB_INVALID_ARGUMENT;
+    SQL_ENG_LOG(WARN, "invalid argument", K(ret), K(chunks.get_size()), K(merge_ways), K(chunks.get_size()));
+  } else if (OB_ISNULL(heap_ = OB_NEWx(MergeHeap, (&allocator_), comp_, &allocator_))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    SQL_ENG_LOG(WARN, "allocate memory failed", K(ret));
+  } else {
+    // 初始化指定数量的chunk迭代器并添加到堆中
+    ChunkType *chunk = chunks.get_first();
+    for (int64_t i = 0; i < merge_ways && OB_SUCC(ret); i++) {
+      chunk->reset_row_iter();
+      if (OB_FAIL(chunk->init_row_iter())) {
+        SQL_ENG_LOG(WARN, "init iterator failed", K(ret));
+      } else if (OB_FAIL(chunk->get_next_row()) || nullptr == chunk->sk_row_) {
+        if (OB_ITER_END == ret || OB_SUCCESS == ret) {
+          ret = OB_ERR_UNEXPECTED;
+          SQL_ENG_LOG(WARN, "row store is not empty, iterate end is unexpected", K(ret),
+                      KP(chunk->sk_row_));
+        }
+        SQL_ENG_LOG(WARN, "get next row failed", K(ret));
+      } else if (OB_FAIL(heap_->push(chunk))) {
+        SQL_ENG_LOG(WARN, "heap push failed", K(ret));
+      } else {
+        chunk = chunk->get_next();
+      }
+    }
+
+    // 初始化堆
+    if (OB_SUCC(ret)) {
+      is_inited_ = true;
+      heap_iter_begin_ = false;
+      SQL_ENG_LOG(DEBUG, "external merge sorter init success",
+                 K(chunks.get_size()), K(merge_ways));
+    }
+  }
+
+  return ret;
+}
+
+template <typename Compare, typename Store_Row, bool has_addon>
+int ObExternalMergeSorter<Compare, Store_Row, has_addon>::heap_next(ChunkType *&chunk)
+{
+  int ret = OB_SUCCESS;
+  chunk = nullptr;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    SQL_ENG_LOG(WARN, "not initialized", K(ret));
+  } else if (OB_ISNULL(heap_)) {
+    ret = OB_ERR_UNEXPECTED;
+    SQL_ENG_LOG(WARN, "heap is null", K(ret));
+  } else {
+    if (heap_iter_begin_) {
+      if (!heap_->empty()) {
+        ChunkType *it = heap_->top();
+        bool is_end = false;
+
+        // 获取下一行
+        if (OB_FAIL(it->get_next_row())) {
+          if (OB_ITER_END == ret) {
+            is_end = true;
+            ret = OB_SUCCESS;
+          } else {
+            SQL_ENG_LOG(WARN, "get next row failed", K(ret));
+          }
+        }
+
+        if (OB_SUCC(ret)) {
+          if (is_end) {
+            if (OB_FAIL(heap_->pop())) {
+              SQL_ENG_LOG(WARN, "heap pop failed", K(ret));
+            }
+          } else {
+            if (OB_FAIL(heap_->replace_top(it))) {
+              SQL_ENG_LOG(WARN, "heap replace failed", K(ret));
+            }
+          }
+        }
+      }
+    } else {
+      heap_iter_begin_ = true;
+    }
+
+    if (OB_SUCC(ret)) {
+      if (heap_->empty()) {
+        ret = OB_ITER_END;
+      } else {
+        chunk = heap_->top();
+      }
+    }
+  }
+
+  return ret;
+}
+
+template <typename Compare, typename Store_Row, bool has_addon>
+int ObExternalMergeSorter<Compare, Store_Row, has_addon>::get_next_row(
+    const Store_Row *&sk_row, const Store_Row *&addon_row)
+{
+  int ret = OB_SUCCESS;
+  sk_row = nullptr;
+  addon_row = nullptr;
+
+  ChunkType *chunk = nullptr;
+  if (OB_FAIL(heap_next(chunk))) {
+    if (OB_ITER_END != ret) {
+      SQL_ENG_LOG(WARN, "heap next failed", K(ret));
+    }
+  } else if (OB_ISNULL(chunk)) {
+    ret = OB_ERR_UNEXPECTED;
+    SQL_ENG_LOG(WARN, "chunk is null", K(ret));
+  } else {
+    sk_row = chunk->sk_row_;
+    if (has_addon) {
+      addon_row = chunk->addon_row_;
+    }
+  }
+
+  return ret;
+}
+
+} // namespace sql
+} // namespace oceanbase
+
+
+#endif /* OCEANBASE_SQL_ENGINE_SORT_OB_EXTERNAL_MERGE_SORTER_H_ */

--- a/src/sql/engine/sort/ob_sort_row_store_mgr.h
+++ b/src/sql/engine/sort/ob_sort_row_store_mgr.h
@@ -1,0 +1,416 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_SORT_OB_SORT_ROW_STORE_MGR_H_
+#define OCEANBASE_SQL_ENGINE_SORT_OB_SORT_ROW_STORE_MGR_H_
+
+#include "sql/engine/basic/ob_temp_row_store.h"
+#include "lib/allocator/ob_allocator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+template <typename Store_Row, bool has_addon>
+class ObSortRowStoreMgr
+{
+public:
+  explicit ObSortRowStoreMgr(ObIAllocator &allocator);
+  ~ObSortRowStoreMgr();
+
+  // 基于RowMeta的初始化接口
+  int init(const RowMeta &sk_row_meta,
+           const RowMeta *addon_row_meta,
+           const int64_t max_batch_size,
+           const lib::ObMemAttr &mem_attr,
+           const common::ObCompressorType compressor_type,
+           const int64_t mem_limit,
+           const bool enable_dump,
+           const bool enable_trunc = false,
+           int64_t tempstore_read_alignment_size = 0);
+
+  // 现有的基于表达式的初始化接口
+  int init(const common::ObIArray<ObExpr *> &sk_exprs,
+           const common::ObIArray<ObExpr *> *addon_exprs,
+           int64_t batch_size,
+           bool need_callback,
+           int64_t extra_sk_size,
+           int64_t extra_addon_size,
+           int64_t tenant_id,
+           const int64_t mem_limit,
+           const bool enable_dump,
+           ObCompressorType compress_type = NONE_COMPRESSOR);
+
+  int add_batch(const common::ObIArray<ObExpr *> &sk_exprs,
+                const common::ObIArray<ObExpr *> *addon_exprs,
+                ObEvalCtx &eval_ctx,
+                const ObBatchRows &input_brs,
+                int64_t &stored_row_cnt,
+                Store_Row **sk_rows,
+                Store_Row **addon_rows,
+                int64_t &inmem_row_size,
+                const int64_t start_pos = 0);
+
+  int add_batch(const common::ObFixedArray<ObIVector *, common::ObIAllocator> &sk_vec_ptrs,
+                const common::ObFixedArray<ObIVector *, common::ObIAllocator> *addon_vec_ptrs,
+                const ObBitVector &skip,
+                const int64_t batch_size,
+                int64_t &stored_rows_cnt,
+                Store_Row **sk_rows,
+                Store_Row **addon_rows,
+                int64_t &inmem_row_size);
+
+  int add_batch(const common::ObFixedArray<ObIVector *, common::ObIAllocator> &sk_vec_ptrs,
+                const common::ObFixedArray<ObIVector *, common::ObIAllocator> *addon_vec_ptrs,
+                const uint16_t selector[],
+                const int64_t size,
+                Store_Row **sk_rows,
+                Store_Row **addon_rows,
+                int64_t &inmem_row_size);
+
+  void set_dir_id(int64_t dir_id);
+  void set_callback(ObSqlMemoryCallback *callback);
+  void set_io_event_observer(ObIOEventObserver *observer);
+
+  void reset();
+  void reuse();
+
+  // Add individual row methods for backward compatibility
+  int add_sk_row(const ObCompactRow *sk_row, ObCompactRow *&sk_store_row);
+  int add_addon_row(const ObCompactRow *addon_row, ObCompactRow *&addon_store_row);
+
+  const RowMeta *get_sk_row_meta() const { return sk_row_meta_; }
+  const RowMeta *get_addon_row_meta() const { return addon_row_meta_; }
+  int64_t get_row_cnt() const { return sk_store_.get_row_cnt(); }
+  int64_t get_mem_hold() const { return sk_store_.get_mem_hold() + addon_store_.get_mem_hold(); }
+  int64_t get_file_size() const { return sk_store_.get_file_size() + addon_store_.get_file_size(); }
+
+  ObTempRowStore &get_sk_store() { return sk_store_; }
+  ObTempRowStore &get_addon_store() { return addon_store_; }
+
+  void set_sk_row_meta(const RowMeta *meta) { sk_row_meta_ = meta; }
+  void set_addon_row_meta(const RowMeta *meta) { addon_row_meta_ = meta; }
+
+  bool is_inited() const { return is_inited_; }
+
+private:
+  ObIAllocator &allocator_;
+  ObTempRowStore sk_store_;
+  ObTempRowStore addon_store_;
+  const RowMeta *sk_row_meta_;
+  const RowMeta *addon_row_meta_;
+  bool is_inited_;
+};
+
+template <typename Store_Row, bool has_addon>
+ObSortRowStoreMgr<Store_Row, has_addon>::ObSortRowStoreMgr(ObIAllocator &allocator)
+  : allocator_(allocator),
+    sk_store_(&allocator),
+    addon_store_(&allocator),
+    sk_row_meta_(nullptr),
+    addon_row_meta_(nullptr),
+    is_inited_(false)
+{}
+
+template <typename Store_Row, bool has_addon>
+ObSortRowStoreMgr<Store_Row, has_addon>::~ObSortRowStoreMgr()
+{
+  reset();
+}
+
+template <typename Store_Row, bool has_addon>
+int ObSortRowStoreMgr<Store_Row, has_addon>::init(
+    const RowMeta &sk_row_meta,
+    const RowMeta *addon_row_meta,
+    const int64_t max_batch_size,
+    const lib::ObMemAttr &mem_attr,
+    const common::ObCompressorType compressor_type,
+    const int64_t mem_limit,
+    const bool enable_dump,
+    const bool enable_trunc,
+    int64_t tempstore_read_alignment_size)
+{
+  int ret = OB_SUCCESS;
+
+  if (is_inited_) {
+    ret = OB_INIT_TWICE;
+    SQL_ENG_LOG(WARN, "init twice", K(ret));
+  } else {
+    // 初始化 sk_store_
+    if (OB_FAIL(sk_store_.init(sk_row_meta, max_batch_size, mem_attr, mem_limit,
+                               enable_dump, compressor_type, enable_trunc,
+                               tempstore_read_alignment_size))) {
+      SQL_ENG_LOG(WARN, "failed to init sk_store_", K(ret));
+    }
+    // 初始化 addon_store_ (如果需要)
+    else if (has_addon && OB_NOT_NULL(addon_row_meta)) {
+      if (OB_FAIL(addon_store_.init(*addon_row_meta, max_batch_size, mem_attr, mem_limit,
+                                    enable_dump, compressor_type, enable_trunc,
+                                    tempstore_read_alignment_size))) {
+        SQL_ENG_LOG(WARN, "failed to init addon_store_", K(ret));
+      }
+    }
+
+    if (OB_SUCC(ret)) {
+      // 保存RowMeta指针
+      sk_row_meta_ = &sk_row_meta;
+      addon_row_meta_ = has_addon ? addon_row_meta : nullptr;
+      is_inited_ = true;
+      SQL_ENG_LOG(INFO, "ObSortRowStoreMgr init success", K(has_addon), K(max_batch_size));
+    }
+  }
+
+  return ret;
+}
+
+// 现有的基于表达式的初始化方法
+template <typename Store_Row, bool has_addon>
+int ObSortRowStoreMgr<Store_Row, has_addon>::init(
+    const common::ObIArray<ObExpr *> &sk_exprs,
+    const common::ObIArray<ObExpr *> *addon_exprs,
+    int64_t batch_size,
+    bool need_callback,
+    int64_t extra_sk_size,
+    int64_t extra_addon_size,
+    int64_t tenant_id,
+    const int64_t mem_limit,
+    const bool enable_dump,
+    ObCompressorType compress_type)
+{
+  int ret = OB_SUCCESS;
+
+  if (is_inited_) {
+    ret = OB_INIT_TWICE;
+    SQL_ENG_LOG(WARN, "init twice", K(ret));
+  } else {
+    const bool enable_trunc = true;
+    const bool reorder_fixed_expr = true;
+    int64_t tempstore_read_alignment_size = ObTempBlockStore::get_read_alignment_size_config(tenant_id);
+    lib::ObMemAttr mem_attr(ObModIds::OB_SQL_SORT_ROW, tenant_id);
+
+    if (OB_FAIL(sk_store_.init(sk_exprs, batch_size, mem_attr, mem_limit, enable_dump,
+                               extra_sk_size, compress_type, reorder_fixed_expr, enable_trunc,
+                               tempstore_read_alignment_size))) {
+      SQL_ENG_LOG(WARN, "failed to init sk store", K(ret));
+    } else {
+      sk_row_meta_ = &sk_store_.get_row_meta();
+      if (has_addon && OB_NOT_NULL(addon_exprs)) {
+        if (OB_FAIL(addon_store_.init(*addon_exprs, batch_size, mem_attr, mem_limit, enable_dump,
+                                      extra_addon_size, compress_type, reorder_fixed_expr,
+                                      enable_trunc, tempstore_read_alignment_size))) {
+          SQL_ENG_LOG(WARN, "failed to init addon store", K(ret));
+        } else {
+          addon_row_meta_ = &addon_store_.get_row_meta();
+        }
+      }
+    }
+
+    if (OB_SUCC(ret)) {
+      is_inited_ = true;
+      SQL_ENG_LOG(INFO, "ObSortRowStoreMgr init success", K(has_addon), K(batch_size));
+    }
+  }
+
+  return ret;
+}
+
+template <typename Store_Row, bool has_addon>
+int ObSortRowStoreMgr<Store_Row, has_addon>::add_batch(
+    const common::ObIArray<ObExpr *> &sk_exprs,
+    const common::ObIArray<ObExpr *> *addon_exprs,
+    ObEvalCtx &eval_ctx,
+    const ObBatchRows &input_brs,
+    int64_t &stored_row_cnt,
+    Store_Row **sk_rows,
+    Store_Row **addon_rows,
+    int64_t &inmem_row_size,
+    const int64_t start_pos)
+{
+  int ret = OB_SUCCESS;
+  inmem_row_size = 0;
+
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    SQL_ENG_LOG(WARN, "not inited", K(ret));
+  } else if (OB_FAIL(sk_store_.add_batch(sk_exprs, eval_ctx, input_brs, stored_row_cnt,
+                                         reinterpret_cast<ObCompactRow **>(sk_rows), start_pos))) {
+    SQL_ENG_LOG(WARN, "failed to add batch to sk store", K(ret));
+  } else if (has_addon && OB_NOT_NULL(addon_exprs) &&
+             OB_FAIL(addon_store_.add_batch(*addon_exprs, eval_ctx, input_brs, stored_row_cnt,
+                                            reinterpret_cast<ObCompactRow **>(addon_rows), start_pos))) {
+    SQL_ENG_LOG(WARN, "failed to add batch to addon store", K(ret));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < stored_row_cnt; i++) {
+      inmem_row_size += sk_rows[i]->get_row_size();
+      if (has_addon) {
+        sk_rows[i]->set_addon_ptr(addon_rows[i], *sk_row_meta_);
+        inmem_row_size += addon_rows[i]->get_row_size();
+      }
+    }
+  }
+
+  return ret;
+}
+
+template <typename Store_Row, bool has_addon>
+int ObSortRowStoreMgr<Store_Row, has_addon>::add_batch(
+    const common::ObFixedArray<ObIVector *, common::ObIAllocator> &sk_vec_ptrs,
+    const common::ObFixedArray<ObIVector *, common::ObIAllocator> *addon_vec_ptrs,
+    const ObBitVector &skip,
+    const int64_t batch_size,
+    int64_t &stored_row_cnt,
+    Store_Row **sk_rows,
+    Store_Row **addon_rows,
+    int64_t &inmem_row_size)
+{
+  int ret = OB_SUCCESS;
+  inmem_row_size = 0;
+
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    SQL_ENG_LOG(WARN, "not inited", K(ret));
+  } else if (OB_FAIL(sk_store_.add_batch(sk_vec_ptrs, skip, batch_size, stored_row_cnt,
+                                         reinterpret_cast<ObCompactRow **>(sk_rows)))) {
+    SQL_ENG_LOG(WARN, "failed to add batch to sk store", K(ret));
+  } else if (has_addon && OB_NOT_NULL(addon_vec_ptrs) &&
+             OB_FAIL(addon_store_.add_batch(*addon_vec_ptrs, skip, batch_size, stored_row_cnt,
+                                            reinterpret_cast<ObCompactRow **>(addon_rows)))) {
+    SQL_ENG_LOG(WARN, "failed to add batch to addon store", K(ret));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < stored_row_cnt; i++) {
+      inmem_row_size += sk_rows[i]->get_row_size();
+      if (has_addon) {
+        sk_rows[i]->set_addon_ptr(addon_rows[i], *sk_row_meta_);
+        inmem_row_size += addon_rows[i]->get_row_size();
+      }
+    }
+  }
+
+  return ret;
+}
+
+template <typename Store_Row, bool has_addon>
+int ObSortRowStoreMgr<Store_Row, has_addon>::add_batch(
+    const common::ObFixedArray<ObIVector *, common::ObIAllocator> &sk_vec_ptrs,
+    const common::ObFixedArray<ObIVector *, common::ObIAllocator> *addon_vec_ptrs,
+    const uint16_t selector[],
+    const int64_t batch_size,
+    Store_Row **sk_rows,
+    Store_Row **addon_rows,
+    int64_t &inmem_row_size)
+{
+  int ret = OB_SUCCESS;
+  inmem_row_size = 0;
+
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    SQL_ENG_LOG(WARN, "not inited", K(ret));
+  } else if (OB_FAIL(sk_store_.add_batch(sk_vec_ptrs, selector, batch_size,
+                                         reinterpret_cast<ObCompactRow **>(sk_rows)))) {
+    SQL_ENG_LOG(WARN, "failed to add batch to sk store", K(ret));
+  } else if (has_addon && OB_NOT_NULL(addon_vec_ptrs) &&
+             OB_FAIL(addon_store_.add_batch(*addon_vec_ptrs, selector, batch_size,
+                                            reinterpret_cast<ObCompactRow **>(addon_rows)))) {
+    SQL_ENG_LOG(WARN, "failed to add batch to addon store", K(ret));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < batch_size; i++) {
+      inmem_row_size += sk_rows[i]->get_row_size();
+      if (has_addon) {
+        sk_rows[i]->set_addon_ptr(addon_rows[i], *sk_row_meta_);
+        inmem_row_size += addon_rows[i]->get_row_size();
+      }
+    }
+  }
+
+  return ret;
+}
+
+template <typename Store_Row, bool has_addon>
+void ObSortRowStoreMgr<Store_Row, has_addon>::set_dir_id(int64_t dir_id)
+{
+  sk_store_.set_dir_id(dir_id);
+  if (has_addon) {
+    addon_store_.set_dir_id(dir_id);
+  }
+}
+
+template <typename Store_Row, bool has_addon>
+void ObSortRowStoreMgr<Store_Row, has_addon>::set_callback(ObSqlMemoryCallback *callback)
+{
+  sk_store_.set_callback(callback);
+  if (has_addon) {
+    addon_store_.set_callback(callback);
+  }
+}
+
+template <typename Store_Row, bool has_addon>
+void ObSortRowStoreMgr<Store_Row, has_addon>::set_io_event_observer(ObIOEventObserver *observer)
+{
+  sk_store_.set_io_event_observer(observer);
+  if (has_addon) {
+    addon_store_.set_io_event_observer(observer);
+  }
+}
+
+template <typename Store_Row, bool has_addon>
+void ObSortRowStoreMgr<Store_Row, has_addon>::reset()
+{
+  sk_store_.reset();
+  addon_store_.reset();
+  sk_row_meta_ = nullptr;
+  addon_row_meta_ = nullptr;
+  is_inited_ = false;
+}
+
+template <typename Store_Row, bool has_addon>
+void ObSortRowStoreMgr<Store_Row, has_addon>::reuse()
+{
+  sk_store_.reset();
+  if (has_addon) {
+    addon_store_.reset();
+  }
+}
+
+template <typename Store_Row, bool has_addon>
+int ObSortRowStoreMgr<Store_Row, has_addon>::add_sk_row(const ObCompactRow *sk_row, ObCompactRow *&sk_store_row)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    SQL_ENG_LOG(WARN, "not inited", K(ret));
+  } else {
+    ret = sk_store_.add_row(sk_row, sk_store_row);
+  }
+  return ret;
+}
+
+template <typename Store_Row, bool has_addon>
+int ObSortRowStoreMgr<Store_Row, has_addon>::add_addon_row(const ObCompactRow *addon_row, ObCompactRow *&addon_store_row)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited_) {
+    ret = OB_NOT_INIT;
+    SQL_ENG_LOG(WARN, "not inited", K(ret));
+  } else if (!has_addon) {
+    ret = OB_INVALID_ARGUMENT;
+    SQL_ENG_LOG(WARN, "addon not enabled", K(ret));
+  } else {
+    ret = addon_store_.add_row(addon_row, addon_store_row);
+  }
+  return ret;
+}
+
+} // namespace sql
+} // namespace oceanbase
+
+#endif /* OCEANBASE_SQL_ENGINE_SORT_OB_SORT_ROW_STORE_MGR_H_ */

--- a/src/sql/engine/sort/ob_sort_vec_dump_strategy.h
+++ b/src/sql/engine/sort/ob_sort_vec_dump_strategy.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_SORT_OB_SORT_VEC_DUMP_STRATEGY_H_
+#define OCEANBASE_SQL_ENGINE_SORT_OB_SORT_VEC_DUMP_STRATEGY_H_
+
+#include <utility>
+#include "lib/container/ob_array.h"
+#include "sql/engine/basic/ob_compact_row.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+template <typename Store_Row, bool has_addon>
+class ObNormalDumpStrategy
+{
+public:
+  ObNormalDumpStrategy(common::ObIArray<Store_Row *> &rows,
+                       common::ObIArray<Store_Row *> &ties_array,
+                       const RowMeta &sk_row_meta)
+    : row_pos_(0),
+      ties_array_pos_(0),
+      rows_(rows),
+      ties_array_(ties_array),
+      sk_row_meta_(sk_row_meta)
+  {}
+
+  int operator()(const Store_Row *&sk_row, const Store_Row *&addon_row)
+  {
+    int ret = OB_SUCCESS;
+    if (row_pos_ >= rows_.count() && ties_array_pos_ >= ties_array_.count()) {
+      ret = OB_ITER_END;
+    } else if (row_pos_ < rows_.count()) {
+      sk_row = rows_.at(row_pos_++);
+      if (has_addon) {
+        addon_row = sk_row->get_addon_ptr(sk_row_meta_);
+      }
+    } else {
+      sk_row = ties_array_.at(ties_array_pos_++);
+      if (has_addon) {
+        addon_row = sk_row->get_addon_ptr(sk_row_meta_);
+      }
+    }
+    return ret;
+  }
+
+private:
+  int64_t row_pos_;
+  int64_t ties_array_pos_;
+  common::ObIArray<Store_Row *> &rows_;
+  common::ObIArray<Store_Row *> &ties_array_;
+  const RowMeta &sk_row_meta_;
+};
+
+template <typename Store_Row, bool has_addon, typename HeapNextFunc>
+class ObIMMSDumpStrategy
+{
+public:
+  ObIMMSDumpStrategy(HeapNextFunc &&heap_next,
+                     const RowMeta &sk_row_meta,
+                     common::ObIArray<Store_Row *> &sorted_dumped_rows,
+                     const bool is_topn_sort,
+                     const bool is_topn_filter_enabled)
+    : heap_next_(std::forward<HeapNextFunc>(heap_next)),
+      sk_row_meta_(sk_row_meta),
+      sorted_dumped_rows_(sorted_dumped_rows),
+      is_topn_sort_(is_topn_sort),
+      is_topn_filter_enabled_(is_topn_filter_enabled)
+  {}
+
+  int operator()(const Store_Row *&sk_row, const Store_Row *&addon_row)
+  {
+    int ret = OB_SUCCESS;
+    if (OB_FAIL(heap_next_(sk_row))) {
+      if (OB_ITER_END != ret) {
+        SQL_ENG_LOG(WARN, "get row from memory heap failed", K(ret));
+      }
+    } else {
+      if (has_addon) {
+        addon_row = sk_row->get_addon_ptr(sk_row_meta_);
+      }
+      if (is_topn_sort_ && is_topn_filter_enabled_) {
+        ret = sorted_dumped_rows_.push_back(const_cast<Store_Row *>(sk_row));
+      }
+    }
+    return ret;
+  }
+
+private:
+  HeapNextFunc heap_next_;
+  const RowMeta &sk_row_meta_;
+  common::ObIArray<Store_Row *> &sorted_dumped_rows_;
+  bool is_topn_sort_;
+  bool is_topn_filter_enabled_;
+};
+
+template <typename Store_Row, bool has_addon, typename PartTopNProvider>
+class ObPartitionTopNDumpStrategy
+{
+public:
+  ObPartitionTopNDumpStrategy(PartTopNProvider &provider, int64_t &node_idx, int64_t &row_idx)
+    : provider_(provider), node_idx_(node_idx), row_idx_(row_idx)
+  {}
+
+  int operator()(const Store_Row *&sk_row, const Store_Row *&addon_row)
+  {
+    return provider_.part_topn_node_next(node_idx_, row_idx_, sk_row, addon_row);
+  }
+
+private:
+  PartTopNProvider &provider_;
+  int64_t &node_idx_;
+  int64_t &row_idx_;
+};
+
+} // namespace sql
+} // namespace oceanbase
+
+#endif /* OCEANBASE_SQL_ENGINE_SORT_OB_SORT_VEC_DUMP_STRATEGY_H_ */

--- a/src/sql/engine/sort/ob_sort_vec_op_chunk.h
+++ b/src/sql/engine/sort/ob_sort_vec_op_chunk.h
@@ -1,43 +1,44 @@
-/*
- * Copyright (c) 2025 OceanBase.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
  */
 
 #ifndef OCEANBASE_SQL_ENGINE_SORT_SORT_VEC_OP_CHUNK_H_
 #define OCEANBASE_SQL_ENGINE_SORT_SORT_VEC_OP_CHUNK_H_
 
 #include "sql/engine/basic/ob_temp_row_store.h"
+#include "sql/engine/sort/ob_sort_row_store_mgr.h"
 
 namespace oceanbase {
 namespace sql {
 template <typename Store_Row, bool has_addon>
 struct ObSortVecOpChunk : public common::ObDLinkBase<ObSortVecOpChunk<Store_Row, has_addon>>
 {
-  explicit ObSortVecOpChunk(const int64_t level) :
-    level_(level), sk_row_iter_(), addon_row_iter_(), sk_row_(nullptr), addon_row_(nullptr)
+  explicit ObSortVecOpChunk(const int64_t level, common::ObIAllocator &allocator) :
+    level_(level), sort_row_store_mgr_(allocator), sk_row_iter_(), addon_row_iter_(), sk_row_(nullptr), addon_row_(nullptr),
+    use_inmem_data_(false), inmem_rows_(), row_idx_(0), slice_id_(0)
   {}
   void reset_row_iter()
   {
     sk_row_iter_.reset();
     addon_row_iter_.reset();
+    row_idx_ = 0;
   }
   int init_row_iter()
   {
     int ret = common::OB_SUCCESS;
-    if (OB_FAIL(sk_row_iter_.init(&sk_store_))) {
+    if (use_inmem_data_) {
+      row_idx_ = 0;
+    } else if (OB_FAIL(sk_row_iter_.init(&sort_row_store_mgr_.get_sk_store()))) {
       SQL_ENG_LOG(WARN, "init iterator failed", K(ret));
-    } else if (has_addon && OB_FAIL(addon_row_iter_.init(&addon_store_))) {
+    } else if (has_addon && OB_FAIL(addon_row_iter_.init(&sort_row_store_mgr_.get_addon_store()))) {
       SQL_ENG_LOG(WARN, "init iterator failed", K(ret));
     }
     return ret;
@@ -47,28 +48,54 @@ struct ObSortVecOpChunk : public common::ObDLinkBase<ObSortVecOpChunk<Store_Row,
     int ret = common::OB_SUCCESS;
     int64_t read_rows = 0;
     const int64_t max_rows = 1;
-    if (OB_FAIL(sk_row_iter_.get_next_batch(max_rows, read_rows,
+    if (use_inmem_data_) {
+      if (row_idx_ >= inmem_rows_.count()) {
+        ret = OB_ITER_END;
+      } else {
+        sk_row_ = inmem_rows_.at(row_idx_);
+        addon_row_ = sk_row_->get_addon_ptr(*sort_row_store_mgr_.get_sk_row_meta());
+        row_idx_++;
+      }
+    } else if (OB_FAIL(sk_row_iter_.get_next_batch(max_rows, read_rows,
                                             reinterpret_cast<const ObCompactRow **>(&sk_row_)))) {
-      SQL_ENG_LOG(WARN, "get next row failed", K(ret));
+      if (OB_ITER_END != ret) {
+        SQL_ENG_LOG(WARN, "get next row failed", K(ret));
+      }
     } else if (has_addon) {
       if (OB_FAIL(addon_row_iter_.get_next_batch(
             max_rows, read_rows, reinterpret_cast<const ObCompactRow **>(&addon_row_)))) {
-        SQL_ENG_LOG(WARN, "get next row failed", K(ret));
+        if (OB_ITER_END != ret) {
+          SQL_ENG_LOG(WARN, "get next row failed", K(ret));
+        }
       } else {
-        const_cast<Store_Row *>(sk_row_)->set_addon_ptr(addon_row_, sk_store_.get_row_meta());
+        const_cast<Store_Row *>(sk_row_)->set_addon_ptr(addon_row_, *sort_row_store_mgr_.get_sk_row_meta());
       }
     }
     return ret;
   }
 
+  ObTempRowStore &get_sk_store() { return sort_row_store_mgr_.get_sk_store(); }
+  ObTempRowStore &get_addon_store() { return sort_row_store_mgr_.get_addon_store(); }
+  int64_t get_file_size() const { return sort_row_store_mgr_.get_file_size(); }
+  int64_t get_mem_hold() const { return sort_row_store_mgr_.get_mem_hold(); }
+  // Row count abstraction for both in-memory and temp-store modes.
+  int64_t get_row_count() const
+  {
+    return use_inmem_data_ ? inmem_rows_.count() : sort_row_store_mgr_.get_row_cnt();
+  }
+  int64_t get_row_cnt() const { return get_row_count(); }
+
 public:
   int64_t level_;
-  ObTempRowStore sk_store_;
-  ObTempRowStore addon_store_;
+  ObSortRowStoreMgr<Store_Row, has_addon> sort_row_store_mgr_;
   ObTempRowStore::Iterator sk_row_iter_;
   ObTempRowStore::Iterator addon_row_iter_;
   const Store_Row *sk_row_;
   const Store_Row *addon_row_;
+  bool use_inmem_data_;
+  common::ObArray<Store_Row *> inmem_rows_;
+  int64_t row_idx_;
+  int64_t slice_id_;
 
 private:
   DISALLOW_COPY_AND_ASSIGN(ObSortVecOpChunk);

--- a/src/sql/engine/sort/ob_sort_vec_op_impl.h
+++ b/src/sql/engine/sort/ob_sort_vec_op_impl.h
@@ -29,6 +29,10 @@
 #include "sql/engine/sort/ob_sort_key_fetcher_vec_op.h"
 #include "sql/engine/sort/ob_sort_vec_op_eager_filter.h"
 #include "sql/engine/sort/ob_sort_vec_op_store_row_factory.h"
+#include "sql/engine/sort/ob_sort_vec_strategy.h"
+#include "sql/engine/sort/ob_sort_vec_dump_strategy.h"
+#include "sql/engine/sort/ob_ddl_sort_provider.h"
+#include "sql/engine/sort/ob_external_merge_sorter.h"
 #include "sql/engine/expr/ob_array_expr_utils.h"
 #include "share/config/ob_tenant_config_mgr.h"
 #include "sql/engine/sort/ob_pd_topn_sort_filter.h"
@@ -48,6 +52,8 @@ template <typename Compare, typename Store_Row, bool has_addon>
 class ObSortVecOpImpl : public ObISortVecOpImpl
 {
   using SortVecOpChunk = ObSortVecOpChunk<Store_Row, has_addon>;
+  using ThisType = ObSortVecOpImpl<Compare, Store_Row, has_addon>;
+  using ExternalMergeSorter = ObExternalMergeSorter<Compare, Store_Row, has_addon>;
 
 public:
   explicit ObSortVecOpImpl(ObMonitorNode &op_monitor_info, lib::MemoryContext &mem_context) :
@@ -59,7 +65,7 @@ public:
     all_exprs_(allocator_), sk_vec_ptrs_(allocator_), addon_vec_ptrs_(allocator_),
     eval_ctx_(nullptr), comp_(allocator_), sk_store_(&allocator_), addon_store_(&allocator_),
     inmem_row_size_(0), mem_check_interval_mask_(1), row_idx_(0), quick_sort_array_(),
-    heap_iter_begin_(false), imms_heap_(nullptr), ems_heap_(nullptr),
+    heap_iter_begin_(false), imms_heap_(nullptr), external_sorter_(nullptr),
     next_stored_row_func_(&ObSortVecOpImpl::array_next_stored_row), exec_ctx_(nullptr),
     sk_rows_(nullptr), addon_rows_(nullptr), buckets_(nullptr), max_bucket_cnt_(0),
     part_hash_nodes_(nullptr), max_node_cnt_(0), part_cnt_(0), topn_cnt_(INT64_MAX),
@@ -190,13 +196,19 @@ public:
   };
 
 protected:
+  template <typename SortImpl> friend class ObFullSortStrategy;
+  template <typename SortImpl> friend class ObPartitionSortStrategy;
+  template <typename SortImpl> friend class ObPartitionTopNSortStrategy;
+
   typedef int (ObSortVecOpImpl::*NextStoredRowFunc)(const Store_Row *&sr);
+  int do_full_sort_strategy(const int64_t begin);
+  int do_partition_sort_strategy(const int64_t begin);
+  int do_partition_topn_sort_strategy(const int64_t begin);
   int sort_inmem_data();
   int do_dump();
   int build_ems_heap(int64_t &merge_ways);
   template <typename Heap, typename NextFunc, typename Item>
   int heap_next(Heap &heap, const NextFunc &func, Item &item);
-  int ems_heap_next(SortVecOpChunk *&chunk);
   int imms_heap_next(const Store_Row *&sk_row);
   int array_next_stored_row(const Store_Row *&sk_row);
   int imms_heap_next_stored_row(const Store_Row *&sr);
@@ -295,18 +307,20 @@ protected:
     if (!is_inited()) {
       ret = OB_NOT_INIT;
       SQL_ENG_LOG(WARN, "not init", K(ret));
-    } else if (OB_ISNULL(
-                 chunk = OB_NEWx(SortVecOpChunk, (&mem_context_->get_malloc_allocator()), level))) {
+    } else if (OB_ISNULL(chunk = OB_NEWx(SortVecOpChunk,
+                                         (&mem_context_->get_malloc_allocator()),
+                                         level,
+                                         *(&mem_context_->get_malloc_allocator())))) {
       ret = OB_ALLOCATE_MEMORY_FAILED;
       SQL_ENG_LOG(WARN, "allocate memory failed", K(ret));
     } else if (OB_FAIL(init_temp_row_store(*sk_exprs_, 1, eval_ctx_->max_batch_size_, true,
                                            true /*enable dump*/, Store_Row::get_extra_size(true), compress_type_,
-                                           chunk->sk_store_))) {
+                                           chunk->get_sk_store()))) {
       SQL_ENG_LOG(WARN, "failed to init temp row store", K(ret));
     } else if (has_addon
                && OB_FAIL(init_temp_row_store(
                     *addon_exprs_, 1, eval_ctx_->max_batch_size_, true, true /*enable dump*/,
-                    Store_Row::get_extra_size(false), compress_type_, chunk->addon_store_))) {
+                    Store_Row::get_extra_size(false), compress_type_, chunk->get_addon_store()))) {
       SQL_ENG_LOG(WARN, "failed to init temp row store", K(ret));
     } else {
       while (OB_SUCC(ret)) {
@@ -319,11 +333,11 @@ protected:
             ret = OB_SUCCESS;
           }
           break;
-        } else if (OB_FAIL(chunk->sk_store_.add_row(SK_CONST_UPCAST_P(sort_key_row), dst_sk_row))) {
+        } else if (OB_FAIL(chunk->get_sk_store().add_row(SK_CONST_UPCAST_P(sort_key_row), dst_sk_row))) {
           SQL_ENG_LOG(WARN, "copy row to row store failed");
         } else if (has_addon
-                   && OB_FAIL(chunk->addon_store_.add_row(SK_CONST_UPCAST_P(addon_field_row),
-                                                          dst_addon_row))) {
+                   && OB_FAIL(chunk->get_addon_store().add_row(SK_CONST_UPCAST_P(addon_field_row),
+                                                               dst_addon_row))) {
           SQL_ENG_LOG(WARN, "copy row to row store failed");
         } else {
           stored_row_cnt++;
@@ -336,29 +350,25 @@ protected:
       // Must force dump first, then finish dump is effective
       if (OB_FAIL(ret)) {
       } else if (has_addon
-                 && (chunk->sk_store_.get_row_cnt() != chunk->addon_store_.get_row_cnt())) {
+                 && (chunk->get_sk_store().get_row_cnt() != chunk->get_addon_store().get_row_cnt())) {
         ret = OB_ERR_UNEXPECTED;
         SQL_ENG_LOG(WARN, "the number of rows in sort key store and addon store is expected to be equal",
-          K(chunk->sk_store_.get_row_cnt()), K(chunk->addon_store_.get_row_cnt()), K(ret));
-      } else if (OB_FAIL(chunk->sk_store_.dump(true))) {
+          K(chunk->get_sk_store().get_row_cnt()), K(chunk->get_addon_store().get_row_cnt()), K(ret));
+      } else if (OB_FAIL(chunk->get_sk_store().dump(true))) {
         SQL_ENG_LOG(WARN, "failed to dump row store", K(ret));
-      } else if (OB_FAIL(chunk->sk_store_.finish_add_row(true /*+ need dump */))) {
+      } else if (OB_FAIL(chunk->get_sk_store().finish_add_row(true /*+ need dump */))) {
         SQL_ENG_LOG(WARN, "finish add row failed", K(ret));
-      } else if (has_addon && OB_FAIL(chunk->addon_store_.dump(true))) {
+      } else if (has_addon && OB_FAIL(chunk->get_addon_store().dump(true))) {
         SQL_ENG_LOG(WARN, "failed to dump row store", K(ret));
-      } else if (has_addon && OB_FAIL(chunk->addon_store_.finish_add_row(true /*+ need dump */))) {
+      } else if (has_addon && OB_FAIL(chunk->get_addon_store().finish_add_row(true /*+ need dump */))) {
         SQL_ENG_LOG(WARN, "finish add row failed", K(ret));
       } else {
         const int64_t sort_io_time = ObTimeUtility::fast_current_time() - curr_time;
-        const int64_t file_size =
-          has_addon ? (chunk->sk_store_.get_file_size() + chunk->addon_store_.get_file_size()) :
-                      chunk->sk_store_.get_file_size();
-        const int64_t mem_hold =
-          has_addon ? (chunk->sk_store_.get_mem_hold() + chunk->addon_store_.get_mem_hold()) :
-                      chunk->sk_store_.get_mem_hold();
+        const int64_t file_size = chunk->get_file_size();
+        const int64_t mem_hold = chunk->get_mem_hold();
         op_monitor_info_.otherstat_4_id_ = ObSqlMonitorStatIds::SORT_DUMP_DATA_TIME;
         op_monitor_info_.otherstat_4_value_ += sort_io_time;
-        LOG_TRACE("dump sort file", "level", level, "rows", chunk->sk_store_.get_row_cnt(),
+        LOG_TRACE("dump sort file", "level", level, "rows", chunk->get_row_cnt(),
                   "file_size", file_size, "memory_hold", mem_hold, "mem_used",
                   mem_context_->used());
       }
@@ -422,7 +432,6 @@ protected:
   static const int64_t MAX_MERGE_WAYS = 256;
   static const int64_t INMEMORY_MERGE_SORT_WARN_WAYS = 10000;
   typedef common::ObBinaryHeap<Store_Row **, Compare, 16> IMMSHeap;
-  typedef common::ObBinaryHeap<SortVecOpChunk *, Compare, MAX_MERGE_WAYS> EMSHeap;
   typedef common::ObBinaryHeap<Store_Row *, Compare> TopnHeap;
 
   union
@@ -466,8 +475,8 @@ protected:
   bool heap_iter_begin_;
   // heap for in-memory merge sort local order rows
   IMMSHeap *imms_heap_;
-  // heap for external merge sort
-  EMSHeap *ems_heap_;
+  // external merge sorter for dumped chunks
+  ExternalMergeSorter *external_sorter_;
   NextStoredRowFunc next_stored_row_func_;
   ObExecContext *exec_ctx_;
   Store_Row **sk_rows_;

--- a/src/sql/engine/sort/ob_sort_vec_op_impl.ipp
+++ b/src/sql/engine/sort/ob_sort_vec_op_impl.ipp
@@ -55,10 +55,10 @@ void ObSortVecOpImpl<Compare, Store_Row, has_addon>::reset()
       mem_context_->get_malloc_allocator().free(imms_heap_);
       imms_heap_ = nullptr;
     }
-    if (nullptr != ems_heap_) {
-      ems_heap_->~EMSHeap();
-      mem_context_->get_malloc_allocator().free(ems_heap_);
-      ems_heap_ = nullptr;
+    if (nullptr != external_sorter_) {
+      external_sorter_->~ExternalMergeSorter();
+      mem_context_->get_malloc_allocator().free(external_sorter_);
+      external_sorter_ = nullptr;
     }
     if (nullptr != sk_rows_) {
       mem_context_->get_malloc_allocator().free(sk_rows_);
@@ -146,8 +146,8 @@ void ObSortVecOpImpl<Compare, Store_Row, has_addon>::reuse()
     imms_heap_->reset();
   }
   heap_iter_begin_ = false;
-  if (nullptr != ems_heap_) {
-    ems_heap_->reset();
+  if (nullptr != external_sorter_) {
+    external_sorter_->reset();
   }
   if (nullptr != topn_heap_) {
     for (int64_t i = 0; i < topn_heap_->count(); ++i) {
@@ -1144,7 +1144,19 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::update_max_available_mem_siz
   if (!got_first_row_) {
     got_first_row_ = true;
     // heap sort will extend rowsize twice to reuse the space
-    int64_t size = OB_INVALID_ID == input_rows_ ? 0 : input_rows_ * input_width_ * 2;
+    const int64_t heap_input_width = OB_INVALID_ID == input_width_ ? input_width_ : input_width_ * 2;
+    const bool is_ddl_sort = OB_NOT_NULL(eval_ctx_)
+                             && OB_NOT_NULL(eval_ctx_->exec_ctx_.get_my_session())
+                             && eval_ctx_->exec_ctx_.get_my_session()->get_ddl_info().is_ddl();
+    int64_t size = (OB_INVALID_ID == input_rows_ || OB_INVALID_ID == heap_input_width)
+                     ? 0
+                     : input_rows_ * heap_input_width;
+    if (is_topn_sort() && topn_cnt_ > 0 && topn_cnt_ != INT64_MAX && heap_input_width > 0) {
+      size = std::min(size, topn_cnt_ * heap_input_width * 2);
+    }
+    if (is_ddl_sort) {
+      size = std::max(size, 256L * 1024L * 1024L);
+    }
     if (OB_FAIL(sql_mem_processor_.init(&mem_context_->get_malloc_allocator(), size,
                                         op_monitor_info_.op_type_, op_monitor_info_.op_id_,
                                         &eval_ctx_->exec_ctx_))) {
@@ -1156,7 +1168,7 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::update_max_available_mem_siz
           &mem_context_->get_malloc_allocator(),
           [&](int64_t cur_cnt) { return topn_heap_->count() > cur_cnt; }, updated))) {
       SQL_ENG_LOG(WARN, "failed to get max available memory size", K(ret));
-    } else if (updated && OB_FAIL(sql_mem_processor_.update_used_mem_size(mem_context_->used()))) {
+    } else if (updated && OB_FAIL(sql_mem_processor_.update_used_mem_size(get_total_used_size()))) {
       SQL_ENG_LOG(WARN, "failed to update used memory size", K(ret));
     }
   }
@@ -1218,6 +1230,8 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::preprocess_dump(bool &dumped
 {
   int ret = OB_SUCCESS;
   dumped = false;
+  const int64_t data_size = sk_store_.get_mem_hold() + sk_store_.get_file_size()
+                            + addon_store_.get_mem_hold() + addon_store_.get_file_size();
   if (OB_FAIL(sql_mem_processor_.get_max_available_mem_size(&mem_context_->get_malloc_allocator()))) {
     SQL_ENG_LOG(WARN, "failed to get max available memory size", K(ret));
   } else if (OB_FAIL(sql_mem_processor_.update_used_mem_size(get_total_used_size()))) {
@@ -1225,51 +1239,28 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::preprocess_dump(bool &dumped
   } else {
     dumped = need_dump();
     if (dumped) {
-      if (!sql_mem_processor_.is_auto_mgr()) {
-        // 如果dump在非auto管理模式也需要注册到workarea
-        if (OB_FAIL(sql_mem_processor_.extend_max_memory_size(&mem_context_->get_malloc_allocator(),
-                                                              [&](int64_t max_memory_size) {
-                                                                UNUSED(max_memory_size);
-                                                                return need_dump();
-                                                              },
-                                                              dumped, mem_context_->used()))) {
-          SQL_ENG_LOG(WARN, "failed to extend memory size", K(ret));
+      if (!sql_mem_processor_.is_auto_mgr() || profile_.get_cache_size() < profile_.get_global_bound_size()) {
+        if (OB_FAIL(sql_mem_processor_.extend_max_memory_size(
+                &mem_context_->get_malloc_allocator(),
+                [&](int64_t max_memory_size) {
+                  UNUSED(max_memory_size);
+                  return need_dump();
+                },
+                dumped, get_total_used_size()))) {
+          SQL_ENG_LOG(WARN, "failed to extend sort memory", K(ret));
         }
-      } else if (profile_.get_cache_size() < profile_.get_global_bound_size()) {
-        // in-memory：所有数据都可以缓存，即global bound
-        // size比较大，则继续看是否有更多内存可用
-        if (OB_FAIL(sql_mem_processor_.extend_max_memory_size(&mem_context_->get_malloc_allocator(),
-                                                              [&](int64_t max_memory_size) {
-                                                                UNUSED(max_memory_size);
-                                                                return need_dump();
-                                                              },
-                                                              dumped, get_total_used_size()))) {
-          SQL_ENG_LOG(WARN, "failed to extend memory size", K(ret));
-        }
-        LOG_TRACE("trace sort need dump", K(dumped), K(get_total_used_size()), K(get_memory_limit()),
-                  K(profile_.get_cache_size()), K(profile_.get_expect_size()));
-      } else {
-        // one-pass
-        if (profile_.get_cache_size() <= sk_store_.get_mem_hold() + sk_store_.get_file_size()
-                                           + addon_store_.get_mem_hold()
-                                           + addon_store_.get_file_size()) {
-          // 总体数据量超过cache
-          // size，说明估算的cache不准确，需要重新估算one-pass
-          // size，按照2*cache_size处理
-          if (OB_FAIL(sql_mem_processor_.update_cache_size(&mem_context_->get_malloc_allocator(),
-                                                           profile_.get_cache_size()
-                                                             * EXTEND_MULTIPLE))) {
-            SQL_ENG_LOG(WARN, "failed to update cache size", K(ret), K(profile_.get_cache_size()));
-          } else {
-            dumped = need_dump();
-          }
+      } else if (profile_.get_cache_size() <= data_size) {
+        if (OB_FAIL(sql_mem_processor_.update_cache_size(
+                &mem_context_->get_malloc_allocator(), profile_.get_cache_size() * 2))) {
+          SQL_ENG_LOG(WARN, "failed to update sort cache size", K(ret), K(profile_.get_cache_size()));
         } else {
+          dumped = need_dump();
         }
       }
-      SQL_ENG_LOG(INFO, "trace sort need dump", K(dumped), K(mem_context_->used()),
-                  K(get_memory_limit()), K(profile_.get_cache_size()),
-                  K(profile_.get_expect_size()), K(sql_mem_processor_.get_data_size()));
     }
+  }
+  if (OB_FAIL(ret)) {
+    SQL_ENG_LOG(WARN, "failed to preprocess sort dump", K(ret));
   }
   if (OB_SUCC(ret) && dumped && OB_NOT_NULL(rows_) && rows_->empty()) {
     dumped = false; //no data to dump, try to add a batch of data directly
@@ -1487,6 +1478,49 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::do_partition_sort(
 }
 
 template <typename Compare, typename Store_Row, bool has_addon>
+int ObSortVecOpImpl<Compare, Store_Row, has_addon>::do_full_sort_strategy(const int64_t begin)
+{
+  int ret = OB_SUCCESS;
+  if (enable_encode_sortkey_) {
+    if (is_fixed_key_sort_enabled_) {
+      if (OB_FAIL(do_fixed_key_sort(begin))) {
+        SQL_ENG_LOG(WARN, "failed to do fixed key sort", K(ret));
+      }
+    } else {
+      bool can_encode = true;
+      ObAdaptiveQS<Store_Row> aqs(*rows_, *sk_row_meta_, mem_context_->get_malloc_allocator());
+      if (OB_FAIL(aqs.init(*rows_, mem_context_->get_malloc_allocator(), begin, rows_->count(),
+                           can_encode))) {
+        SQL_ENG_LOG(WARN, "failed to init aqs", K(ret));
+      } else if (can_encode) {
+        aqs.sort(begin, rows_->count());
+      } else {
+        enable_encode_sortkey_ = false;
+        comp_.fallback_to_disable_encode_sortkey();
+        lib::ob_sort(&rows_->at(begin), &rows_->at(0) + rows_->count(), CopyableComparer(comp_));
+      }
+    }
+  } else {
+    lib::ob_sort(&rows_->at(begin), &rows_->at(0) + rows_->count(), CopyableComparer(comp_));
+  }
+  return ret;
+}
+
+template <typename Compare, typename Store_Row, bool has_addon>
+int ObSortVecOpImpl<Compare, Store_Row, has_addon>::do_partition_sort_strategy(const int64_t begin)
+{
+  return do_partition_sort(*sk_row_meta_, *rows_, begin, rows_->count());
+}
+
+template <typename Compare, typename Store_Row, bool has_addon>
+int ObSortVecOpImpl<Compare, Store_Row, has_addon>::do_partition_topn_sort_strategy(const int64_t begin)
+{
+  // The legacy vector path keeps partition TopN in heap-sort code. Until that path is
+  // selected explicitly, partition sort is the safe strategy fallback.
+  return do_partition_sort_strategy(begin);
+}
+
+template <typename Compare, typename Store_Row, bool has_addon>
 int ObSortVecOpImpl<Compare, Store_Row, has_addon>::sort_inmem_data()
 {
   int ret = OB_SUCCESS;
@@ -1509,28 +1543,11 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::sort_inmem_data()
         }
       }
       if (part_cnt_ > 0) {
-        OZ(do_partition_sort(*sk_row_meta_, *rows_, begin, rows_->count()));
-      } else if (enable_encode_sortkey_) {
-          if (is_fixed_key_sort_enabled_) {
-            if (OB_FAIL(do_fixed_key_sort(begin))) {
-              SQL_ENG_LOG(WARN, "failed to do fixed key sort", K(ret));
-            }
-          } else {
-            bool can_encode = true;
-            ObAdaptiveQS<Store_Row> aqs(*rows_, *sk_row_meta_, mem_context_->get_malloc_allocator());
-            if (OB_FAIL(aqs.init(*rows_, mem_context_->get_malloc_allocator(), begin, rows_->count(),
-                              can_encode))) {
-              SQL_ENG_LOG(WARN, "failed to init aqs", K(ret));
-            } else if (can_encode) {
-              aqs.sort(begin, rows_->count());
-            } else {
-              enable_encode_sortkey_ = false;
-              comp_.fallback_to_disable_encode_sortkey();
-              lib::ob_sort(&rows_->at(begin), &rows_->at(0) + rows_->count(), CopyableComparer(comp_));
-            }
-          }
+        ObPartitionSortStrategy<ThisType> strategy;
+        OZ(strategy.sort(*this, begin));
       } else {
-        lib::ob_sort(&rows_->at(begin), &rows_->at(0) + rows_->count(), CopyableComparer(comp_));
+        ObFullSortStrategy<ThisType> strategy;
+        OZ(strategy.sort(*this, begin));
       }
       if (OB_SUCCESS != comp_.ret_) {
         ret = comp_.ret_;
@@ -1652,47 +1669,19 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::do_dump()
   } else {
     const int64_t level = 0;
     if (!need_imms()) {
-      int64_t row_pos = 0;
-      int64_t ties_array_pos = 0;
-      auto input = [&](const Store_Row *&sk_row, const Store_Row *&addon_row) {
-        int ret = OB_SUCCESS;
-        if (row_pos >= rows_->count() && ties_array_pos >= ties_array_.count()) {
-          ret = OB_ITER_END;
-        } else if (row_pos < rows_->count()) {
-          sk_row = rows_->at(row_pos);
-          if (has_addon) {
-            addon_row = sk_row->get_addon_ptr(*sk_row_meta_);
-          }
-          row_pos += 1;
-        } else {
-          sk_row = ties_array_.at(ties_array_pos);
-          if (has_addon) {
-            addon_row = sk_row->get_addon_ptr(*sk_row_meta_);
-          }
-          ties_array_pos += 1;
-        }
-        return ret;
-      };
+      ObNormalDumpStrategy<Store_Row, has_addon> input(*rows_, ties_array_, *sk_row_meta_);
       if (OB_FAIL(build_chunk(level, input))) {
         SQL_ENG_LOG(WARN, "build chunk failed");
       } else if (OB_FAIL(eager_topn_filter(rows_))) {
         SQL_ENG_LOG(WARN, "eager_topn_filter failed", K(ret));
       }
     } else {
-      auto input = [&](const Store_Row *&sk_row, const Store_Row *&addon_row) {
-        int ret = OB_SUCCESS;
-        if (OB_FAIL(imms_heap_next(sk_row))) {
-          if (OB_ITER_END != ret) {
-            SQL_ENG_LOG(WARN, "get row from memory heap failed", K(ret));
-          }
-        } else if (has_addon) {
-          addon_row = sk_row->get_addon_ptr(*sk_row_meta_);
-        }
-        if (OB_SUCC(ret) && is_topn_sort() && is_topn_filter_enabled()) {
-          sorted_dumped_rows_ptrs_.push_back(SK_RC_DOWNCAST_P(sk_row));
-        }
-        return ret;
+      auto heap_next = [this](const Store_Row *&sk_row) {
+        return this->imms_heap_next(sk_row);
       };
+      ObIMMSDumpStrategy<Store_Row, has_addon, decltype(heap_next)> input(
+        std::move(heap_next), *sk_row_meta_, sorted_dumped_rows_ptrs_,
+        is_topn_sort(), is_topn_filter_enabled());
       if (OB_FAIL(build_chunk(level, input))) {
         SQL_ENG_LOG(WARN, "build chunk failed", K(ret));
       } else if (OB_FAIL(eager_topn_filter(&sorted_dumped_rows_ptrs_))) {
@@ -1762,7 +1751,18 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::before_add_row()
       SQL_ENG_LOG(WARN, "init compare failed", K(ret));
     } else {
       got_first_row_ = true;
-      int64_t size = OB_INVALID_ID == input_rows_ ? 0 : input_rows_ * input_width_;
+      const bool is_ddl_sort = OB_NOT_NULL(exec_ctx_)
+                               && OB_NOT_NULL(exec_ctx_->get_my_session())
+                               && exec_ctx_->get_my_session()->get_ddl_info().is_ddl();
+      int64_t size = (OB_INVALID_ID == input_rows_ || OB_INVALID_ID == input_width_)
+                       ? 0
+                       : input_rows_ * input_width_;
+      if (is_topn_sort() && topn_cnt_ > 0 && topn_cnt_ != INT64_MAX && input_width_ > 0) {
+        size = std::min(size, topn_cnt_ * input_width_ * 2);
+      }
+      if (is_ddl_sort) {
+        size = std::max(size, 256L * 1024L * 1024L);
+      }
       if (OB_FAIL(sql_mem_processor_.init(&mem_context_->get_malloc_allocator(), size,
                                           op_monitor_info_.op_type_, op_monitor_info_.op_id_,
                                           exec_ctx_))) {
@@ -1836,9 +1836,6 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::build_ems_heap(int64_t &merg
   } else if (sort_chunks_.get_size() < 2) {
     ret = OB_ERR_UNEXPECTED;
     SQL_ENG_LOG(WARN, "empty or one way, merge sort not needed", K(ret));
-  } else if (OB_FAIL(sql_mem_processor_.get_max_available_mem_size(
-               &mem_context_->get_malloc_allocator()))) {
-    SQL_ENG_LOG(WARN, "failed to get max available memory size", K(ret));
   } else {
     SortVecOpChunk *first = sort_chunks_.get_first();
     if (first->level_ != first->get_next()->level_) {
@@ -1853,53 +1850,59 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::build_ems_heap(int64_t &merg
       max_ways += 1;
       c = c->get_next();
     }
-  
-    if (nullptr == ems_heap_) {
-      if (OB_ISNULL(ems_heap_ = OB_NEWx(EMSHeap, (&mem_context_->get_malloc_allocator()), comp_,
-                                        &mem_context_->get_malloc_allocator()))) {
-        ret = OB_ALLOCATE_MEMORY_FAILED;
-        SQL_ENG_LOG(WARN, "allocate memory failed", K(ret));
+
+    const bool is_ddl_sort = OB_NOT_NULL(exec_ctx_)
+                             && OB_NOT_NULL(exec_ctx_->get_my_session())
+                             && exec_ctx_->get_my_session()->get_ddl_info().is_ddl();
+    if (is_ddl_sort) {
+      if (OB_FAIL(ObDDLSortProvider::calc_merge_ways(sql_mem_processor_, mem_context_,
+                                                     max_ways, merge_ways))) {
+        SQL_ENG_LOG(WARN, "failed to calc ddl merge ways", K(ret), K(max_ways));
       }
+    } else if (OB_FAIL(sql_mem_processor_.get_max_available_mem_size(
+                   &mem_context_->get_malloc_allocator()))) {
+      SQL_ENG_LOG(WARN, "failed to get max available memory size", K(ret));
     } else {
-      ems_heap_->reset();
-    }
-    if (OB_SUCC(ret)) {
-      merge_ways = get_memory_limit() / ObTempBlockStore::BLOCK_SIZE;
-      merge_ways = std::max(static_cast<int64_t>(2), merge_ways);
+      const int64_t block_size = ObTempBlockStore::BLOCK_SIZE;
+      merge_ways = std::max(static_cast<int64_t>(2),
+                            sql_mem_processor_.get_mem_bound() / block_size);
       if (merge_ways < max_ways) {
         bool dumped = false;
-        int64_t need_size = max_ways * ObTempBlockStore::BLOCK_SIZE;
+        const int64_t need_size = max_ways * block_size;
         if (OB_FAIL(sql_mem_processor_.extend_max_memory_size(
-              &mem_context_->get_malloc_allocator(),
-              [&](int64_t max_memory_size) { return max_memory_size < need_size; }, dumped,
-              mem_context_->used()))) {
-          SQL_ENG_LOG(WARN, "failed to extend memory size", K(ret));
+                &mem_context_->get_malloc_allocator(),
+                [&](int64_t max_memory_size) { return max_memory_size < need_size; },
+                dumped, mem_context_->used()))) {
+          SQL_ENG_LOG(WARN, "failed to extend merge memory", K(ret));
+        } else {
+          merge_ways = std::max(merge_ways, sql_mem_processor_.get_mem_bound() / block_size);
         }
-        merge_ways = std::max(merge_ways, get_memory_limit() / ObTempBlockStore::BLOCK_SIZE);
       }
       merge_ways = std::min(merge_ways, max_ways);
+    }
+    if (OB_FAIL(ret)) {
+      SQL_ENG_LOG(WARN, "failed to calc merge ways", K(ret), K(max_ways));
+    } else {
       LOG_TRACE("do merge sort ", K(first->level_), K(merge_ways), K(sort_chunks_.get_size()),
                 K(get_memory_limit()), K(sql_mem_processor_.get_profile()));
     }
 
     if (OB_SUCC(ret)) {
-      SortVecOpChunk *chunk = sort_chunks_.get_first();
-      for (int64_t i = 0; i < merge_ways && OB_SUCC(ret); i++) {
-        chunk->reset_row_iter();
-        if (OB_FAIL(chunk->init_row_iter())) {
-          SQL_ENG_LOG(WARN, "init iterator failed", K(ret));
-        } else if (OB_FAIL(chunk->get_next_row()) || nullptr == chunk->sk_row_) {
-          if (OB_ITER_END == ret || OB_SUCCESS == ret) {
-            ret = OB_ERR_UNEXPECTED;
-            SQL_ENG_LOG(WARN, "row store is not empty, iterate end is unexpected", K(ret),
-                        KP(chunk->sk_row_));
-          }
-          SQL_ENG_LOG(WARN, "get next row failed", K(ret));
-        } else if (OB_FAIL(ems_heap_->push(chunk))) {
-          SQL_ENG_LOG(WARN, "heap push failed", K(ret));
-        } else {
-          chunk = chunk->get_next();
+      if (nullptr == external_sorter_) {
+        if (OB_ISNULL(external_sorter_ = OB_NEWx(ExternalMergeSorter,
+                                                (&mem_context_->get_malloc_allocator()),
+                                                mem_context_->get_malloc_allocator(), comp_))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          SQL_ENG_LOG(WARN, "allocate memory failed", K(ret));
         }
+      } else {
+        external_sorter_->reset();
+      }
+    }
+
+    if (OB_SUCC(ret)) {
+      if (OB_FAIL(external_sorter_->init(sort_chunks_, merge_ways))) {
+        SQL_ENG_LOG(WARN, "init external merge sorter failed", K(ret), K(merge_ways));
       }
     }
   }
@@ -1952,24 +1955,6 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::heap_next(Heap &heap, const 
 }
 
 template <typename Compare, typename Store_Row, bool has_addon>
-int ObSortVecOpImpl<Compare, Store_Row, has_addon>::ems_heap_next(SortVecOpChunk *&chunk)
-{
-  const auto f = [](SortVecOpChunk *&c, bool &is_end) {
-    int ret = OB_SUCCESS;
-    if (OB_FAIL(c->get_next_row())) {
-      if (OB_ITER_END == ret) {
-        is_end = true;
-        ret = OB_SUCCESS;
-      } else {
-        SQL_ENG_LOG(WARN, "get next row failed", K(ret));
-      }
-    }
-    return ret;
-  };
-  return heap_next(*ems_heap_, f, chunk);
-}
-
-template <typename Compare, typename Store_Row, bool has_addon>
 int ObSortVecOpImpl<Compare, Store_Row, has_addon>::rewind()
 {
   int ret = OB_SUCCESS;
@@ -1991,7 +1976,6 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::rewind()
   }
   return ret;
 }
-
 template <typename Compare, typename Store_Row, bool has_addon>
 int ObSortVecOpImpl<Compare, Store_Row, has_addon>::imms_heap_next_stored_row(const Store_Row *&sr)
 {
@@ -2002,16 +1986,14 @@ template <typename Compare, typename Store_Row, bool has_addon>
 int ObSortVecOpImpl<Compare, Store_Row, has_addon>::ems_heap_next_stored_row(const Store_Row *&sr)
 {
   int ret = OB_SUCCESS;
-  SortVecOpChunk *chunk = nullptr;
-  if (OB_FAIL(ems_heap_next(chunk))) {
+  const Store_Row *addon_row = nullptr;
+  if (OB_ISNULL(external_sorter_)) {
+    ret = OB_ERR_UNEXPECTED;
+    SQL_ENG_LOG(WARN, "external sorter is null", K(ret));
+  } else if (OB_FAIL(external_sorter_->get_next_row(sr, addon_row))) {
     if (OB_ITER_END != ret) {
       SQL_ENG_LOG(WARN, "get next heap row failed", K(ret));
     }
-  } else if (nullptr == chunk || nullptr == chunk->sk_row_) {
-    ret = OB_ERR_UNEXPECTED;
-    SQL_ENG_LOG(WARN, "nullptr chunk or store row", K(ret));
-  } else {
-    sr = chunk->sk_row_;
   }
   return ret;
 }
@@ -2079,18 +2061,12 @@ int ObSortVecOpImpl<Compare, Store_Row, has_addon>::sort()
         }
         auto input = [&](const Store_Row *&sk_row, const Store_Row *&addon_row) {
           int ret = OB_SUCCESS;
-          SortVecOpChunk *chunk = nullptr;
-          if (OB_FAIL(ems_heap_next(chunk))) {
+          if (OB_ISNULL(external_sorter_)) {
+            ret = OB_ERR_UNEXPECTED;
+            SQL_ENG_LOG(WARN, "external sorter is null", K(ret));
+          } else if (OB_FAIL(external_sorter_->get_next_row(sk_row, addon_row))) {
             if (OB_ITER_END != ret) {
               SQL_ENG_LOG(WARN, "get next heap row failed", K(ret));
-            }
-          } else if (nullptr == chunk) {
-            ret = OB_ERR_UNEXPECTED;
-            SQL_ENG_LOG(WARN, "get chunk from heap is nullptr", K(ret));
-          } else {
-            sk_row = chunk->sk_row_;
-            if (has_addon) {
-              addon_row = chunk->addon_row_;
             }
           }
           return ret;

--- a/src/sql/engine/sort/ob_sort_vec_op_store_row_factory.h
+++ b/src/sql/engine/sort/ob_sort_vec_op_store_row_factory.h
@@ -1,17 +1,13 @@
-/*
- * Copyright (c) 2025 OceanBase.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
  */
 
 #ifndef OCEANBASE_SQL_ENGINE_SORT_SORT_VEC_OP_STORE_ROW_FACTORY_H_
@@ -25,7 +21,7 @@ class ObSortVecOpStoreRowFactory {
 public:
   ObSortVecOpStoreRowFactory(common::ObIAllocator &allocator,
                   ObSqlMemMgrProcessor &sql_mem_processor,
-                  const RowMeta *&sk_row_meta, 
+                  const RowMeta *&sk_row_meta,
                   const RowMeta *&addon_row_meta,
                   int64_t &inmem_row_size,
                   const int64_t &topn_cnt)
@@ -75,7 +71,7 @@ public:
       }
       if (OB_ISNULL(buf = reinterpret_cast<char *>(allocator_.alloc(buffer_len)))) {
         ret = OB_ERR_UNEXPECTED;
-        LOG_ERROR("alloc buf failed", K(ret));
+        SQL_ENG_LOG(ERROR, "alloc buf failed", K(ret));
       } else {
         // generate new row
         sql_mem_processor_.alloc(buffer_len);
@@ -87,7 +83,7 @@ public:
     if (OB_FAIL(ret)) {
     } else if (OB_FAIL(reuse_row->assign(
             *reinterpret_cast<const ObCompactRow *>(src_row)))) {
-      LOG_WARN("stored row assign failed", K(ret));
+      SQL_ENG_LOG(WARN, "stored row assign failed", K(ret));
     } else {
       if (has_addon && is_sort_key) {
         reuse_row->set_addon_ptr(nullptr, *sk_row_meta);
@@ -123,10 +119,10 @@ public:
     }
 
     if (OB_FAIL(copy_row(sk_row_meta_, src_row, true, reuse_row))) {
-      LOG_WARN("failed to copy sort key row", K(ret));
+      SQL_ENG_LOG(WARN, "failed to copy sort key row", K(ret));
     } else if (has_addon) {
       if (OB_FAIL(copy_row(addon_row_meta_, ori_addon_row, false, reuse_addon_row))) {
-        LOG_WARN("failed to copy addon row", K(ret));
+        SQL_ENG_LOG(WARN, "failed to copy addon row", K(ret));
       } else {
         reuse_row->set_addon_ptr(reuse_addon_row, *sk_row_meta_);
       }
@@ -160,17 +156,17 @@ public:
     char *buf = nullptr;
     if (OB_ISNULL(orign_row)) {
       ret = OB_ERR_UNEXPECTED;
-      LOG_WARN("unexpected null", K(ret));
+      SQL_ENG_LOG(WARN, "unexpected null", K(ret));
     } else if (OB_ISNULL(buf = reinterpret_cast<char *>(
                              allocator_.alloc(orign_row->get_row_size())))) {
       ret = OB_ALLOCATE_MEMORY_FAILED;
-      LOG_ERROR("alloc buf failed", K(ret));
+      SQL_ENG_LOG(ERROR, "alloc buf failed", K(ret));
     } else if (OB_ISNULL(new_row = new (buf) Store_Row())) {
       ret = OB_ALLOCATE_MEMORY_FAILED;
-      LOG_ERROR("failed to new row", K(ret));
+      SQL_ENG_LOG(ERROR, "failed to new row", K(ret));
     } else if (OB_FAIL(new_row->assign(
                    *reinterpret_cast<const ObCompactRow *>(orign_row)))) {
-      LOG_WARN("stored row assign failed", K(ret));
+      SQL_ENG_LOG(WARN, "stored row assign failed", K(ret));
     } else {
       int64_t row_size = orign_row->get_row_size();
       sql_mem_processor_.alloc(row_size);
@@ -183,21 +179,21 @@ public:
   {
     int ret = OB_SUCCESS;
     if (OB_SUCCESS != (ret = deep_copy_row(sk_row_meta_, orign_row, new_row))) {
-      LOG_WARN("failed to copy to row", K(ret));
+      SQL_ENG_LOG(WARN, "failed to copy to row", K(ret));
     } else if (has_addon) {
       Store_Row *new_addon_row = nullptr;
       Store_Row *ori_addon_row =
           const_cast<Store_Row *>(orign_row->get_addon_ptr(*sk_row_meta_));
       if (OB_FAIL(deep_copy_row(addon_row_meta_, ori_addon_row, new_addon_row))) {
         free_row_store(*sk_row_meta_, new_row);
-        LOG_WARN("failed to copy to row", K(ret));
+        SQL_ENG_LOG(WARN, "failed to copy to row", K(ret));
       } else {
         new_row->set_addon_ptr(new_addon_row, *sk_row_meta_);
       }
     }
     return ret;
   }
-  
+
 private:
   common::ObIAllocator &allocator_;
   ObSqlMemMgrProcessor &sql_mem_processor_;

--- a/src/sql/engine/sort/ob_sort_vec_strategy.h
+++ b/src/sql/engine/sort/ob_sort_vec_strategy.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_SORT_OB_SORT_VEC_STRATEGY_H_
+#define OCEANBASE_SQL_ENGINE_SORT_OB_SORT_VEC_STRATEGY_H_
+
+namespace oceanbase
+{
+namespace sql
+{
+
+template <typename SortImpl>
+class ObISortStrategy
+{
+public:
+  virtual ~ObISortStrategy() {}
+  virtual int sort(SortImpl &impl, const int64_t begin) = 0;
+};
+
+template <typename SortImpl>
+class ObFullSortStrategy final : public ObISortStrategy<SortImpl>
+{
+public:
+  virtual int sort(SortImpl &impl, const int64_t begin) override
+  {
+    return impl.do_full_sort_strategy(begin);
+  }
+};
+
+template <typename SortImpl>
+class ObPartitionSortStrategy final : public ObISortStrategy<SortImpl>
+{
+public:
+  virtual int sort(SortImpl &impl, const int64_t begin) override
+  {
+    return impl.do_partition_sort_strategy(begin);
+  }
+};
+
+template <typename SortImpl>
+class ObPartitionTopNSortStrategy final : public ObISortStrategy<SortImpl>
+{
+public:
+  virtual int sort(SortImpl &impl, const int64_t begin) override
+  {
+    return impl.do_partition_topn_sort_strategy(begin);
+  }
+};
+
+} // namespace sql
+} // namespace oceanbase
+
+#endif /* OCEANBASE_SQL_ENGINE_SORT_OB_SORT_VEC_STRATEGY_H_ */

--- a/src/sql/engine/table/ob_table_scan_op.cpp
+++ b/src/sql/engine/table/ob_table_scan_op.cpp
@@ -763,6 +763,7 @@ ObTableScanOp::ObTableScanOp(ObExecContext &exec_ctx, const ObOpSpec &spec, ObOp
     in_rescan_(false),
     domain_index_(),
     fts_index_(),
+    fts_output_exprs_{},
     fts_lob_allocator_("FTSLobBuffer"),
     output_   (nullptr),
     fold_iter_(nullptr),
@@ -1679,6 +1680,8 @@ int ObTableScanOp::inner_open()
   } else if (MY_SPEC.is_fts_ddl_ && OB_FAIL(fts_index_.init(MY_SPEC.is_fts_index_aux_, MY_SPEC.parser_name_,
           MY_SPEC.parser_properties_))) {
     LOG_WARN("fail to init fts index cache", K(ret));
+  } else if (MY_SPEC.is_fts_ddl_ && OB_FAIL(init_fts_output_exprs())) {
+    LOG_WARN("fail to initialize fulltext output expressions", K(ret));
   } else {
     if (MY_SPEC.report_col_checksum_) {
       if (PHY_TABLE_SCAN == MY_SPEC.get_type()) {
@@ -4043,8 +4046,10 @@ int ObTableScanOp::fetch_next_fts_index_rows()
   int ret = OB_SUCCESS;
   bool has_segment_word = false;
   while (OB_SUCC(ret) && !has_segment_word) {
-    ObExpr *ft_expr = nullptr;
-    ObExpr *doc_id_expr = nullptr;
+    const int64_t word_idx = MY_SPEC.is_fts_index_aux_ ? 0 : 1;
+    const int64_t doc_id_idx = MY_SPEC.is_fts_index_aux_ ? 1 : 0;
+    ObExpr *ft_expr = fts_output_exprs_[word_idx];
+    ObExpr *doc_id_expr = fts_output_exprs_[doc_id_idx];
     ObDatum *ft_datum = nullptr;
     ObDatum *doc_id_datum = nullptr;
 
@@ -4052,10 +4057,6 @@ int ObTableScanOp::fetch_next_fts_index_rows()
       if (OB_ITER_END != ret) {
         LOG_WARN("fail to get next row implement", K(ret));
       }
-    } else if (OB_FAIL(get_output_fts_col_expr_by_type(T_FUN_SYS_DOC_ID, doc_id_expr))) {
-      LOG_WARN("fail to get doc id column expr from output", K(ret));
-    } else if (OB_FAIL(get_output_fts_col_expr_by_type(T_FUN_SYS_WORD_SEGMENT, ft_expr))) {
-      LOG_WARN("fail to get word segment column expr from output", K(ret));
     } else if (OB_ISNULL(ft_expr) || OB_ISNULL(doc_id_expr)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("unexpeted error, ft or doc id expr is nullptr", K(ret), KP(ft_expr), KP(doc_id_expr));
@@ -4098,9 +4099,10 @@ int ObTableScanOp::fill_generated_fts_cols(blocksstable::ObDatumRow *row)
     LOG_WARN("invalid argument, row is nullptr", K(ret), KP(row));
   } else {
     for (int64_t i = 0; OB_SUCC(ret) && i < share::ObFtsIndexBuilderUtil::OB_FTS_INDEX_OR_DOC_WORD_TABLE_COL_CNT; ++i) {
-      ObExpr *expr = nullptr;
-      if (OB_FAIL(get_output_fts_col_expr_by_type(expr_types[i], expr))) {
-        LOG_WARN("fail to get fts column expr", K(ret), K(i), K(expr_types[i]));
+      ObExpr *expr = fts_output_exprs_[i];
+      if (OB_ISNULL(expr)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected null fulltext output expression", K(ret), K(i), K(expr_types[i]));
       } else {
         ObDatum &datum = expr->locate_datum_for_write(eval_ctx_);
         ObEvalInfo &eval_info = expr->get_eval_info(eval_ctx_);
@@ -4111,6 +4113,23 @@ int ObTableScanOp::fill_generated_fts_cols(blocksstable::ObDatumRow *row)
           eval_info.projected_ = true;
         }
       }
+    }
+  }
+  return ret;
+}
+
+int ObTableScanOp::init_fts_output_exprs()
+{
+  int ret = OB_SUCCESS;
+  const ObExprOperatorType *expr_types = MY_SPEC.is_fts_index_aux_
+      ? ObFTIndexRowCache::FTS_INDEX_EXPR_TYPE
+      : ObFTIndexRowCache::FTS_DOC_WORD_EXPR_TYPE;
+  for (int64_t i = 0;
+       OB_SUCC(ret) && i < share::ObFtsIndexBuilderUtil::OB_FTS_INDEX_OR_DOC_WORD_TABLE_COL_CNT;
+       ++i) {
+    fts_output_exprs_[i] = nullptr;
+    if (OB_FAIL(get_output_fts_col_expr_by_type(expr_types[i], fts_output_exprs_[i]))) {
+      LOG_WARN("fail to cache fulltext output expression", K(ret), K(i), K(expr_types[i]));
     }
   }
   return ret;

--- a/src/sql/engine/table/ob_table_scan_op.cpp
+++ b/src/sql/engine/table/ob_table_scan_op.cpp
@@ -763,6 +763,7 @@ ObTableScanOp::ObTableScanOp(ObExecContext &exec_ctx, const ObOpSpec &spec, ObOp
     in_rescan_(false),
     domain_index_(),
     fts_index_(),
+    fts_lob_allocator_("FTSLobBuffer"),
     output_   (nullptr),
     fold_iter_(nullptr),
     iter_tree_(nullptr),
@@ -1773,6 +1774,7 @@ int ObTableScanOp::inner_close()
 
   if (OB_SUCC(ret)) {
     fts_index_.reuse();
+    fts_lob_allocator_.reset_remain_one_page();
     iter_end_ = false;
     need_init_before_get_row_ = true;
     rand_scan_processor_.reset();
@@ -4066,8 +4068,8 @@ int ObTableScanOp::fetch_next_fts_index_rows()
       LOG_WARN("unexpeted error, ft or doc id datum is nullptr", K(ret), KP(ft_datum), KP(doc_id_datum));
     } else {
       ObString ft = ft_datum->get_string();
-      ObArenaAllocator tmp_allocator(ObModIds::OB_LOB_ACCESS_BUFFER, OB_MALLOC_NORMAL_BLOCK_SIZE);
-      if (OB_FAIL(ObTextStringHelper::read_real_string_data(tmp_allocator,
+      fts_lob_allocator_.reset_remain_one_page();
+      if (OB_FAIL(ObTextStringHelper::read_real_string_data(fts_lob_allocator_,
                                                             *ft_datum,
                                                             ft_expr->datum_meta_,
                                                             ft_expr->obj_meta_.has_lob_header(),

--- a/src/sql/engine/table/ob_table_scan_op.h
+++ b/src/sql/engine/table/ob_table_scan_op.h
@@ -754,6 +754,7 @@ protected:
   bool in_rescan_;
   ObDomainIndexCache domain_index_;
   ObFTIndexRowCache fts_index_;
+  common::ObArenaAllocator fts_lob_allocator_;
 
   // output_ is used to output data, TSC operator directly invokes output_::get_next_row(s),
   // it points to fold_iter_ in group rescan and iter_tree_ in normal scan.

--- a/src/sql/engine/table/ob_table_scan_op.h
+++ b/src/sql/engine/table/ob_table_scan_op.h
@@ -724,6 +724,7 @@ private:
   int inner_get_next_fts_index_row();
   int fetch_next_fts_index_rows();
   int fill_generated_fts_cols(ObDatumRow *row);
+  int init_fts_output_exprs();
   int get_output_fts_col_expr_by_type(const ObExprOperatorType &type, ObExpr *&expr);
   bool is_resume_point_saved();
 protected:
@@ -754,6 +755,7 @@ protected:
   bool in_rescan_;
   ObDomainIndexCache domain_index_;
   ObFTIndexRowCache fts_index_;
+  ObExpr *fts_output_exprs_[4];
   common::ObArenaAllocator fts_lob_allocator_;
 
   // output_ is used to output data, TSC operator directly invokes output_::get_next_row(s),

--- a/src/sql/executor/ob_cmd_executor.cpp
+++ b/src/sql/executor/ob_cmd_executor.cpp
@@ -515,6 +515,10 @@ int ObCmdExecutor::execute(ObExecContext &ctx, ObICmd &cmd)
         DEFINE_EXECUTE_CMD(ObRefreshMemStatStmt, ObRefreshMemStatExecutor);
         break;
       }
+      case stmt::T_REFRESH_FULLTEXT_DICT: {
+        DEFINE_EXECUTE_CMD(ObRefreshFulltextDictStmt, ObRefreshFulltextDictExecutor);
+        break;
+      }
       case stmt::T_WASH_MEMORY_FRAGMENTATION: {
         DEFINE_EXECUTE_CMD(ObWashMemFragmentationStmt, ObWashMemFragmentationExecutor);
         break;

--- a/src/sql/optimizer/ob_del_upd_log_plan.cpp
+++ b/src/sql/optimizer/ob_del_upd_log_plan.cpp
@@ -1257,11 +1257,15 @@ int ObDelUpdLogPlan::get_ddl_sample_sort_column_count(int64_t &sample_sort_colum
     } else if (OB_ISNULL(table_item)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("table item of insert stmt is null", K(ret));
-    } else if (OB_FAIL(schema_guard->get_table_schema( table_item->ddl_table_id_, table_schema))) {
+    } else if (OB_FAIL(schema_guard->get_table_schema(table_item->ddl_table_id_, table_schema))) {
       LOG_WARN("get target table schema failed", K(ret), KPC(table_item));
     } else if (OB_ISNULL(table_schema)) {
       ret = OB_TABLE_NOT_EXIST;
       LOG_WARN("target table not exist", K(ret), KPC(table_item));
+    } else if (table_schema->is_fts_doc_word_aux()) {
+      // Repartition FTS doc-word rows by doc_id ranges while preserving the
+      // complete sort key for the final local sort performed by each worker.
+      sample_sort_column_count = 1;
     } else if (table_schema->is_unique_index()) {
       sample_sort_column_count = table_schema->get_index_column_num();
     }

--- a/src/sql/optimizer/ob_join_order.cpp
+++ b/src/sql/optimizer/ob_join_order.cpp
@@ -19641,15 +19641,14 @@ int ObJoinOrder::get_query_tokens(ObMatchFunRawExpr *match_expr,
     const ObString &parser_properties = index_schema->get_parser_property_str();
     const ObObjMeta &key_meta = match_expr->get_search_key()->get_result_meta();
     storage::ObFTParseHelper tokenize_helper;
-    common::ObSEArray<ObFTWord, 16> tokens;
-    hash::ObHashMap<ObFTWord, int64_t> token_map;
+    ObFTTokenMap token_map;
     int64_t doc_length = 0;
     const int64_t ft_word_bkt_cnt = MAX(search_text_string.length() / 10, 2);
     if (search_text_string.length() == 0) {
       // do nothing
     } else if (OB_FAIL(tokenize_helper.init(allocator_, parser_name, parser_properties))) {
       LOG_WARN("failed to init tokenize helper", K(ret));
-    } else if (OB_FAIL(token_map.create(ft_word_bkt_cnt, common::ObMemAttr("FTWordMap")))) {
+    } else if (OB_FAIL(token_map.create(ft_word_bkt_cnt, common::ObMemAttr("FTTokenMap")))) {
       LOG_WARN("failed to create token map", K(ret));
     } else if (OB_FAIL(tokenize_helper.segment(
                            key_meta,
@@ -19659,13 +19658,13 @@ int ObJoinOrder::get_query_tokens(ObMatchFunRawExpr *match_expr,
                            token_map))) {
       LOG_WARN("failed to segment");
     } else {
-      for (hash::ObHashMap<ObFTWord, int64_t>::const_iterator iter = token_map.begin();
+      for (ObFTTokenMap::const_iterator iter = token_map.begin();
           OB_SUCC(ret) && iter != token_map.end();
           ++iter) {
-        const ObFTWord &token = iter->first;
+        const ObFTToken &token = iter->first;
         ObString token_string;
         ObConstRawExpr *token_expr = NULL;
-        if (OB_FAIL(ob_write_string(*allocator_, token.get_word().get_string(), token_string))) {
+        if (OB_FAIL(ob_write_string(*allocator_, token.get_token().get_string(), token_string))) {
           LOG_WARN("failed to deep copy query token", K(ret));
         } else if (OB_FAIL(ObRawExprUtils::build_const_string_expr(
                                *OPT_CTX.get_exec_ctx()->get_expr_factory(),

--- a/src/sql/optimizer/ob_log_plan.cpp
+++ b/src/sql/optimizer/ob_log_plan.cpp
@@ -14650,7 +14650,7 @@ int ObLogPlan::prepare_text_retrieval_scan(const ObIArray<ObRawExpr *> &scan_mat
   } else {
     ObTextRetrievalInfo &tr_info = table_scan->get_text_retrieval_info();
     tr_info.match_expr_ = match_against;
-    tr_info.pushdown_match_filter_ = match_pred;
+    tr_info.pushdown_match_filter_ = tr_info.need_calc_relevance_ ? match_pred : nullptr;
     // in new version, doc_id_idx_tid_ is invalid.
     table_scan->set_doc_id_index_table_id(tr_info.doc_id_idx_tid_);
     if (table_scan->is_vec_adaptive_scan() || table_scan->is_vec_idx_scan_post_filter()) {
@@ -14895,18 +14895,20 @@ int ObLogPlan::prepare_text_retrieval_info(const uint64_t ref_table_id,
     }
   }
   if (OB_SUCC(ret)) {
-    /*
-    if (OB_FAIL(ObTransformUtils::check_need_calc_match_score(get_optimizer_context().get_exec_ctx(),
-                                                              get_stmt(),
-                                                              match_against,
-                                                              need_calc_relevance,
-                                                              constraints))) {
+    if (BOOLEAN_MODE == match_against->get_mode_flag()) {
+      // Boolean retrieval needs the per-token match state to evaluate its
+      // expression tree, even when MATCH itself is only used as a predicate.
+      need_calc_relevance = true;
+    } else if (OB_FAIL(ObTransformUtils::check_need_calc_match_score(get_optimizer_context().get_exec_ctx(),
+                                                                     get_stmt(),
+                                                                     match_against,
+                                                                     need_calc_relevance,
+                                                                     constraints))) {
       LOG_WARN("failed to check need calc relevance", K(ret));
     } else if (!need_calc_relevance &&
                OB_FAIL(append_array_no_dup(get_optimizer_context().get_query_ctx()->all_expr_constraints_, constraints))) {
       LOG_WARN("failed to append array no dup", K(ret));
     }
-    */
     tr_info.match_expr_ = match_against;
     tr_info.inv_idx_tid_ = inv_idx_tid;
     tr_info.fwd_idx_tid_ = fwd_idx_tid;

--- a/src/sql/parser/non_reserved_keywords_mysql_mode.c
+++ b/src/sql/parser/non_reserved_keywords_mysql_mode.c
@@ -250,6 +250,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"deterministic", DETERMINISTIC},
   {"dense_rank", DENSE_RANK},
   {"diagnostics", DIAGNOSTICS},
+  {"dict", DICT},
   {"dict_table", DICT_TABLE},
   {"diff", DIFF},
   {"disallow", DISALLOW},
@@ -1162,6 +1163,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"INCONSISTENT", INCONSISTENT},
   {"INDIVIDUAL", INDIVIDUAL},
   {"hybrid_search", HYBRID_SEARCH},
+  {"fulltext_dict", FULLTEXT_DICT},
 };
 
 /** https://dev.mysql.com/doc/refman/5.7/en/sql-syntax-prepared-statements.html

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -2881,6 +2881,8 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_FULLTEXT_DICT = 4920,
+  T_REFRESH_FULLTEXT_DICT = 4921,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -292,7 +292,7 @@ END_P SET_VAR DELIMITER
         CTXCAT CTX_ID CUBE CURDATE CURRENT STACKED CURTIME CURSOR_NAME CUME_DIST CYCLE CALC_PARTITION_ID CONNECT
 
         DAG DATA DATAFILE DATA_DISK_SIZE DATA_SOURCE DATA_TABLE_ID DATE DATE_ADD DATE_SUB DATETIME DAY DEALLOCATE DECRYPT
-        DEFAULT_AUTH DEFAULT_LOB_INROW_THRESHOLD DEFINER DELAY DELAY_KEY_WRITE DEPTH DES_KEY_FILE DENSE_RANK DESCRIPTION DESTINATION DIAGNOSTICS DICT_TABLE
+        DEFAULT_AUTH DEFAULT_LOB_INROW_THRESHOLD DEFINER DELAY DELAY_KEY_WRITE DEPTH DES_KEY_FILE DENSE_RANK DESCRIPTION DESTINATION DIAGNOSTICS DICT DICT_TABLE
         DIFF DIRECTORY DISABLE DISALLOW DISCARD DISK DISKGROUP DO DOT DUMP DUMPFILE DUPLICATE DUPLICATE_SCOPE DUPLICATE_READ_CONSISTENCY DYNAMIC
         DATABASE_ID DEFAULT_TABLEGROUP DISCONNECT DEMAND DELETE_INSERT DYNAMIC_PARTITION_POLICY
 
@@ -302,7 +302,7 @@ END_P SET_VAR DELIMITER
 
         FAIL FAILOVER FAST FAULTS FILE_BLOCK_SIZE FIELDS FILEX FINAL_COUNT FIRST FIRST_VALUE FIXED FLUSH FOLLOWER FORMAT
         FOUND FORK FREEZE FREQUENCY FUNCTION FOLLOWING FLASHBACK FULL FRAGMENTATION FROZEN FILE_ID FILTER
-        FIELD_OPTIONALLY_ENCLOSED_BY FIELD_DELIMITER FIELD_ENCLOSED_BY FILE_EXTENSION
+        FIELD_OPTIONALLY_ENCLOSED_BY FIELD_DELIMITER FIELD_ENCLOSED_BY FILE_EXTENSION FULLTEXT_DICT
 
         GENERAL GEOMETRY GEOMCOLLECTION GEOMETRYCOLLECTION GET_FORMAT GLOBAL GRANTS GRANULARITY GROUP_CONCAT GROUPING GTS
         GLOBAL_NAME GLOBAL_ALIAS
@@ -471,7 +471,7 @@ END_P SET_VAR DELIMITER
 %type <node> alter_column_behavior opt_set opt_position_column
 %type <node> alter_system_stmt alter_system_set_parameter_actions alter_system_settp_actions settp_option alter_system_set_parameter_action alter_system_reset_parameter_actions alter_system_reset_parameter_action
 %type <node> opt_comment opt_as
-%type <node> column_name relation_name relation_name_list opt_relation_name function_name column_label var_name relation_name_or_string row_format_option compression_name merge_engine_types
+%type <node> column_name relation_name relation_name_list opt_relation_name function_name column_label var_name relation_name_or_string refresh_fulltext_dict_dst row_format_option compression_name merge_engine_types
 %type <node> opt_hint_list hint_option select_with_opt_hint update_with_opt_hint delete_with_opt_hint hint_list_with_end global_hint transform_hint optimize_hint
 %type <node> create_index_stmt index_name sort_column_list sort_column_key opt_index_option_list opt_fulltext_index_option_list index_option fulltext_index_option opt_sort_column_key_length opt_index_using_algorithm index_using_algorithm visibility_option opt_constraint_name constraint_name create_with_opt_hint index_expr alter_with_opt_hint
 %type <node> opt_when check_state constraint_definition
@@ -6864,6 +6864,11 @@ TABLE_MODE opt_equal_mark STRING_VALUE
   (void)($2);
   malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_MODE, 1, $3);
 }
+| FULLTEXT_DICT opt_equal_mark STRING_VALUE
+{
+  (void)($2);
+  malloc_non_terminal_node($$, result->malloc_pool_, T_FULLTEXT_DICT, 1, $3);
+}
 | DUPLICATE_SCOPE opt_equal_mark STRING_VALUE
 {
   (void)($2);
@@ -7419,6 +7424,22 @@ relation_name
 | ALL
 {
   make_name_node($$, result->malloc_pool_, "all");
+}
+;
+
+refresh_fulltext_dict_dst:
+relation_name_or_string { $$ = $1; }
+| relation_name '.' relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_RELATION_FACTOR, 2, $1, $3);
+  dup_node_string($3, $$, result->malloc_pool_);
+}
+| id_dot_id
+{
+  ParseNode *db_node = $1->children_[0];
+  ParseNode *tb_node = $1->children_[1];
+  malloc_non_terminal_node($$, result->malloc_pool_, T_RELATION_FACTOR, 2, db_node, tb_node);
+  dup_node_string(tb_node, $$, result->malloc_pool_);
 }
 ;
 
@@ -18457,6 +18478,12 @@ alter_with_opt_hint SYSTEM REFRESH IO CALIBRATION opt_storage_name opt_calibrati
   malloc_non_terminal_node($$, result->malloc_pool_, T_REFRESH_IO_CALIBRATION, 3, $6, $7, NULL);
 }
 |
+alter_with_opt_hint SYSTEM REFRESH FULLTEXT DICT refresh_fulltext_dict_dst
+{
+  (void)($1);
+  malloc_non_terminal_node($$, result->malloc_pool_, T_REFRESH_FULLTEXT_DICT, 1, $6);
+}
+|
 alter_with_opt_hint SYSTEM opt_set alter_system_set_parameter_actions
 {
   (void)($1);
@@ -22175,6 +22202,7 @@ ACCESS_INFO
 |       DESCRIPTION
 |       DEMAND
 |       DIAGNOSTICS
+|       DICT
 |       DICT_TABLE
 |       DIFF
 |       DIRECTORY
@@ -22265,6 +22293,7 @@ ACCESS_INFO
 |       FREQUENCY
 |       FUNCTION
 |       FULL %prec HIGHER_PARENS
+|       FULLTEXT_DICT
 |       GENERAL
 |       GEOMETRY
 |       GEOMCOLLECTION

--- a/src/sql/printer/ob_schema_printer.cpp
+++ b/src/sql/printer/ob_schema_printer.cpp
@@ -1516,6 +1516,12 @@ int ObSchemaPrinter::print_table_definition_table_options(const ObTableSchema &t
       SHARE_SCHEMA_LOG(WARN, "fail to print collate", K(ret), K(table_schema));
     }
   }
+  if (OB_SUCC(ret) && !strict_compat_ && !is_for_table_status && !is_index_tbl
+      && !is_no_table_options(sql_mode) && table_schema.is_fulltext_dict()) {
+    if (OB_FAIL(databuff_printf(buf, buf_len, pos, "FULLTEXT_DICT = 'Y' "))) {
+      SHARE_SCHEMA_LOG(WARN, "fail to print fulltext dictionary option", K(ret), K(table_schema));
+    }
+  }
   if (OB_SUCC(ret) && table_schema.is_fts_index()
       && !is_no_key_options(sql_mode) && !table_schema.get_parser_name_str().empty()) {
     if (OB_FAIL(ObFtsIndexSchemaPrinter::print_fts_parser_info(table_schema, strict_compat_, buf, buf_len, pos))) {

--- a/src/sql/resolver/cmd/ob_alter_system_resolver.cpp
+++ b/src/sql/resolver/cmd/ob_alter_system_resolver.cpp
@@ -1145,6 +1145,82 @@ int ObRefreshMemStatResolver::resolve(const ParseNode &parse_tree)
   return ret;
 }
 
+int ObRefreshFulltextDictResolver::resolve(const ParseNode &parse_tree)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(T_REFRESH_FULLTEXT_DICT != parse_tree.type_)
+      || OB_ISNULL(parse_tree.children_)
+      || parse_tree.num_child_ < 1
+      || OB_ISNULL(parse_tree.children_[0])) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid refresh fulltext dictionary parse tree", K(ret), K(parse_tree.type_));
+  } else {
+    ObRefreshFulltextDictStmt *stmt = create_stmt<ObRefreshFulltextDictStmt>();
+    const ParseNode *relation_node = parse_tree.children_[0];
+    ObString database_name;
+    ObString table_name;
+    if (OB_ISNULL(stmt)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else {
+      stmt_ = stmt;
+      if (T_RELATION_FACTOR == relation_node->type_) {
+        if (relation_node->num_child_ < 2
+            || OB_ISNULL(relation_node->children_[0])
+            || OB_ISNULL(relation_node->children_[1])) {
+          ret = OB_ERR_UNEXPECTED;
+        } else {
+          database_name.assign_ptr(relation_node->children_[0]->str_value_,
+                                   relation_node->children_[0]->str_len_);
+          table_name.assign_ptr(relation_node->children_[1]->str_value_,
+                                relation_node->children_[1]->str_len_);
+        }
+      } else if (T_VARCHAR == relation_node->type_ || T_CHAR == relation_node->type_) {
+        ObString full_name;
+        if (OB_FAIL(Util::resolve_string(relation_node, full_name))) {
+          LOG_WARN("fail to resolve dictionary table string", K(ret));
+        } else {
+          const char *dot = full_name.find('.');
+          if (OB_ISNULL(dot)) {
+            table_name = full_name;
+          } else {
+            database_name.assign_ptr(full_name.ptr(), static_cast<int32_t>(dot - full_name.ptr()));
+            table_name.assign_ptr(dot + 1,
+                static_cast<int32_t>(full_name.length() - (dot - full_name.ptr()) - 1));
+          }
+        }
+      } else if (T_IDENT == relation_node->type_) {
+        if (OB_FAIL(Util::resolve_relation_name(relation_node, table_name))) {
+          LOG_WARN("fail to resolve dictionary table identifier", K(ret));
+        }
+      } else {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected dictionary table node", K(ret), K(relation_node->type_));
+      }
+
+      if (OB_FAIL(ret)) {
+      } else if (database_name.empty()) {
+        if (OB_ISNULL(session_info_)) {
+          ret = OB_ERR_UNEXPECTED;
+        } else if (FALSE_IT(database_name = session_info_->get_database_name())) {
+        } else if (database_name.empty()) {
+          ret = OB_ERR_NO_DB_SELECTED;
+          LOG_USER_ERROR(OB_ERR_NO_DB_SELECTED);
+        }
+      }
+      if (OB_SUCC(ret)) {
+        if (database_name.empty() || table_name.empty() || OB_NOT_NULL(table_name.find('.'))) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name must be [database.]table");
+        } else {
+          stmt->set_database_name(database_name);
+          stmt->set_table_name(table_name);
+        }
+      }
+    }
+  }
+  return ret;
+}
+
 int ObWashMemFragmentationResolver::resolve(const ParseNode &parse_tree)
 {
   int ret = OB_SUCCESS;

--- a/src/sql/resolver/cmd/ob_alter_system_resolver.h
+++ b/src/sql/resolver/cmd/ob_alter_system_resolver.h
@@ -96,6 +96,8 @@ DEF_SIMPLE_CMD_RESOLVER(ObAdminMergeResolver);
 
 DEF_SIMPLE_CMD_RESOLVER(ObRefreshMemStatResolver);
 
+DEF_SIMPLE_CMD_RESOLVER(ObRefreshFulltextDictResolver);
+
 DEF_SIMPLE_CMD_RESOLVER(ObWashMemFragmentationResolver);
 
 DEF_SIMPLE_CMD_RESOLVER(ObRefreshIOCalibrationResolver);

--- a/src/sql/resolver/cmd/ob_alter_system_stmt.h
+++ b/src/sql/resolver/cmd/ob_alter_system_stmt.h
@@ -169,6 +169,26 @@ private:
   obcall::ObAdminRefreshMemStatArg rpc_arg_;
 };
 
+class ObRefreshFulltextDictStmt : public ObSystemCmdStmt
+{
+public:
+  ObRefreshFulltextDictStmt()
+      : ObSystemCmdStmt(stmt::T_REFRESH_FULLTEXT_DICT), database_name_(), table_name_()
+  {
+  }
+  virtual ~ObRefreshFulltextDictStmt() {}
+
+  const common::ObString &get_database_name() const { return database_name_; }
+  const common::ObString &get_table_name() const { return table_name_; }
+  void set_database_name(const common::ObString &database_name) { database_name_ = database_name; }
+  void set_table_name(const common::ObString &table_name) { table_name_ = table_name; }
+
+  TO_STRING_KV(N_STMT_TYPE, ((int)stmt_type_), K_(database_name), K_(table_name));
+private:
+  common::ObString database_name_;
+  common::ObString table_name_;
+};
+
 class ObWashMemFragmentationStmt : public ObSystemCmdStmt
 {
 public:

--- a/src/sql/resolver/ddl/ob_alter_table_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_alter_table_resolver.cpp
@@ -166,6 +166,10 @@ int ObAlterTableResolver::resolve(const ParseNode &parse_tree)
         } else if (1 == parse_tree.value_ && OB_ISNULL(index_schema_)) {
           ret = OB_ERR_UNEXPECTED;
           LOG_WARN("table schema is NULL", K(ret));
+        } else if (table_schema_->is_fulltext_dict()) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "alter fulltext dictionary table structure is");
+          LOG_WARN("alter fulltext dictionary table is not supported", K(ret), KPC(table_schema_));
         }
       }
     }

--- a/src/sql/resolver/ddl/ob_ddl_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_ddl_resolver.cpp
@@ -1602,9 +1602,13 @@ int ObDDLResolver::resolve_table_option(const ParseNode *option_node, const bool
         break;
       }
       case T_PARSER_PROPERTIES: {
-        if (OB_FAIL(ObFTParserResolverHelper::resolve_parser_properties(*option_node,
-                                                                               *allocator_,
-                                                                               parser_properties_))) {
+        if (OB_FAIL(ObFTParserResolverHelper::resolve_parser_properties(
+                database_name_,
+                *option_node,
+                common::OB_SERVER_TENANT_ID,
+                *allocator_,
+                schema_checker_,
+                parser_properties_))) {
           LOG_WARN("fail to resolve parser properties", K(ret));
         }
         break;
@@ -1732,6 +1736,29 @@ int ObDDLResolver::resolve_table_option(const ParseNode *option_node, const bool
               table_mode_.pk_exists_ = tbl_schema->get_table_mode_struct().pk_exists_;
               table_mode_.table_organization_mode_ = tbl_schema->get_table_mode_struct().table_organization_mode_;
             }
+          }
+        }
+        break;
+      }
+      case T_FULLTEXT_DICT: {
+        if (is_index_option) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "FULLTEXT_DICT in index option is");
+        } else if (OB_ISNULL(option_node->children_[0])) {
+          ret = OB_ERR_UNEXPECTED;
+          SQL_RESV_LOG(WARN, "option_node child is null", K(ret));
+        } else if (stmt::T_CREATE_TABLE != stmt_->get_stmt_type()) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "FULLTEXT_DICT outside CREATE TABLE is");
+        } else {
+          const ObString flag(static_cast<int32_t>(option_node->children_[0]->str_len_),
+                              option_node->children_[0]->str_value_);
+          if (0 != flag.case_compare("Y")) {
+            ret = OB_INVALID_ARGUMENT;
+            LOG_USER_ERROR(OB_INVALID_ARGUMENT, "FULLTEXT_DICT only accepts 'Y'");
+          } else {
+            ObCreateTableStmt *create_table_stmt = static_cast<ObCreateTableStmt *>(stmt_);
+            create_table_stmt->get_create_table_arg().schema_.set_fulltext_dict();
           }
         }
         break;
@@ -6847,6 +6874,10 @@ int ObDDLResolver::generate_global_index_schema(
     ObTableType table_type = table_schema->get_table_type();
     LOG_WARN("Not support to create index on non-normal table", K(ret), K(table_type),
              "arg", crt_idx_stmt->get_create_index_arg());
+  } else if (table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "create index on fulltext dictionary table is");
+    LOG_WARN("create index on fulltext dictionary table is not supported", K(ret), KPC(table_schema));
   } else {
     ObArray<ObColumnSchemaV2 *> gen_columns;
     ObCreateIndexArg &create_index_arg = crt_idx_stmt->get_create_index_arg();

--- a/src/sql/resolver/ddl/ob_fts_index_builder_util.cpp
+++ b/src/sql/resolver/ddl/ob_fts_index_builder_util.cpp
@@ -24,7 +24,11 @@
 #include "share/ob_server_struct.h"
 #include "rootserver/ob_root_service.h"
 #include "plugin/sys/ob_plugin_helper.h"
+#include "share/schema/ob_dependency_info.h"
 #include "share/schema/ob_schema_utils.h"  // relocated-definition owner
+#include "storage/fts/dict/ob_ft_dict_def.h"
+#include "storage/fts/ob_fts_parser_property.h"
+#include "storage/fts/ob_fts_plugin_helper.h"
 
 namespace oceanbase
 {
@@ -34,6 +38,48 @@ using namespace share::schema;
 
 namespace share
 {
+
+int ObFtsIndexBuilderUtil::check_fulltext_dict_schema(
+    const share::schema::ObTableSchema &table_schema,
+    const int64_t inline_index_count)
+{
+  int ret = OB_SUCCESS;
+  if (!table_schema.is_fulltext_dict()) {
+  } else if (table_schema.is_heap_organized_table()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "heap organization for fulltext dictionary table is");
+  } else if (inline_index_count > 0) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "inline index on fulltext dictionary table is");
+  } else if (table_schema.is_partitioned_table()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "partitioning fulltext dictionary table is");
+  } else if (1 != table_schema.get_column_count()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table must contain exactly one column");
+  } else {
+    const share::schema::ObColumnSchemaV2 *word_column = table_schema.get_column_schema("word");
+    if (OB_ISNULL(word_column)) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table must contain column 'word'");
+    } else if (!word_column->is_rowkey_column()
+               || 1 != table_schema.get_rowkey_column_num()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "column 'word' must be the only primary key column");
+    } else if (ObVarcharType != word_column->get_data_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "column 'word' must be varchar");
+    } else if (CHARSET_UTF8MB4 != word_column->get_charset_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table charset must be utf8mb4");
+    } else if (word_column->get_accuracy().get_length() < 1
+               || word_column->get_accuracy().get_length() > 500) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_USER_ERROR(OB_INVALID_ARGUMENT, "column 'word' varchar length must be in [1, 500]");
+    }
+  }
+  return ret;
+}
 namespace
 {
 bool get_function_args(const ObString &expr_string,
@@ -2199,6 +2245,122 @@ int ObFtsIndexBuilderUtil::try_load_and_lock_dictionary_tables(
           LOG_WARN("fail to lock all dictionaries", K(ret), K(1UL), K(dic_loader_handle));
         }
       }
+    }
+  }
+  return ret;
+}
+
+namespace
+{
+typedef int (storage::ObFTParserJsonProps::*DictTableIdGetter)(uint64_t &) const;
+
+int append_fts_dict_dependency(const storage::ObFTParserJsonProps &properties,
+                               const ObTableSchema &index_schema,
+                               const storage::ObFTDictType dict_type,
+                               DictTableIdGetter getter,
+                               ObIArray<ObDependencyInfo> &dependencies)
+{
+  int ret = OB_SUCCESS;
+  uint64_t dict_table_id = OB_INVALID_ID;
+  if (OB_FAIL((properties.*getter)(dict_table_id))) {
+    if (OB_SEARCH_NOT_FOUND == ret) {
+      ret = OB_SUCCESS;
+    } else {
+      LOG_WARN("fail to get dictionary table id from parser properties", K(ret), K(dict_type));
+    }
+  } else if (is_inner_table(dict_table_id)) {
+    // Built-in dictionaries are immutable inner tables and need no dependency row.
+  } else {
+    ObDependencyInfo dependency;
+    dependency.set_dep_obj_type(ObObjectType::INDEX);
+    dependency.set_ref_obj_id(dict_table_id);
+    dependency.set_ref_obj_type(ObObjectType::TABLE);
+    dependency.set_property(static_cast<uint64_t>(dict_type));
+    dependency.set_order(dependencies.count());
+    if (OB_FAIL(dependencies.push_back(dependency))) {
+      LOG_WARN("fail to append dictionary table dependency", K(ret), K(dict_table_id));
+    }
+  }
+  return ret;
+}
+} // namespace
+
+int ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+    const ObTableSchema &index_schema,
+    ObMySQLTransaction &trans)
+{
+  int ret = OB_SUCCESS;
+  storage::ObFTParser parser;
+  storage::ObFTParserJsonProps properties;
+  ObArray<ObDependencyInfo> dependencies;
+  const ObString &parser_name = index_schema.get_parser_name();
+  const ObString &parser_properties = index_schema.get_parser_property_str();
+
+  if (!index_schema.is_fts_index_aux() || parser_name.empty() || parser_properties.empty()) {
+  } else if (OB_FAIL(parser.parse_from_str(parser_name.ptr(), parser_name.length()))) {
+    LOG_WARN("fail to parse fulltext parser name", K(ret), K(parser_name));
+  } else if (!parser.is_ik()) {
+  } else if (OB_FAIL(properties.init())) {
+    LOG_WARN("fail to initialize parser properties", K(ret));
+  } else if (OB_FAIL(properties.parse_from_valid_str(parser_properties))) {
+    LOG_WARN("fail to parse fulltext parser properties", K(ret), K(parser_properties));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_MAIN,
+                 &storage::ObFTParserJsonProps::config_get_dict_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append main dictionary dependency", K(ret));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_QUAN,
+                 &storage::ObFTParserJsonProps::config_get_quantifier_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append quantifier dictionary dependency", K(ret));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_STOP,
+                 &storage::ObFTParserJsonProps::config_get_stopword_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append stopword dictionary dependency", K(ret));
+  } else if (!dependencies.empty()
+             && OB_FAIL(ObDependencyInfo::insert_dependency_infos(
+                    trans,
+                    dependencies,
+                    index_schema.get_table_id(),
+                    index_schema.get_schema_version(),
+                    index_schema.get_table_id()))) {
+    LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(index_schema));
+  }
+  return ret;
+}
+
+int ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+    const uint64_t dict_table_id,
+    ObMySQLTransaction &trans)
+{
+  int ret = OB_SUCCESS;
+  ObArray<ObDependencyInfo> dependencies;
+  bool is_in_use = false;
+  if (OB_INVALID_ID == dict_table_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table id", K(ret), K(dict_table_id));
+  } else if (OB_FAIL(ObDependencyInfo::collect_dep_infos(dict_table_id, trans, dependencies))) {
+    LOG_WARN("fail to collect dictionary table dependencies", K(ret), K(dict_table_id));
+  } else {
+    for (int64_t i = 0; !is_in_use && i < dependencies.count(); ++i) {
+      const ObDependencyInfo &dependency = dependencies.at(i);
+      is_in_use = ObObjectType::INDEX == dependency.get_dep_obj_type()
+                  && ObObjectType::TABLE == dependency.get_ref_obj_type()
+                  && dict_table_id == dependency.get_ref_obj_id();
+    }
+    if (is_in_use) {
+      ret = OB_OP_NOT_ALLOW;
+      LOG_WARN("cannot drop a fulltext dictionary table in use", K(ret), K(dict_table_id));
+      LOG_USER_ERROR(OB_OP_NOT_ALLOW,
+                     "drop fulltext dictionary table that is being used by fulltext index");
     }
   }
   return ret;

--- a/src/sql/resolver/ddl/ob_fts_index_builder_util.cpp
+++ b/src/sql/resolver/ddl/ob_fts_index_builder_util.cpp
@@ -23,6 +23,7 @@
 #include "storage/fts/dict/ob_dic_lock.h"
 #include "share/ob_server_struct.h"
 #include "rootserver/ob_root_service.h"
+#include "plugin/interface/ob_plugin_ftparser_intf.h"
 #include "plugin/sys/ob_plugin_helper.h"
 #include "share/schema/ob_dependency_info.h"
 #include "share/schema/ob_schema_utils.h"  // relocated-definition owner

--- a/src/sql/resolver/ddl/ob_fts_index_builder_util.h
+++ b/src/sql/resolver/ddl/ob_fts_index_builder_util.h
@@ -74,6 +74,9 @@ public:
   // Check if we can use rowkey instead of doc id.
   // if we want to add more types, make this one condition of them.
   static int determine_docid_type(const ObTableSchema &table_schema, ObDocIDType &doc_id_type);
+  static int check_fulltext_dict_schema(
+      const share::schema::ObTableSchema &table_schema,
+      const int64_t inline_index_count);
   static int check_need_doc_id(
       const ObTableSchema &table_schema,
       bool &need_doc_id);
@@ -154,6 +157,12 @@ public:
       bool &need_to_load_dic);
   static int try_load_and_lock_dictionary_tables(
       const ObTableSchema &index_schema,
+      ObMySQLTransaction &trans);
+  static int record_fts_dict_table_dependencies(
+      const ObTableSchema &index_schema,
+      ObMySQLTransaction &trans);
+  static int check_can_drop_dict_table(
+      const uint64_t dict_table_id,
       ObMySQLTransaction &trans);
   static int try_load_dictionary_for_all_tenants();
   static int check_supportability_for_loader_key(const ObString &parser_name,

--- a/src/sql/resolver/ddl/ob_fts_parser_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_fts_parser_resolver.cpp
@@ -16,6 +16,8 @@
 
 #include "storage/fts/ob_fts_literal.h"
 #include "storage/fts/ob_fts_parser_property.h"
+#include "lib/string/ob_sql_string.h"
+#include "sql/resolver/ob_schema_checker.h"
 #define USING_LOG_PREFIX STORAGE_FTS
 
 #include "sql/resolver/ddl/ob_fts_parser_resolver.h"
@@ -25,13 +27,88 @@ namespace oceanbase
 namespace sql
 {
 
-int ObFTParserResolverHelper::resolve_parser_properties(
-    const ParseNode &parse_tree,
+int ObFTParserResolverHelper::resolve_dict_table_name_and_id(
+    const common::ObString &index_database_name,
+    const common::ObString &table_name,
+    const uint64_t tenant_id,
+    share::schema::ObSchemaGetterGuard &schema_guard,
     common::ObIAllocator &allocator,
+    uint64_t &table_id,
+    common::ObString &full_table_name)
+{
+  int ret = OB_SUCCESS;
+  ObString database_name;
+  ObString parsed_table_name;
+  table_id = OB_INVALID_ID;
+  full_table_name.reset();
+  const char *dot = table_name.find('.');
+  if (table_name.empty() || OB_INVALID_TENANT_ID == tenant_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table argument", K(ret), K(table_name), K(tenant_id));
+  } else if (OB_NOT_NULL(dot)) {
+    database_name.assign_ptr(table_name.ptr(), static_cast<int32_t>(dot - table_name.ptr()));
+    parsed_table_name.assign_ptr(dot + 1,
+        static_cast<int32_t>(table_name.length() - (dot - table_name.ptr()) - 1));
+    if (database_name.empty() || parsed_table_name.empty()
+        || OB_NOT_NULL(parsed_table_name.find('.'))) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name must be [database.]table");
+    }
+  } else if (index_database_name.empty()) {
+    ret = OB_ERR_NO_DB_SELECTED;
+    LOG_USER_ERROR(OB_ERR_NO_DB_SELECTED);
+  } else {
+    database_name = index_database_name;
+    parsed_table_name = table_name;
+  }
+
+  const share::schema::ObTableSchema *table_schema = nullptr;
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(schema_guard.get_table_id(database_name,
+                                               parsed_table_name,
+                                               false,
+                                               share::schema::ObSchemaGetterGuard::ALL_NON_HIDDEN_TYPES,
+                                               table_id))) {
+    LOG_WARN("fail to resolve dictionary table id", K(ret), K(database_name), K(parsed_table_name));
+  } else if (OB_INVALID_ID == table_id) {
+    ret = OB_ERR_UNKNOWN_TABLE;
+    LOG_USER_ERROR(OB_ERR_UNKNOWN_TABLE,
+                   parsed_table_name.length(), parsed_table_name.ptr(),
+                   database_name.length(), database_name.ptr());
+  } else if (OB_FAIL(schema_guard.get_table_schema(table_id, table_schema))) {
+    LOG_WARN("fail to get dictionary table schema", K(ret), K(table_id));
+  } else if (OB_ISNULL(table_schema)) {
+    ret = OB_TABLE_NOT_EXIST;
+  } else if (!table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "using a non-fulltext-dictionary table as dictionary is");
+  } else {
+    const int64_t buffer_size = database_name.length() + parsed_table_name.length() + 2;
+    char *buffer = static_cast<char *>(allocator.alloc(buffer_size));
+    int64_t pos = 0;
+    if (OB_ISNULL(buffer)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else if (OB_FAIL(databuff_printf(buffer, buffer_size, pos, "%.*s.%.*s",
+                                      database_name.length(), database_name.ptr(),
+                                      parsed_table_name.length(), parsed_table_name.ptr()))) {
+      LOG_WARN("fail to construct dictionary table name", K(ret));
+    } else {
+      full_table_name.assign_ptr(buffer, static_cast<int32_t>(pos));
+    }
+  }
+  return ret;
+}
+
+int ObFTParserResolverHelper::resolve_parser_properties(
+    const common::ObString &index_database_name,
+    const ParseNode &parse_tree,
+    const uint64_t tenant_id,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker *schema_checker,
     common::ObString &parser_property)
 {
   int ret = OB_SUCCESS;
-  if (OB_UNLIKELY(parse_tree.num_child_ <= 0)) {
+  if (OB_UNLIKELY(parse_tree.num_child_ <= 0) || OB_ISNULL(schema_checker)) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument, parser properties is empty", K(ret), K(parse_tree.num_child_));
   } else {
@@ -44,7 +121,12 @@ int ObFTParserResolverHelper::resolve_parser_properties(
       if (OB_ISNULL(parse_tree.children_[i])) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("option_node child is nullptr", K(ret));
-      } else if (OB_FAIL(resolve_fts_index_parser_properties(parse_tree.children_[i], property))) {
+      } else if (OB_FAIL(resolve_fts_index_parser_properties(index_database_name,
+                                                             parse_tree.children_[i],
+                                                             tenant_id,
+                                                             property,
+                                                             allocator,
+                                                             *schema_checker))) {
         LOG_WARN("fail to resolve fts index parser properties", K(ret));
       }
     }
@@ -57,8 +139,12 @@ int ObFTParserResolverHelper::resolve_parser_properties(
 }
 
 int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
+    const common::ObString &index_database_name,
     const ParseNode *node,
-    storage::ObFTParserJsonProps &property)
+    const uint64_t tenant_id,
+    storage::ObFTParserJsonProps &property,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker &schema_checker)
 {
   int ret = OB_SUCCESS;
   if (OB_ISNULL(node) || node->num_child_ != 1 || OB_ISNULL(node->children_[0])){
@@ -115,54 +201,24 @@ int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
         break;
       }
       case T_PARSER_STOPWORD_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the stopword table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_stopword_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set stopword table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_stopword_table,
+                                   &storage::ObFTParserJsonProps::config_set_stopword_table_id);
         break;
       }
       case T_PARSER_DICT_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the dict table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_dict_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set dict table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_dict_table,
+                                   &storage::ObFTParserJsonProps::config_set_dict_table_id);
         break;
       }
       case T_PARSER_QUANTIFIER_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the quanitfier table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_quantifier_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set quantifier table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_quantifier_table,
+                                   &storage::ObFTParserJsonProps::config_set_quantifier_table_id);
         break;
       }
       case T_IK_MODE: {
@@ -230,6 +286,43 @@ int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
         ret = OB_INVALID_ARGUMENT;
         LOG_WARN("invalid fts index parser properties option", K(ret), K(node->type_));
       }
+    }
+  }
+  return ret;
+}
+
+int ObFTParserResolverHelper::resolve_table_config(
+    const common::ObString &index_database_name,
+    const ParseNode *node,
+    const uint64_t tenant_id,
+    storage::ObFTParserJsonProps &property,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker &schema_checker,
+    int (storage::ObFTParserJsonProps::*set_name)(const common::ObString &),
+    int (storage::ObFTParserJsonProps::*set_id)(const uint64_t))
+{
+  int ret = OB_SUCCESS;
+  uint64_t table_id = OB_INVALID_ID;
+  ObString full_table_name;
+  if (OB_ISNULL(node) || OB_ISNULL(node->children_) || OB_ISNULL(node->children_[0])
+      || node->children_[0]->str_len_ <= 0 || OB_ISNULL(schema_checker.get_schema_guard())) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name is empty");
+  } else {
+    const ObString table_name(static_cast<int32_t>(node->children_[0]->str_len_),
+                              node->children_[0]->str_value_);
+    if (OB_FAIL(resolve_dict_table_name_and_id(index_database_name,
+                                               table_name,
+                                               tenant_id,
+                                               *schema_checker.get_schema_guard(),
+                                               allocator,
+                                               table_id,
+                                               full_table_name))) {
+      LOG_WARN("fail to resolve dictionary table", K(ret), K(table_name));
+    } else if (OB_FAIL((property.*set_name)(full_table_name))) {
+      LOG_WARN("fail to set dictionary table name", K(ret), K(full_table_name));
+    } else if (OB_FAIL((property.*set_id)(table_id))) {
+      LOG_WARN("fail to set dictionary table id", K(ret), K(table_id));
     }
   }
   return ret;

--- a/src/sql/resolver/ddl/ob_fts_parser_resolver.h
+++ b/src/sql/resolver/ddl/ob_fts_parser_resolver.h
@@ -20,11 +20,13 @@
 #include "sql/resolver/ddl/ob_ddl_resolver.h"
 #include "storage/fts/ob_fts_parser_property.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
+#include "share/schema/ob_schema_getter_guard.h"
 
 namespace oceanbase
 {
 namespace sql
 {
+class ObSchemaChecker;
 class ObFTParserResolverHelper final
 {
 public:
@@ -32,13 +34,39 @@ public:
   ~ObFTParserResolverHelper() = default;
 
   static int resolve_parser_properties(
+      const common::ObString &index_database_name,
       const ParseNode &parse_tree,
+      const uint64_t tenant_id,
       common::ObIAllocator &allocator,
+      ObSchemaChecker *schema_checker,
       common::ObString &parser_property);
 
+  static int resolve_dict_table_name_and_id(
+      const common::ObString &index_database_name,
+      const common::ObString &table_name,
+      const uint64_t tenant_id,
+      share::schema::ObSchemaGetterGuard &schema_guard,
+      common::ObIAllocator &allocator,
+      uint64_t &table_id,
+      common::ObString &full_table_name);
+
 private:
-  static int resolve_fts_index_parser_properties(const ParseNode *node,
-                                                 storage::ObFTParserJsonProps &property);
+  static int resolve_fts_index_parser_properties(
+      const common::ObString &index_database_name,
+      const ParseNode *node,
+      const uint64_t tenant_id,
+      storage::ObFTParserJsonProps &property,
+      common::ObIAllocator &allocator,
+      ObSchemaChecker &schema_checker);
+  static int resolve_table_config(
+      const common::ObString &index_database_name,
+      const ParseNode *node,
+      const uint64_t tenant_id,
+      storage::ObFTParserJsonProps &property,
+      common::ObIAllocator &allocator,
+      ObSchemaChecker &schema_checker,
+      int (storage::ObFTParserJsonProps::*set_name)(const common::ObString &),
+      int (storage::ObFTParserJsonProps::*set_id)(const uint64_t));
 };
 
 } // end namespace sql

--- a/src/sql/resolver/ob_resolver.cpp
+++ b/src/sql/resolver/ob_resolver.cpp
@@ -365,6 +365,10 @@ int ObResolver::resolve(IsPrepared if_prepared, const ParseNode &parse_tree, ObS
         REGISTER_STMT_RESOLVER(RefreshMemStat);
         break;
       }
+      case T_REFRESH_FULLTEXT_DICT: {
+        REGISTER_STMT_RESOLVER(RefreshFulltextDict);
+        break;
+      }
       case T_WASH_MEMORY_FRAGMENTATION: {
         REGISTER_STMT_RESOLVER(WashMemFragmentation);
         break;

--- a/src/sql/resolver/ob_stmt_type.h
+++ b/src/sql/resolver/ob_stmt_type.h
@@ -347,6 +347,7 @@ OB_STMT_TYPE_DEF_UNKNOWN_AT(T_LOCATION_UTILS_LIST, no_priv_needed, 390)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_LOCATION_UTILS, no_priv_needed, 391)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_DIFF_TABLE, get_dml_stmt_need_privs, 392)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_MERGE_TABLE, get_merge_table_stmt_need_privs, 393)
+OB_STMT_TYPE_DEF_UNKNOWN_AT(T_REFRESH_FULLTEXT_DICT, get_sys_tenant_alter_system_priv, 394)
 
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_MAX, err_stmt_type_priv, 500)
 #endif

--- a/src/sql/rewrite/ob_transform_pre_process.cpp
+++ b/src/sql/rewrite/ob_transform_pre_process.cpp
@@ -4625,11 +4625,13 @@ int ObTransformPreProcess::preserve_order_for_fulltext_search(
   TableItem *table_item = NULL;
   ObRawExpr *match_expr = nullptr;
   bool parent_only_counts_rows = false;
+  bool can_prune_counted_projection = false;
+  ObSelectStmt *child_stmt = nullptr;
   if (OB_ISNULL(stmt)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected null", K(ret));
   } else if (parent_stmts.count() == 1 && stmt->is_select_stmt()) {
-    const ObSelectStmt *child_stmt = static_cast<const ObSelectStmt *>(stmt);
+    child_stmt = static_cast<ObSelectStmt *>(stmt);
     const ObDMLStmt *parent_stmt = parent_stmts.at(0).stmt_;
     if (OB_NOT_NULL(parent_stmt) && parent_stmt->is_select_stmt()) {
       const ObSelectStmt *parent_select = static_cast<const ObSelectStmt *>(parent_stmt);
@@ -4658,6 +4660,18 @@ int ObTransformPreProcess::preserve_order_for_fulltext_search(
           && OB_NOT_NULL(parent_table)
           && parent_table->is_generated_table()
           && parent_table->ref_query_ == child_stmt;
+      can_prune_counted_projection = parent_only_counts_rows
+          && !child_stmt->is_set_stmt()
+          && child_stmt->get_select_item_size() == 1
+          && OB_NOT_NULL(child_stmt->get_select_item(0).expr_)
+          && child_stmt->get_select_item(0).expr_->is_column_ref_expr()
+          && child_stmt->get_table_items().count() == 1
+          && child_stmt->get_order_item_size() == 0
+          && !child_stmt->has_group_by()
+          && !child_stmt->has_having()
+          && !child_stmt->has_distinct()
+          && !child_stmt->has_window_function()
+          && child_stmt->get_aggr_item_size() == 0;
     }
   }
 
@@ -4666,6 +4680,22 @@ int ObTransformPreProcess::preserve_order_for_fulltext_search(
     // COUNT(*) only observes the number of rows produced by LIMIT, not which
     // equally sized subset is selected.  Avoid the implicit relevance order
     // so the full-text scan can stop as soon as the limit is satisfied.
+    if (can_prune_counted_projection) {
+      ObConstRawExpr *one_expr = nullptr;
+      if (OB_ISNULL(ctx_) || OB_ISNULL(ctx_->expr_factory_)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("transform context is null", K(ret), KP(ctx_));
+      } else if (OB_FAIL(ObRawExprUtils::build_const_int_expr(
+                     *ctx_->expr_factory_, ObIntType, 1, one_expr))) {
+        LOG_WARN("failed to build constant projection", K(ret));
+      } else {
+        // The parent does not consume the generated-table column.  Replacing
+        // it with a constant lets the FTS scan satisfy LIMIT without fetching
+        // base-table rows only to discard their values in COUNT(*).
+        child_stmt->get_select_item(0).expr_ = one_expr;
+        trans_happened = true;
+      }
+    }
   } else if (stmt->get_table_items().count() != 1 || stmt->get_order_item_size() != 0) {
     // do nothing
   } else if (stmt->is_select_stmt() && 

--- a/src/sql/rewrite/ob_transform_pre_process.cpp
+++ b/src/sql/rewrite/ob_transform_pre_process.cpp
@@ -238,7 +238,7 @@ int ObTransformPreProcess::transform_one_stmt(common::ObIArray<ObParentDMLStmt> 
     }
     if (OB_SUCC(ret)) {
       if (stmt->get_match_exprs().count() > 0 &&
-          OB_FAIL(preserve_order_for_fulltext_search(stmt, is_happened))) {
+          OB_FAIL(preserve_order_for_fulltext_search(parent_stmts, stmt, is_happened))) {
         LOG_WARN("failed to preserve order for fulltext search", K(ret));
       } else {
         trans_happened |= is_happened;
@@ -4615,15 +4615,57 @@ int ObTransformPreProcess::do_flatten_conditions(ObDMLStmt *stmt, ObIArray<ObRaw
 
 // full-text index queries on a single base table are processed with order preservation. 
 // (Order is not preserved in multi-table join scenarios.)
-int ObTransformPreProcess::preserve_order_for_fulltext_search(ObDMLStmt *stmt, bool& trans_happened)
+int ObTransformPreProcess::preserve_order_for_fulltext_search(
+    const ObIArray<ObParentDMLStmt> &parent_stmts,
+    ObDMLStmt *stmt,
+    bool &trans_happened)
 {
   int ret = OB_SUCCESS;
   trans_happened = false;
   TableItem *table_item = NULL;
   ObRawExpr *match_expr = nullptr;
+  bool parent_only_counts_rows = false;
   if (OB_ISNULL(stmt)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected null", K(ret));
+  } else if (parent_stmts.count() == 1 && stmt->is_select_stmt()) {
+    const ObSelectStmt *child_stmt = static_cast<const ObSelectStmt *>(stmt);
+    const ObDMLStmt *parent_stmt = parent_stmts.at(0).stmt_;
+    if (OB_NOT_NULL(parent_stmt) && parent_stmt->is_select_stmt()) {
+      const ObSelectStmt *parent_select = static_cast<const ObSelectStmt *>(parent_stmt);
+      const ObAggFunRawExpr *count_expr = parent_select->get_aggr_item_size() == 1
+          ? parent_select->get_aggr_item(0) : nullptr;
+      const TableItem *parent_table = parent_select->get_table_size() == 1
+          ? parent_select->get_table_item(0) : nullptr;
+      parent_only_counts_rows = child_stmt->has_limit()
+          && !child_stmt->is_calc_found_rows()
+          && !child_stmt->is_fetch_with_ties()
+          && OB_ISNULL(child_stmt->get_limit_percent_expr())
+          && parent_select->is_scala_group_by()
+          && parent_select->get_select_item_size() == 1
+          && parent_select->get_from_item_size() == 1
+          && parent_select->get_condition_exprs().empty()
+          && !parent_select->has_having()
+          && !parent_select->has_order_by()
+          && !parent_select->has_distinct()
+          && !parent_select->has_window_function()
+          && !parent_select->has_limit()
+          && !parent_select->has_select_into()
+          && OB_NOT_NULL(count_expr)
+          && count_expr->get_expr_type() == T_FUN_COUNT
+          && count_expr->get_real_param_count() == 0
+          && parent_select->get_select_item(0).expr_ == count_expr
+          && OB_NOT_NULL(parent_table)
+          && parent_table->is_generated_table()
+          && parent_table->ref_query_ == child_stmt;
+    }
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (parent_only_counts_rows) {
+    // COUNT(*) only observes the number of rows produced by LIMIT, not which
+    // equally sized subset is selected.  Avoid the implicit relevance order
+    // so the full-text scan can stop as soon as the limit is satisfied.
   } else if (stmt->get_table_items().count() != 1 || stmt->get_order_item_size() != 0) {
     // do nothing
   } else if (stmt->is_select_stmt() && 

--- a/src/sql/rewrite/ob_transform_pre_process.h
+++ b/src/sql/rewrite/ob_transform_pre_process.h
@@ -383,7 +383,10 @@ private:
   int check_exec_param_correlated(const ObRawExpr *expr, bool &is_correlated);
   int check_is_correlated_cte(ObSelectStmt *stmt, ObIArray<ObSelectStmt *> &visited_cte, bool &is_correlated);
   int convert_join_preds_vector_to_scalar(JoinedTable &joined_table, bool &trans_happened);
-  int preserve_order_for_fulltext_search(ObDMLStmt *stmt, bool& trans_happened);
+  int preserve_order_for_fulltext_search(
+      const common::ObIArray<ObParentDMLStmt> &parent_stmts,
+      ObDMLStmt *stmt,
+      bool &trans_happened);
 
   int flatten_conditions(ObDMLStmt *stmt, bool &trans_happened);
   int recursive_flatten_join_conditions(ObDMLStmt *stmt, TableItem *table, bool &trans_happened);

--- a/src/sql/rewrite/ob_transform_utils.cpp
+++ b/src/sql/rewrite/ob_transform_utils.cpp
@@ -14771,6 +14771,63 @@ bool ObTransformUtils::is_full_group_by(ObSelectStmt& stmt, ObSQLMode mode)
   return !stmt.has_order_by() && is_only_full_group_by_on(mode);
 }
 
+int ObTransformUtils::check_need_calc_match_score(ObExecContext *exec_ctx,
+                                                  const ObDMLStmt *stmt,
+                                                  ObRawExpr *match_expr,
+                                                  bool &need_calc,
+                                                  ObIArray<ObExprConstraint> &constraints)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<ObRawExpr *, 16> relation_exprs;
+  need_calc = false;
+  if (OB_ISNULL(exec_ctx) || OB_ISNULL(stmt) || OB_ISNULL(match_expr)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid argument", K(ret), KP(exec_ctx), KP(stmt), KP(match_expr));
+  } else if (OB_FAIL(stmt->get_relation_exprs(relation_exprs))) {
+    LOG_WARN("failed to get statement relation expressions", K(ret));
+  }
+  for (int64_t i = 0; OB_SUCC(ret) && !need_calc && i < relation_exprs.count(); ++i) {
+    ObSEArray<ObMatchFunRawExpr *, 2> curr_match_exprs;
+    bool contains_match_expr = false;
+    bool used_as_condition = false;
+    bool relation_need_calc = false;
+    if (OB_FAIL(ObRawExprUtils::extract_match_exprs(relation_exprs.at(i), curr_match_exprs))) {
+      LOG_WARN("failed to extract match expressions", K(ret), K(i));
+    }
+    for (int64_t j = 0; OB_SUCC(ret) && !contains_match_expr && j < curr_match_exprs.count(); ++j) {
+      contains_match_expr = curr_match_exprs.at(j) == match_expr;
+    }
+    if (OB_FAIL(ret) || !contains_match_expr) {
+      // skip expressions that do not reference the target MATCH expression
+    } else {
+      if (ObOptimizerUtil::find_item(stmt->get_condition_exprs(), relation_exprs.at(i))) {
+        used_as_condition = true;
+      } else if (stmt->is_select_stmt() && ObOptimizerUtil::find_item(
+          static_cast<const ObSelectStmt *>(stmt)->get_having_exprs(), relation_exprs.at(i))) {
+        used_as_condition = true;
+      } else if (OB_FAIL(check_expr_used_as_condition(stmt,
+                                                      relation_exprs.at(i),
+                                                      match_expr,
+                                                      used_as_condition))) {
+        LOG_WARN("failed to check whether match expression is used as a condition", K(ret), K(i));
+      }
+      if (OB_FAIL(ret)) {
+      } else if (!used_as_condition) {
+        need_calc = true;
+      } else if (OB_FAIL(inner_check_need_calc_match_score(exec_ctx,
+                                                           relation_exprs.at(i),
+                                                           match_expr,
+                                                           relation_need_calc,
+                                                           constraints))) {
+        LOG_WARN("failed to check whether match score is used", K(ret), K(i));
+      } else if (relation_need_calc) {
+        need_calc = true;
+      }
+    }
+  }
+  return ret;
+}
+
 int ObTransformUtils::inner_check_need_calc_match_score(ObExecContext *exec_ctx,
                                                         ObRawExpr* expr, 
                                                         ObRawExpr* match_expr, 
@@ -14876,7 +14933,7 @@ int ObTransformUtils::check_expr_eq_zero(ObExecContext *ctx,
   return ret;
 }
 
-int ObTransformUtils::check_expr_used_as_condition(ObDMLStmt *stmt, 
+int ObTransformUtils::check_expr_used_as_condition(const ObDMLStmt *stmt,
                                                   ObRawExpr *root_expr, 
                                                   ObRawExpr *expr, 
                                                   bool &used_as_condition)
@@ -14894,7 +14951,7 @@ int ObTransformUtils::check_expr_used_as_condition(ObDMLStmt *stmt,
   } else if (ObOptimizerUtil::find_item(stmt->get_condition_exprs(), cur_expr)) {
     parent_as_condition = true;
   } else if (stmt->is_select_stmt() && ObOptimizerUtil::find_item(
-             static_cast<ObSelectStmt*>(stmt)->get_having_exprs(), cur_expr)) {
+             static_cast<const ObSelectStmt*>(stmt)->get_having_exprs(), cur_expr)) {
     parent_as_condition = true;
   }
   if (OB_SUCC(ret)) {

--- a/src/sql/rewrite/ob_transform_utils.h
+++ b/src/sql/rewrite/ob_transform_utils.h
@@ -1885,6 +1885,11 @@ public:
   static int check_contain_lost_deterministic_expr(const ObIArray<ObRawExpr*> &exprs,
                                                    bool &is_contain);
   // check whether the score calculated by match expr is actually utilized
+  static int check_need_calc_match_score(ObExecContext *exec_ctx,
+                                         const ObDMLStmt *stmt,
+                                         ObRawExpr *match_expr,
+                                         bool &need_calc,
+                                         ObIArray<ObExprConstraint> &constraints);
   static int check_expr_eq_zero(ObExecContext *ctx,
                                 ObRawExpr *expr, 
                                 bool &eq_zero, 
@@ -1893,7 +1898,7 @@ public:
                                            const ObIArray<ObRawExpr*> &raw_having_exprs,
                                            const ObIArray<ObRawExpr*> &group_clause_exprs,
                                            ObIArray<ObRawExpr*> &having_exprs_for_deduce);
-  static int check_expr_used_as_condition(ObDMLStmt *stmt, 
+  static int check_expr_used_as_condition(const ObDMLStmt *stmt,
                                           ObRawExpr *root_expr, 
                                           ObRawExpr *expr,
                                           bool &used_as_condition);

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -286,6 +286,8 @@ ob_set_subtarget(ob_storage fts
   fts/ob_fts_doc_word_iterator.cpp
   fts/ob_fts_parser_property.cpp
   fts/ob_fts_plugin_helper.cpp
+  fts/ob_ft_token_processor.cpp
+  fts/ob_fts_stop_token_check.cpp
   fts/ob_fts_stop_word.cpp
   fts/ob_fts_struct.cpp
   fts/ob_ngram_ft_parser.cpp

--- a/src/storage/fts/dict/ob_ft_cache.h
+++ b/src/storage/fts/dict/ob_ft_cache.h
@@ -36,10 +36,11 @@ namespace storage
 class ObDictCacheKey : public common::ObIKVCacheKey
 {
 public:
-  ObDictCacheKey(const uint64_t name,
-                 const ObFTDictType dict_type,
-                 int32_t range_id)
-      : name_(name), dict_type_(dict_type), range_id_(range_id)
+  ObDictCacheKey(const uint64_t tenant_id,
+                 const uint64_t table_id,
+                 const uint64_t generation,
+                 const int32_t range_id)
+      : tenant_id_(tenant_id), table_id_(table_id), generation_(generation), range_id_(range_id)
   {
   }
   ~ObDictCacheKey() override {}
@@ -48,14 +49,18 @@ public:
   {
     const ObDictCacheKey &other_key = reinterpret_cast<const ObDictCacheKey &>(other);
     return (&other == this)
-           || ((other_key.name_ == name_) && (other_key.dict_type_ == dict_type_));
+           || (other_key.tenant_id_ == tenant_id_
+               && other_key.table_id_ == table_id_
+               && other_key.generation_ == generation_
+               && other_key.range_id_ == range_id_);
   }
 
   uint64_t hash() const override
   {
     uint64_t hash_val = 0;
-    hash_val = murmurhash(&name_, sizeof(name_), hash_val);
-    hash_val = murmurhash(&dict_type_, sizeof(dict_type_), hash_val);
+    hash_val = murmurhash(&tenant_id_, sizeof(tenant_id_), hash_val);
+    hash_val = murmurhash(&table_id_, sizeof(table_id_), hash_val);
+    hash_val = murmurhash(&generation_, sizeof(generation_), hash_val);
     hash_val = murmurhash(&range_id_, sizeof(range_id_), hash_val);
     return hash_val;
   }
@@ -80,17 +85,18 @@ public:
       ret = OB_INVALID_ARGUMENT;
       CLOG_LOG(WARN, "invalid argument for ob dict cache", K(ret), K(buf_len), K(size()));
     } else {
-      ObDictCacheKey *new_key = new (buf) ObDictCacheKey(name_, dict_type_, range_id_);
+      ObDictCacheKey *new_key = new (buf) ObDictCacheKey(
+          tenant_id_, table_id_, generation_, range_id_);
       key = new_key;
     }
     return ret;
   }
 
-  TO_STRING_KV(K_(name), K_(dict_type), K_(range_id));
+  TO_STRING_KV(K_(tenant_id), K_(table_id), K_(generation), K_(range_id));
 private:
-  // to change to name
-  uint64_t name_; // when build dict
-  ObFTDictType dict_type_;
+  uint64_t tenant_id_;
+  uint64_t table_id_;
+  uint64_t generation_;
   int32_t range_id_;
 };
 

--- a/src/storage/fts/dict/ob_ft_cache_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_cache_dict.cpp
@@ -87,8 +87,8 @@ int ObFTCacheDict::make_and_fetch_cache_entry(const ObFTDictDesc &desc,
 {
   int ret = OB_SUCCESS;
   ObDictCache &cache = ObDictCache::get_instance();
-  uint64_t name = static_cast<uint64_t>(desc.type_);
-  const ObDictCacheKey put_key(name, desc.type_, range_id);
+  const ObDictCacheKey put_key(
+      desc.tenant_id_, desc.table_id_, desc.generation_, range_id);
   const ObDictCacheValue put_value(dat_buff);
   if (OB_FAIL(cache.put_and_fetch_dict(put_key, put_value, value, handle))) {
     LOG_WARN("Failed to put dict into kv cache", K(ret));

--- a/src/storage/fts/dict/ob_ft_dat_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_dat_dict.cpp
@@ -39,7 +39,7 @@ int ObFTDATBuilder<DATA_TYPE>::init(ObFTTrie<DATA_TYPE> &trie)
     ret = OB_INIT_TWICE;
     LOG_WARN("Builder has already inited", K(ret));
   } else {
-    size_t map_size = ObArrayHashMap::estimate_size(trie.node_num());
+    size_t map_size = ObFTArrayHashMap::estimate_size(trie.node_num());
     size_t array_size = trie.node_num() * 6; // by experience.
     size_t base_size = array_size * sizeof(int32_t);
     size_t check_size = base_size;
@@ -305,9 +305,9 @@ int ObFTDATReader<DATA_TYPE>::match_with_hit(const ObString &ft_char,
 template class ObFTDATBuilder<void>;
 template class ObFTDATReader<void>;
 
-ObArrayHashMap *ObFTDAT::get_map() { return reinterpret_cast<ObArrayHashMap *>(buff); }
+ObFTArrayHashMap *ObFTDAT::get_map() { return reinterpret_cast<ObFTArrayHashMap *>(buff); }
 
-int ObArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
+int ObFTArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
 {
   int ret = OB_ENTRY_NOT_EXIST;
   uint64_t hash = word.get_word().hash();
@@ -324,7 +324,7 @@ int ObArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
   return ret;
 }
 
-int ObArrayHashMap::insert(const ObString &key, ObFTWordCode code)
+int ObFTArrayHashMap::insert(const ObString &key, ObFTWordCode code)
 {
   int ret = OB_SUCCESS;
   uint64_t hash = key.hash();
@@ -340,7 +340,7 @@ int ObArrayHashMap::insert(const ObString &key, ObFTWordCode code)
   return ret;
 }
 
-int ObArrayHashMap::init(size_t word_num)
+int ObFTArrayHashMap::init(size_t word_num)
 {
   int ret = OB_SUCCESS;
   size_t capacity = estimate_capacity(word_num);
@@ -353,14 +353,14 @@ int ObArrayHashMap::init(size_t word_num)
   return OB_SUCCESS;
 }
 
-size_t ObArrayHashMap::estimate_size(size_t word_num)
+size_t ObFTArrayHashMap::estimate_size(size_t word_num)
 {
   size_t capacity = estimate_capacity(word_num);
   size_t size = sizeof(Header) + capacity * sizeof(Entry);
   return size;
 }
 
-size_t ObArrayHashMap::estimate_capacity(size_t word_num)
+size_t ObFTArrayHashMap::estimate_capacity(size_t word_num)
 {
   constexpr size_t MIN_CAPACITY = 101;                   // prime
   size_t capacity = MAX(word_num * 4 / 3, MIN_CAPACITY); // 75%

--- a/src/storage/fts/dict/ob_ft_dat_dict.h
+++ b/src/storage/fts/dict/ob_ft_dat_dict.h
@@ -33,10 +33,10 @@ namespace oceanbase
 {
 namespace storage
 {
-/* @class ObArrayHashMap
+/* @class ObFTArrayHashMap
  * @description: a fixed size hash map, used to store words and their code.
  */
-class ObArrayHashMap final
+class ObFTArrayHashMap final
 {
 public:
   struct Entry
@@ -105,7 +105,7 @@ public:
   char buff[1] = {0};
 
 public:
-  ObArrayHashMap *get_map();
+  ObFTArrayHashMap *get_map();
 } __attribute__((packed));
 
 template <typename DataType>
@@ -150,7 +150,7 @@ private:
 private:
   common::ObIAllocator &alloc_;
   ObFTDAT *dat_;
-  ObArrayHashMap *map_;
+  ObFTArrayHashMap *map_;
 
   bool is_inited_;
   int32_t next_code_;

--- a/src/storage/fts/dict/ob_ft_dict_def.h
+++ b/src/storage/fts/dict/ob_ft_dict_def.h
@@ -64,15 +64,52 @@ public:
                const ObFTDictType type,
                const ObCharsetType charset,
                const ObCollationType coll_type)
-      : name_(name), type_(type), charset_(charset), coll_type_(coll_type)
+      : tenant_id_(1),
+        table_id_(static_cast<uint64_t>(type)),
+        table_name_(name),
+        type_(type),
+        charset_(charset),
+        coll_type_(coll_type),
+        generation_(0),
+        is_builtin_(true),
+        need_casedown_(false)
   {
   }
 
+  ObFTDictDesc(const uint64_t tenant_id,
+               const uint64_t table_id,
+               const ObString &table_name,
+               const ObFTDictType type,
+               const ObCharsetType charset,
+               const ObCollationType coll_type,
+               const bool is_builtin,
+               const bool need_casedown)
+      : tenant_id_(tenant_id),
+        table_id_(table_id),
+        table_name_(table_name),
+        type_(type),
+        charset_(charset),
+        coll_type_(coll_type),
+        generation_(0),
+        is_builtin_(is_builtin),
+        need_casedown_(need_casedown)
+  {
+  }
+
+  TO_STRING_KV(K_(tenant_id), K_(table_id), K_(table_name), K_(type),
+               K_(charset), K_(coll_type), K_(generation), K_(is_builtin),
+               K_(need_casedown));
+
 public:
-  ObString name_;
+  uint64_t tenant_id_;
+  uint64_t table_id_;
+  ObString table_name_;
   ObFTDictType type_;
   ObCharsetType charset_;
   ObCollationType coll_type_;
+  uint64_t generation_;
+  bool is_builtin_;
+  bool need_casedown_;
 };
 
 } //  namespace storage

--- a/src/storage/fts/dict/ob_ft_dict_hub.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_hub.cpp
@@ -45,13 +45,27 @@ int ObFTDictHub::init()
 int ObFTDictHub::destroy()
 {
   int ret = OB_SUCCESS;
+  dict_map_.destroy();
+  rw_dict_lock_.destroy();
   is_inited_ = false;
   return ret;
 }
 int ObFTDictHub::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container)
 {
+  return build_cache_internal(desc, container, false);
+}
+
+int ObFTDictHub::refresh(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container)
+{
+  return build_cache_internal(desc, container, true);
+}
+
+int ObFTDictHub::build_cache_internal(const ObFTDictDesc &desc,
+                                      ObFTCacheRangeContainer &container,
+                                      const bool force_refresh)
+{
   int ret = OB_SUCCESS;
-  ObFTDictInfoKey key(static_cast<uint64_t>(desc.type_));
+  ObFTDictInfoKey key(desc.tenant_id_, desc.table_id_);
   ObFTDictInfo info;
   container.reset();
 
@@ -61,28 +75,44 @@ int ObFTDictHub::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &
   } else {
     ObBucketHashWLockGuard guard(rw_dict_lock_, key.hash());
 
-    // try if valid with no recursive lock
-    if (OB_FAIL(get_dict_info(key, info))) {
-      if (OB_HASH_NOT_EXIST == ret) {
-        // dict not exist, make new one, by caller
-        ret = OB_ENTRY_NOT_EXIST;
+    int info_ret = get_dict_info(key, info);
+    if (OB_HASH_NOT_EXIST == info_ret) {
+      info_ret = OB_SUCCESS;
+    }
+    if (OB_SUCCESS != info_ret) {
+      ret = info_ret;
+      LOG_WARN("Failed to get dict info", K(ret), K(desc));
+    } else if (!force_refresh && info.generation_ > 0) {
+      ObFTDictDesc load_desc(desc);
+      load_desc.generation_ = info.generation_;
+      if (OB_FAIL(ObFTRangeDict::try_load_cache(
+                      load_desc, info.range_count_, container))) {
+        if (OB_ENTRY_NOT_EXIST == ret) {
+          ret = OB_SUCCESS;
+        } else {
+          LOG_WARN("Failed to load current dictionary cache", K(ret), K(load_desc));
+        }
       } else {
-        LOG_WARN("Failed to get dict info", K(ret));
-      }
-    } else if (OB_FAIL(ObFTRangeDict::try_load_cache(desc, info.range_count_, container))) {
-      if (OB_ENTRY_NOT_EXIST == ret) {
-      } else {
-        LOG_WARN("Failed to load cache", K(ret));
+        return OB_SUCCESS;
       }
     }
 
-    if (OB_FAIL(ret)) {
-      if (OB_ENTRY_NOT_EXIST == ret) {
-        if (OB_FAIL(ObFTRangeDict::build_cache_from_ik_dict(desc, container))) {
-          LOG_WARN("Failed to build cache", K(ret));
-        } else if (FALSE_IT(info.range_count_ = container.get_handles().size())) {
-        } else if (OB_FAIL(put_dict_info(key, info))) {
-          LOG_WARN("Failed to put dict info", K(ret));
+    if (OB_SUCC(ret)) {
+      ObFTDictDesc build_desc(desc);
+      build_desc.generation_ = info.generation_ + 1;
+      container.reset();
+      if (build_desc.is_builtin_) {
+        if (OB_FAIL(ObFTRangeDict::build_cache_from_ik_dict(build_desc, container))) {
+          LOG_WARN("Failed to build compiled dictionary cache", K(ret), K(build_desc));
+        }
+      } else if (OB_FAIL(ObFTRangeDict::build_cache(build_desc, container))) {
+        LOG_WARN("Failed to build custom dictionary cache", K(ret), K(build_desc));
+      }
+      if (OB_SUCC(ret)) {
+        info.generation_ = build_desc.generation_;
+        info.range_count_ = static_cast<int32_t>(container.get_handles().size());
+        if (OB_FAIL(put_dict_info(key, info))) {
+          LOG_WARN("Failed to publish dictionary cache generation", K(ret), K(build_desc));
         }
       }
     }
@@ -95,7 +125,7 @@ int ObFTDictHub::load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &c
   int ret = OB_SUCCESS;
   ObFTDictInfo info;
   container.reset();
-  ObFTDictInfoKey key(static_cast<uint64_t>(desc.type_));
+  ObFTDictInfoKey key(desc.tenant_id_, desc.table_id_);
   if (!is_inited_) {
     ret = OB_NOT_INIT;
     LOG_WARN("dict hub not init", K(ret));
@@ -112,11 +142,16 @@ int ObFTDictHub::load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &c
       }
     }
     if (OB_FAIL(ret)) {
-    } else if (OB_FAIL(ObFTRangeDict::try_load_cache(desc, info.range_count_, container))) {
+    } else {
+      ObFTDictDesc load_desc(desc);
+      load_desc.generation_ = info.generation_;
+      if (OB_FAIL(ObFTRangeDict::try_load_cache(
+                      load_desc, info.range_count_, container))) {
       if (OB_ENTRY_NOT_EXIST == ret) {
         // dict not exist, make new one, by caller
       } else {
         LOG_WARN("Failed to load cache", K(ret));
+      }
       }
     }
   }

--- a/src/storage/fts/dict/ob_ft_dict_hub.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_hub.cpp
@@ -47,6 +47,7 @@ int ObFTDictHub::destroy()
   int ret = OB_SUCCESS;
   dict_map_.destroy();
   rw_dict_lock_.destroy();
+  ATOMIC_STORE(&generation_epoch_, 0);
   is_inited_ = false;
   return ret;
 }
@@ -113,6 +114,8 @@ int ObFTDictHub::build_cache_internal(const ObFTDictDesc &desc,
         info.range_count_ = static_cast<int32_t>(container.get_handles().size());
         if (OB_FAIL(put_dict_info(key, info))) {
           LOG_WARN("Failed to publish dictionary cache generation", K(ret), K(build_desc));
+        } else {
+          ATOMIC_INC(&generation_epoch_);
         }
       }
     }

--- a/src/storage/fts/dict/ob_ft_dict_hub.h
+++ b/src/storage/fts/dict/ob_ft_dict_hub.h
@@ -18,6 +18,7 @@
 #define _OCEANBASE_STORAGE_FTS_DICT_OB_FT_DICT_HUB_H_
 
 #include "lib/charset/ob_charset.h"
+#include "lib/atomic/ob_atomic.h"
 #include "lib/lock/ob_bucket_lock.h"
 #include "storage/fts/dict/ob_ft_dict_def.h"
 
@@ -96,7 +97,7 @@ class ObFTCacheRangeContainer;
 class ObFTDictHub
 {
 public:
-  ObFTDictHub() : is_inited_(false), dict_map_(), rw_dict_lock_() {}
+  ObFTDictHub() : is_inited_(false), generation_epoch_(0), dict_map_(), rw_dict_lock_() {}
   ~ObFTDictHub() {}
 
   int init();
@@ -109,6 +110,8 @@ public:
 
   int refresh(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
 
+  uint64_t get_generation_epoch() const { return ATOMIC_LOAD(&generation_epoch_); }
+
 private:
   int build_cache_internal(const ObFTDictDesc &desc,
                            ObFTCacheRangeContainer &container,
@@ -120,6 +123,7 @@ private:
 
 private:
   bool is_inited_;
+  uint64_t generation_epoch_;
   // holds info of dict
   hash::ObHashMap<ObFTDictInfoKey, ObFTDictInfo> dict_map_;
   ObBucketLock rw_dict_lock_;

--- a/src/storage/fts/dict/ob_ft_dict_hub.h
+++ b/src/storage/fts/dict/ob_ft_dict_hub.h
@@ -32,19 +32,12 @@ class ObFTDictInfo
 {
 public:
   ObFTDictInfo()
-      : name_(""),
-        type_(ObFTDictType::DICT_TYPE_INVALID),
-        charset_(CHARSET_INVALID),
-        version_(0),
-        range_count_(0)
+      : generation_(0), range_count_(0)
   {
   }
 
 public:
-  char name_[2048]; // for now
-  ObFTDictType type_;
-  ObCharsetType charset_;
-  int64_t version_; // in memory
+  uint64_t generation_;
   int32_t range_count_;
 };
 
@@ -52,11 +45,11 @@ struct ObFTDictInfoKey
 {
 public:
   ObFTDictInfoKey()
-      : type_(static_cast<uint64_t>(ObFTDictType::DICT_TYPE_INVALID))
+      : tenant_id_(OB_INVALID_TENANT_ID), table_id_(OB_INVALID_ID)
   {
-  } // default constructor
-  ObFTDictInfoKey(const uint64_t type)
-      : type_(type)
+  }
+  ObFTDictInfoKey(const uint64_t tenant_id, const uint64_t table_id)
+      : tenant_id_(tenant_id), table_id_(table_id)
   {
   }
   int hash(uint64_t &hash_value) const
@@ -69,27 +62,34 @@ public:
   uint64_t hash() const
   {
     uint64_t hash = 0;
-    hash = common::murmurhash(&type_, sizeof(int64_t), hash);
+    hash = common::murmurhash(&tenant_id_, sizeof(tenant_id_), hash);
+    hash = common::murmurhash(&table_id_, sizeof(table_id_), hash);
     return hash;
   }
 
   bool operator==(const ObFTDictInfoKey &other) const
   {
-    return type_ == other.type_ && true;
+    return tenant_id_ == other.tenant_id_ && table_id_ == other.table_id_;
   }
 
   int compare(const ObFTDictInfoKey &other) const
   {
     int ret = 0;
-    if (0 == ret) {
-      ret = type_ - other.type_;
+    if (tenant_id_ < other.tenant_id_) {
+      ret = -1;
+    } else if (tenant_id_ > other.tenant_id_) {
+      ret = 1;
+    } else if (table_id_ < other.table_id_) {
+      ret = -1;
+    } else if (table_id_ > other.table_id_) {
+      ret = 1;
     }
     return ret;
   }
 
 private:
-  uint64_t type_;
-  // name
+  uint64_t tenant_id_;
+  uint64_t table_id_;
 };
 
 class ObFTCacheRangeContainer;
@@ -107,7 +107,12 @@ public:
 
   int load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
 
+  int refresh(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
+
 private:
+  int build_cache_internal(const ObFTDictDesc &desc,
+                           ObFTCacheRangeContainer &container,
+                           const bool force_refresh);
   int get_dict_info(const ObFTDictInfoKey &key, ObFTDictInfo &info);
 
   int put_dict_info(const ObFTDictInfoKey &key, const ObFTDictInfo &info);

--- a/src/storage/fts/dict/ob_ft_dict_table_iter.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_table_iter.cpp
@@ -30,7 +30,7 @@ namespace oceanbase
 namespace storage
 {
 ObFTDictTableIter::ObFTDictTableIter(ObISQLClient::ReadResult &result)
-    : ObIFTDictIterator(), is_inited_(false), res_(result)
+    : ObIFTDictIterator(), is_inited_(false), iter_end_(false), res_(result)
 {
 }
 
@@ -40,6 +40,8 @@ int ObFTDictTableIter::get_key(ObString &str)
   if (!IS_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("Not inited.", K(ret));
+  } else if (iter_end_) {
+    ret = OB_ITER_END;
   } else if (OB_FAIL(res_.get_result()->get_varchar("word", str))) {
     LOG_WARN("Failed to get varchar", K(ret));
   }
@@ -58,29 +60,50 @@ int ObFTDictTableIter::next()
   if (!IS_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("Not inited.", K(ret));
+  } else if (iter_end_) {
+    ret = OB_ITER_END;
   } else if (OB_FAIL(res_.get_result()->next())) {
-    if (OB_ITER_END != ret) {
+    if (OB_ITER_END == ret) {
+      iter_end_ = true;
+    } else {
       LOG_WARN("Failed to get next row", K(ret));
     }
   }
   return ret;
 }
 
-int ObFTDictTableIter::init(const ObString &table_name)
+int ObFTDictTableIter::init(const ObFTDictDesc &desc)
 {
   int ret = OB_SUCCESS;
   common::ObMySQLProxy *sql_proxy = GCTX.sql_proxy_;
+  const char *dot = desc.table_name_.find('.');
 
   if (IS_INIT) {
     ret = OB_INIT_TWICE;
     LOG_WARN("Inited twice.", K(ret));
+  } else if (OB_ISNULL(sql_proxy) || OB_ISNULL(dot)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table descriptor", K(ret), K(desc), KP(sql_proxy));
   } else {
+    const ObString database_name(static_cast<int32_t>(dot - desc.table_name_.ptr()),
+                                 desc.table_name_.ptr());
+    const ObString table_name(static_cast<int32_t>(
+                                  desc.table_name_.length() - (dot - desc.table_name_.ptr()) - 1),
+                              dot + 1);
     SMART_VAR(ObSqlString, sql_string)
     {
-      if (OB_FAIL(sql_string.append("SELECT word FROM oceanbase."))) {
-        LOG_WARN("Failed to append sql", K(ret));
-      } else if (OB_FAIL(sql_string.append(table_name))) {
-        LOG_WARN("Failed to append sql", K(ret));
+      if (desc.need_casedown_) {
+        if (OB_FAIL(sql_string.append_fmt("SELECT DISTINCT LOWER(word) AS word FROM `%.*s`.`%.*s`",
+                                         database_name.length(), database_name.ptr(),
+                                         table_name.length(), table_name.ptr()))) {
+          LOG_WARN("Failed to append lowercase dictionary sql", K(ret));
+        }
+      } else if (OB_FAIL(sql_string.append_fmt("SELECT word FROM `%.*s`.`%.*s`",
+                                              database_name.length(), database_name.ptr(),
+                                              table_name.length(), table_name.ptr()))) {
+        LOG_WARN("Failed to append dictionary sql", K(ret));
+      }
+      if (OB_FAIL(ret)) {
       } else if (OB_FAIL(sql_string.append(" ORDER BY word"))) {
         LOG_WARN("Failed to append sql", K(ret));
       } else if (OB_FAIL(sql_proxy->read(res_, sql_string.ptr()))) {
@@ -94,10 +117,12 @@ int ObFTDictTableIter::init(const ObString &table_name)
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("Failed to get result", K(ret));
     } else if (OB_FAIL(res_.get_result()->next())) {
-      if (OB_ITER_END != ret) {
-        LOG_WARN("Failed to get next row", K(ret));
-      } else {
+      if (OB_ITER_END == ret) {
+        ret = OB_SUCCESS;
+        iter_end_ = true;
         is_inited_ = true;
+      } else {
+        LOG_WARN("Failed to get next row", K(ret));
       }
     } else {
       is_inited_ = true;
@@ -111,6 +136,7 @@ void ObFTDictTableIter::reset()
 {
   res_.close();
   is_inited_ = false;
+  iter_end_ = false;
 }
 
 } //  namespace storage

--- a/src/storage/fts/dict/ob_ft_dict_table_iter.h
+++ b/src/storage/fts/dict/ob_ft_dict_table_iter.h
@@ -19,6 +19,7 @@
 
 #include "common/mysqlclient/ob_isql_client.h"
 #include "storage/fts/dict/ob_ft_dict_iterator.h"
+#include "storage/fts/dict/ob_ft_dict_def.h"
 
 namespace oceanbase
 {
@@ -37,13 +38,14 @@ public:
   int next() override;
 
 public:
-  int init(const ObString &table_name);
+  int init(const ObFTDictDesc &desc);
 
 private:
   void reset();
 
 private:
   bool is_inited_;
+  bool iter_end_;
   ObISQLClient::ReadResult &res_;
 };
 

--- a/src/storage/fts/dict/ob_ft_range_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_range_dict.cpp
@@ -465,35 +465,19 @@ int ObFTRangeDict::build_dict_from_cache(const ObFTCacheRangeContainer &range_co
 int ObFTRangeDict::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &range_container)
 {
   int ret = OB_SUCCESS;
-
-  ObString table_name;
-  switch (desc.type_) {
-  case ObFTDictType::DICT_IK_MAIN: {
-    table_name = ObString(share::OB_FT_DICT_IK_UTF8_TNAME);
-  } break;
-  case ObFTDictType::DICT_IK_QUAN: {
-    table_name = ObString(share::OB_FT_QUANTIFIER_IK_UTF8_TNAME);
-  } break;
-  case ObFTDictType::DICT_IK_STOP: {
-    table_name = ObString(share::OB_FT_STOPWORD_IK_UTF8_TNAME);
-  } break;
-  default:
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("Not supported dict type.", K(ret));
-  }
-
-  if (OB_SUCC(ret)) {
-    SMART_VAR(ObISQLClient::ReadResult, result)
-    {
-      ObFTDictTableIter iter_table(result);
-      if (OB_FAIL(iter_table.init(table_name))) {
-        LOG_WARN("Failed to init iterator.", K(ret));
-      } else if (OB_FAIL(ObFTRangeDict::build_ranges(desc, iter_table, range_container))) {
-        LOG_WARN("Failed to build ranges.", K(ret));
-      }
+  SMART_VAR(ObISQLClient::ReadResult, result)
+  {
+    ObFTDictTableIter iter_table(result);
+    if (desc.is_builtin_) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("built-in dictionary must use compiled data", K(ret), K(desc));
+    } else if (OB_FAIL(iter_table.init(desc))) {
+      LOG_WARN("Failed to init dictionary table iterator", K(ret), K(desc));
+    } else if (OB_FAIL(ObFTRangeDict::build_ranges_concurrently_thread_pool(
+                           desc, iter_table, range_container))) {
+      LOG_WARN("Failed to build dictionary table ranges", K(ret), K(desc));
     }
   }
-
   return ret;
 }
 
@@ -502,10 +486,8 @@ int ObFTRangeDict::try_load_cache(const ObFTDictDesc &desc,
                                   ObFTCacheRangeContainer &range_container)
 {
   int ret = OB_SUCCESS;
-  uint64_t name = static_cast<uint64_t>(desc.type_);
-
   for (int64_t i = 0; OB_SUCC(ret) && i < range_count; ++i) {
-    ObDictCacheKey key(name, desc.type_, i);
+    ObDictCacheKey key(desc.tenant_id_, desc.table_id_, desc.generation_, i);
     ObFTCacheRangeHandle *info = nullptr;
     if (OB_FAIL(range_container.fetch_info_for_dict(info))) {
       LOG_WARN("Failed to fetch info for dict.", K(ret));

--- a/src/storage/fts/ik/ob_fast_list.h
+++ b/src/storage/fts/ik/ob_fast_list.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#ifndef OB_FAST_LIST_H_
+#define OB_FAST_LIST_H_
+
+#include "storage/fts/ik/ob_fast_segment_array.h"
+
+namespace oceanbase
+{
+namespace storage
+{
+
+// Node-pool list for POD-like values. Removed nodes are reclaimed on reuse.
+template <typename T, int64_t BLOCK_CAPACITY = 256>
+class ObFastList
+{
+  struct Node
+  {
+    Node() : next_(nullptr), prev_(nullptr), value_() {}
+    explicit Node(const T &value) : next_(nullptr), prev_(nullptr), value_(value) {}
+    Node *next_;
+    Node *prev_;
+    T value_;
+  };
+  struct Root
+  {
+    operator Node *() { return reinterpret_cast<Node *>(this); }
+    operator const Node *() const { return reinterpret_cast<const Node *>(this); }
+    Node *next_;
+    Node *prev_;
+  };
+
+public:
+  class const_iterator;
+
+  class iterator
+  {
+  public:
+    iterator() : node_(nullptr) {}
+    explicit iterator(Node *node) : node_(node) {}
+    T &operator*() const { return node_->value_; }
+    T *operator->() const { return &node_->value_; }
+    iterator &operator++() { node_ = node_->next_; return *this; }
+    iterator operator++(int) { iterator old(*this); ++(*this); return old; }
+    iterator &operator--() { node_ = node_->prev_; return *this; }
+    iterator operator--(int) { iterator old(*this); --(*this); return old; }
+    bool operator==(const iterator &other) const { return node_ == other.node_; }
+    bool operator!=(const iterator &other) const { return node_ != other.node_; }
+  private:
+    friend class ObFastList;
+    friend class const_iterator;
+    Node *node_;
+  };
+
+  class const_iterator
+  {
+  public:
+    const_iterator() : node_(nullptr) {}
+    explicit const_iterator(const Node *node) : node_(const_cast<Node *>(node)) {}
+    const_iterator(const iterator &iter) : node_(iter.node_) {}
+    const T &operator*() const { return node_->value_; }
+    const T *operator->() const { return &node_->value_; }
+    const_iterator &operator++() { node_ = node_->next_; return *this; }
+    const_iterator operator++(int) { const_iterator old(*this); ++(*this); return old; }
+    const_iterator &operator--() { node_ = node_->prev_; return *this; }
+    const_iterator operator--(int) { const_iterator old(*this); --(*this); return old; }
+    bool operator==(const const_iterator &other) const { return node_ == other.node_; }
+    bool operator!=(const const_iterator &other) const { return node_ != other.node_; }
+  private:
+    friend class ObFastList;
+    Node *node_;
+  };
+
+  explicit ObFastList(ObIAllocator &allocator) : pool_(allocator), size_(0)
+  {
+    root_.next_ = root_;
+    root_.prev_ = root_;
+  }
+  ~ObFastList() { reset(); }
+
+  void reset() { reuse(); pool_.reset(); }
+  void reuse()
+  {
+    root_.next_ = root_;
+    root_.prev_ = root_;
+    size_ = 0;
+    pool_.reuse();
+  }
+  bool empty() const { return 0 == size_; }
+  int64_t size() const { return size_; }
+  T &get_first() { return root_.next_->value_; }
+  const T &get_first() const { return root_.next_->value_; }
+  T &get_last() { return root_.prev_->value_; }
+  const T &get_last() const { return root_.prev_->value_; }
+  iterator begin() { return iterator(root_.next_); }
+  iterator end() { return iterator(root_); }
+  const_iterator begin() const { return const_iterator(root_.next_); }
+  const_iterator end() const { return const_iterator(root_); }
+  iterator last() { return iterator(root_.prev_); }
+  const_iterator last() const { return const_iterator(root_.prev_); }
+  int push_front(const T &value) { return insert_before(root_.next_, value); }
+  int push_back(const T &value) { return insert_before(root_, value); }
+  int insert(iterator pos, const T &value) { return insert_before(pos.node_, value); }
+  int insert(const_iterator pos, const T &value) { return insert_before(pos.node_, value); }
+  int pop_front()
+  {
+    int ret = OB_SUCCESS;
+    if (empty()) { ret = OB_ENTRY_NOT_EXIST; } else { remove(root_.next_); }
+    return ret;
+  }
+  int pop_back()
+  {
+    int ret = OB_SUCCESS;
+    if (empty()) { ret = OB_ENTRY_NOT_EXIST; } else { remove(root_.prev_); }
+    return ret;
+  }
+
+private:
+  int insert_before(Node *anchor, const T &value)
+  {
+    int ret = OB_SUCCESS;
+    Node node_value(value);
+    if (OB_FAIL(pool_.push_back(node_value))) {
+      LOG_WARN("fail to allocate fast-list node", K(ret));
+    } else {
+      Node *node = &pool_.at(pool_.count() - 1);
+      node->next_ = anchor;
+      node->prev_ = anchor->prev_;
+      anchor->prev_->next_ = node;
+      anchor->prev_ = node;
+      ++size_;
+    }
+    return ret;
+  }
+  void remove(Node *node)
+  {
+    node->prev_->next_ = node->next_;
+    node->next_->prev_ = node->prev_;
+    node->next_ = nullptr;
+    node->prev_ = nullptr;
+    --size_;
+  }
+
+private:
+  ObFastSegmentArray<Node, BLOCK_CAPACITY> pool_;
+  Root root_;
+  int64_t size_;
+};
+
+} // namespace storage
+} // namespace oceanbase
+
+#endif // OB_FAST_LIST_H_

--- a/src/storage/fts/ik/ob_fast_segment_array.h
+++ b/src/storage/fts/ik/ob_fast_segment_array.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#ifndef OB_FAST_SEGMENT_ARRAY_H_
+#define OB_FAST_SEGMENT_ARRAY_H_
+
+#include "lib/allocator/ob_allocator.h"
+#include "lib/ob_errno.h"
+#include "lib/oblog/ob_log_module.h"
+#include <cstdint>
+#include <new>
+
+namespace oceanbase
+{
+namespace storage
+{
+
+// A POD-oriented segmented array. Reuse is O(1) and retains allocated blocks.
+template <typename T, int64_t BLOCK_CAPACITY = 256>
+class ObFastSegmentArray
+{
+  static_assert(BLOCK_CAPACITY > 2 && BLOCK_CAPACITY <= (1L << 30),
+      "invalid segmented array block capacity");
+public:
+  static constexpr int64_t DEFAULT_BLOCK_PTR_CAPACITY = 64;
+  static constexpr int64_t BLOCK_POWER =
+      64 - __builtin_clzll(static_cast<uint64_t>(BLOCK_CAPACITY) - 1);
+  static constexpr int64_t REAL_BLOCK_CAPACITY = 1L << BLOCK_POWER;
+  static constexpr int64_t BLOCK_MASK = REAL_BLOCK_CAPACITY - 1;
+
+  explicit ObFastSegmentArray(
+      ObIAllocator &allocator,
+      const int64_t initial_block_ptr_capacity = DEFAULT_BLOCK_PTR_CAPACITY)
+      : allocator_(allocator), block_arr_(nullptr), block_arr_capacity_(0),
+        block_count_(0), size_(0), constructed_size_(0), initial_block_ptr_capacity_(
+            initial_block_ptr_capacity > 0
+                ? initial_block_ptr_capacity : DEFAULT_BLOCK_PTR_CAPACITY)
+  {}
+  ~ObFastSegmentArray() { reset(); }
+
+  int push_back(const T &value)
+  {
+    int ret = OB_SUCCESS;
+    const int64_t block_idx = size_ >> BLOCK_POWER;
+    if (OB_FAIL(ensure_block(block_idx))) {
+      LOG_WARN("fail to ensure segmented array block", K(ret), K(block_idx));
+    } else {
+      T *slot = &block_arr_[block_idx][size_ & BLOCK_MASK];
+      if (size_ < constructed_size_) {
+        *slot = value;
+      } else {
+        new (slot) T(value);
+        ++constructed_size_;
+      }
+      ++size_;
+    }
+    return ret;
+  }
+
+  int alloc(T *&ptr)
+  {
+    int ret = OB_SUCCESS;
+    const int64_t block_idx = size_ >> BLOCK_POWER;
+    if (OB_FAIL(ensure_block(block_idx))) {
+      LOG_WARN("fail to ensure segmented array block", K(ret), K(block_idx));
+    } else {
+      ptr = &block_arr_[block_idx][size_ & BLOCK_MASK];
+      if (size_ >= constructed_size_) {
+        new (ptr) T();
+        ++constructed_size_;
+      }
+      ++size_;
+    }
+    return ret;
+  }
+
+  int free_an_obj()
+  {
+    int ret = OB_SUCCESS;
+    if (OB_UNLIKELY(0 == size_)) {
+      ret = OB_ERR_UNEXPECTED;
+    } else {
+      --size_;
+    }
+    return ret;
+  }
+
+  const T &at(const int64_t idx) const
+  {
+    return block_arr_[idx >> BLOCK_POWER][idx & BLOCK_MASK];
+  }
+  T &at(const int64_t idx)
+  {
+    return const_cast<T &>(static_cast<const ObFastSegmentArray &>(*this).at(idx));
+  }
+  int64_t count() const { return size_; }
+  bool empty() const { return 0 == size_; }
+  void reuse() { size_ = 0; }
+
+  void reset()
+  {
+    for (int64_t i = 0; i < constructed_size_; ++i) {
+      at(i).~T();
+    }
+    for (int64_t i = 0; i < block_count_; ++i) {
+      if (OB_NOT_NULL(block_arr_[i])) {
+        allocator_.free(block_arr_[i]);
+        block_arr_[i] = nullptr;
+      }
+    }
+    if (OB_NOT_NULL(block_arr_)) {
+      allocator_.free(block_arr_);
+      block_arr_ = nullptr;
+    }
+    block_arr_capacity_ = 0;
+    block_count_ = 0;
+    size_ = 0;
+    constructed_size_ = 0;
+  }
+
+private:
+  int ensure_block(const int64_t block_idx)
+  {
+    int ret = OB_SUCCESS;
+    if (block_idx >= block_count_) {
+      if (block_idx >= block_arr_capacity_
+          && OB_FAIL(expand_block_array(block_idx + 1))) {
+        LOG_WARN("fail to expand segmented array block pointers", K(ret), K(block_idx));
+      } else if (OB_NOT_NULL(block_arr_[block_idx])) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected existing segmented array block", K(ret), K(block_idx));
+      } else if (OB_ISNULL(block_arr_[block_idx] = static_cast<T *>(
+                     allocator_.alloc(REAL_BLOCK_CAPACITY * sizeof(T))))) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("fail to allocate segmented array block", K(ret), K(block_idx));
+      } else {
+        ++block_count_;
+      }
+    }
+    return ret;
+  }
+
+  int expand_block_array(const int64_t required_capacity)
+  {
+    int ret = OB_SUCCESS;
+    int64_t next_capacity = block_arr_capacity_ > 0
+        ? block_arr_capacity_ : initial_block_ptr_capacity_;
+    while (next_capacity < required_capacity) {
+      next_capacity <<= 1;
+    }
+    const int64_t bytes = next_capacity * sizeof(T *);
+    T **next = static_cast<T **>(allocator_.alloc(bytes));
+    if (OB_ISNULL(next)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("fail to allocate segmented array block pointers", K(ret), K(next_capacity));
+    } else {
+      MEMSET(next, 0, bytes);
+      if (OB_NOT_NULL(block_arr_)) {
+        MEMCPY(next, block_arr_, block_count_ * sizeof(T *));
+        allocator_.free(block_arr_);
+      }
+      block_arr_ = next;
+      block_arr_capacity_ = next_capacity;
+    }
+    return ret;
+  }
+
+private:
+  ObIAllocator &allocator_;
+  T **block_arr_;
+  int64_t block_arr_capacity_;
+  int64_t block_count_;
+  int64_t size_;
+  int64_t constructed_size_;
+  const int64_t initial_block_ptr_capacity_;
+  DISALLOW_COPY_AND_ASSIGN(ObFastSegmentArray);
+};
+
+} // namespace storage
+} // namespace oceanbase
+
+#endif // OB_FAST_SEGMENT_ARRAY_H_

--- a/src/storage/fts/ik/ob_ik_arbitrator.cpp
+++ b/src/storage/fts/ik/ob_ik_arbitrator.cpp
@@ -36,11 +36,10 @@ int ObIKArbitrator::process(TokenizeContext &ctx)
 {
   int ret = OB_SUCCESS;
 
-  ObList<ObIKToken, ObIAllocator> &tokens = ctx.token_list().tokens();
+  ObFastList<ObIKToken, IK_HANDLE_SIZE_LIMIT> &tokens = ctx.token_list().tokens();
   ObIKTokenChain *chain_need_arbitrate = nullptr;
   bool use_smart = ctx.is_smart();
-  if (OB_FAIL(prepare(ctx))) {
-  } else if (OB_ISNULL(chain_need_arbitrate = OB_NEWx(ObIKTokenChain, &alloc_, alloc_))) {
+  if (OB_ISNULL(chain_need_arbitrate = OB_NEWx(ObIKTokenChain, &alloc_, alloc_))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("alloc memory failed");
   } else {
@@ -121,19 +120,20 @@ int ObIKArbitrator::output_result(TokenizeContext &ctx)
 
   int64_t char_len = 0;
   ObIKTokenChain *chain = nullptr;
-  for (int64_t current = 0; OB_SUCC(ret) && current < ctx.fulltext_len();) {
+  const int64_t buffer_start_cursor = ctx.get_buffer_start_cursor();
+  const int64_t buffer_end_cursor = ctx.get_buffer_end_cursor();
+  for (int64_t current = buffer_start_cursor;
+       OB_SUCC(ret) && current < buffer_end_cursor;) {
     ObFTCharUtil::CharType type;
     // maybe not so good to keep single, check it later
-    if (OB_FAIL(ObCharset::first_valid_char(ctx.collation(),
-                                            ctx.fulltext() + current,
-                                            ctx.fulltext_len() - current,
-                                            char_len))) {
-      LOG_WARN("Failed to get next valid char", K(ret));
-    } else if (OB_FAIL(ObFTCharUtil::classify_first_char(ctx.collation(),
-                                                         ctx.fulltext() + current,
-                                                         char_len,
-                                                         type))) {
-      LOG_WARN("Failed to classify first char", K(ret));
+    if (OB_FAIL(ObFTCharUtil::classify_first_valid_char(ctx.get_charset_type(),
+                                                        ctx.fulltext() + current,
+                                                        ctx.fulltext_len() - current,
+                                                        ctx.get_well_formed_len(),
+                                                        ctx.get_charset_info(),
+                                                        char_len,
+                                                        type))) {
+      LOG_WARN("Failed to classify first valid char", K(ret));
     } else if (ObFTCharUtil::CharType::USELESS == type) {
       current += char_len; // skip useless char
     } else if (OB_FAIL(chains_.get_refactored(current, chain)) && OB_HASH_NOT_EXIST != ret) {
@@ -152,7 +152,7 @@ int ObIKArbitrator::output_result(TokenizeContext &ctx)
         bool is_ignore = false;
         if (ObFTCharUtil::CharType::CHINESE == type) {
           token.type_ = ObIKTokenType::IK_CHINESE_TOKEN;
-          if (OB_FAIL(ctx.result_list().push_back(token))) {
+          if (OB_FAIL(ctx.get_results().push_back(token))) {
             LOG_WARN("Failed to output result to ctx", K(ret));
           }
         } else if (ObFTCharUtil::CharType::OTHER_CJK == type) {
@@ -162,7 +162,7 @@ int ObIKArbitrator::output_result(TokenizeContext &ctx)
                                                          is_ignore))) {
             LOG_WARN("Failed to check ignore", K(ret));
           } else if (!is_ignore && !FALSE_IT(token.type_ = ObIKTokenType::IK_OTHER_CJK_TOKEN)
-                     && OB_FAIL(ctx.result_list().push_back(token))) {
+                     && OB_FAIL(ctx.get_results().push_back(token))) {
             LOG_WARN("Failed to add token to ctx result", K(ret));
           } else {
             // ignore
@@ -180,12 +180,16 @@ int ObIKArbitrator::output_result(TokenizeContext &ctx)
         } else {
           // output single word between two token
           while (OB_SUCC(ret) && current < token.offset_) {
-            if (OB_FAIL(ObCharset::first_valid_char(ctx.collation(),
-                                                    ctx.fulltext() + current,
-                                                    ctx.fulltext_len() - current,
-                                                    char_len))) {
-              LOG_WARN("Failed to get next valid char, ", K(ret));
-              break;
+            if (OB_FAIL(ObFTCharUtil::classify_first_valid_char(ctx.get_charset_type(),
+                                                                ctx.fulltext() + current,
+                                                                ctx.fulltext_len() - current,
+                                                                ctx.get_well_formed_len(),
+                                                                ctx.get_charset_info(),
+                                                                char_len,
+                                                                type))) {
+              LOG_WARN("Failed to classify first valid char", K(ret));
+            } else if (ObFTCharUtil::CharType::USELESS == type) {
+              current += char_len;
             } else {
               ObIKToken token;
               token.offset_ = current;
@@ -195,7 +199,9 @@ int ObIKArbitrator::output_result(TokenizeContext &ctx)
               bool is_ignore = false;
               if (ObFTCharUtil::CharType::CHINESE == type) {
                 token.type_ = ObIKTokenType::IK_CHINESE_TOKEN;
-                ctx.result_list().push_back(token);
+                if (OB_FAIL(ctx.get_results().push_back(token))) {
+                  LOG_WARN("Failed to add token to ctx result", K(ret));
+                }
               } else if (ObFTCharUtil::CharType::OTHER_CJK == type) {
                 if (OB_FAIL(ObFTCharUtil::is_ignore_single_cjk(ctx.collation(),
                                                                ctx.fulltext() + current,
@@ -204,7 +210,9 @@ int ObIKArbitrator::output_result(TokenizeContext &ctx)
                   LOG_WARN("Failed to check ignore", K(ret));
                 } else if (!is_ignore) {
                   token.type_ = ObIKTokenType::IK_OTHER_CJK_TOKEN;
-                  ctx.result_list().push_back(token);
+                  if (OB_FAIL(ctx.get_results().push_back(token))) {
+                    LOG_WARN("Failed to add token to ctx result", K(ret));
+                  }
                 } else {
                 }
               }
@@ -214,7 +222,7 @@ int ObIKArbitrator::output_result(TokenizeContext &ctx)
         }
 
         if (OB_FAIL(ret)) {
-        } else if (OB_FAIL(ctx.result_list().push_back(token))) {
+        } else if (OB_FAIL(ctx.get_results().push_back(token))) {
           LOG_WARN("Failed to add token to ctx result", K(ret));
         } else
           // output the token
@@ -324,13 +332,11 @@ int ObIKArbitrator::remove_conflict(const ObIKToken &token, ObIKTokenChain *opti
   return ret;
 }
 
-int ObIKArbitrator::prepare(TokenizeContext &ctx)
+int ObIKArbitrator::prepare()
 {
   int ret = OB_SUCCESS;
-
-  int cal_bucket_num = MAX(ctx.fulltext_len() / 100, 10);
-  cal_bucket_num = MIN(cal_bucket_num, 100);
-  if (OB_FAIL(chains_.create(cal_bucket_num, ObMemAttr("IK ARBITRATE")))) {
+  if (OB_FAIL(chains_.create(IK_HANDLE_SIZE_LIMIT * 2,
+                             ObMemAttr("IK ARBITRATE")))) {
     LOG_WARN("create chain map failed", K(ret));
   }
   return ret;
@@ -356,6 +362,12 @@ ObIKArbitrator::~ObIKArbitrator()
 {
   chains_.destroy();
   alloc_.reset();
+}
+
+void ObIKArbitrator::reuse()
+{
+  chains_.reuse();
+  alloc_.reset_remain_one_page();
 }
 } // namespace storage
 } // namespace oceanbase

--- a/src/storage/fts/ik/ob_ik_arbitrator.h
+++ b/src/storage/fts/ik/ob_ik_arbitrator.h
@@ -38,9 +38,11 @@ public:
 
   int output_result(TokenizeContext &ctx);
 
-private:
-  int prepare(TokenizeContext &ctx);
+  int prepare();
 
+  void reuse();
+
+private:
   int add_chain(ObIKTokenChain *chain);
 
   int optimize(TokenizeContext &ctx,
@@ -61,7 +63,17 @@ private:
 
 private:
   ObArenaAllocator alloc_;
-  hash::ObHashMap<int64_t, ObIKTokenChain *> chains_;
+  hash::ObHashMap<
+      int64_t,
+      ObIKTokenChain *,
+      common::hash::NoPthreadDefendMode,
+      common::hash::hash_func<int64_t>,
+      common::hash::equal_to<int64_t>,
+      common::hash::SimpleAllocer<
+          typename common::hash::HashMapTypes<int64_t, ObIKTokenChain *>::AllocType,
+          common::hash::NodeNumTraits<
+              typename common::hash::HashMapTypes<int64_t, ObIKTokenChain *>::AllocType>::NODE_NUM,
+          common::hash::NoPthreadDefendMode>> chains_;
 
 private:
   DISALLOW_COPY_AND_ASSIGN(ObIKArbitrator);

--- a/src/storage/fts/ik/ob_ik_char_util.h
+++ b/src/storage/fts/ik/ob_ik_char_util.h
@@ -52,6 +52,19 @@ public:
                                  const uint8_t char_len,
                                  CharType &type);
 
+  static int classify_first_valid_char(
+      ObCharsetType cs_type,
+      const char *buf,
+      int64_t buf_size,
+      size_t (*well_formed_len_fn)(const ObCharsetInfo *,
+                                   const char *,
+                                   const char *,
+                                   size_t,
+                                   int *),
+      const ObCharsetInfo *cs,
+      int64_t &char_len,
+      CharType &type);
+
   static int check_cn_number(ObCollationType coll_type,
                              const char *input,
                              const uint8_t char_len,
@@ -455,32 +468,71 @@ template <ObCharsetType CS_TYPE>
 inline int ObFTCharUtil::do_classify(const char *input, const uint8_t char_len, CharType &type)
 {
   int ret = OB_SUCCESS;
-  bool checker = false;
+  ob_wc_t unicode = 0;
   type = CharType::USELESS;
-
-  if (OB_FAIL(is_alpha<CS_TYPE>(input, char_len, checker))) {
-  } else if (checker) {
+  if (OB_FAIL(decode_unicode<CS_TYPE>(input, char_len, unicode))) {
+    STORAGE_FTS_LOG(WARN, "Failed to decode unicode", K(ret));
+  } else if (ObUnicodeBlockUtils::is_alpha(unicode)) {
     type = CharType::ENGLISH_LETTER;
-  } else if (OB_FAIL(is_arabic<CS_TYPE>(input, char_len, checker))) {
-    STORAGE_FTS_LOG(WARN, "Failed to check arabic letter", K(ret));
-  } else if (checker) {
+  } else if (ObUnicodeBlockUtils::is_arabic(unicode)) {
     type = CharType::ARABIC_LETTER;
-  } else if (OB_FAIL(is_chinese<CS_TYPE>(input, char_len, checker))) {
-    STORAGE_FTS_LOG(WARN, "Failed to check chinese letter", K(ret));
-  } else if (checker) {
+  } else if (ObUnicodeBlockUtils::is_chinese(unicode)) {
     type = CharType::CHINESE;
-  } else if (OB_FAIL(is_other_cjk<CS_TYPE>(input, char_len, checker))) {
-    STORAGE_FTS_LOG(WARN, "Failed to check other cjk letter", K(ret));
-  } else if (checker) {
+  } else if (ObUnicodeBlockUtils::is_other_cjk(unicode)) {
     type = CharType::OTHER_CJK;
-  } else if (OB_FAIL(is_surrogate_high<CS_TYPE>(input, char_len, checker))) {
-    STORAGE_FTS_LOG(WARN, "Failed to check surrogate high letter", K(ret));
-  } else if (checker) {
+  } else if ((CS_TYPE == CHARSET_UTF16 || CS_TYPE == CHARSET_UTF16LE)
+             && ObUnicodeBlockUtils::check_high_surrogate(unicode)) {
     type = CharType::SURROGATE_HIGH;
-  } else if (OB_FAIL(is_surrogate_low<CS_TYPE>(input, char_len, checker))) {
-    STORAGE_FTS_LOG(WARN, "Failed to check surrogate low letter", K(ret));
-  } else if (checker) {
+  } else if ((CS_TYPE == CHARSET_UTF16 || CS_TYPE == CHARSET_UTF16LE)
+             && ObUnicodeBlockUtils::check_low_surrogate(unicode)) {
     type = CharType::SURROGATE_LOW;
+  }
+  return ret;
+}
+
+inline int ObFTCharUtil::classify_first_valid_char(
+    ObCharsetType cs_type,
+    const char *buf,
+    int64_t buf_size,
+    size_t (*well_formed_len_fn)(const ObCharsetInfo *,
+                                 const char *,
+                                 const char *,
+                                 size_t,
+                                 int *),
+    const ObCharsetInfo *cs,
+    int64_t &char_len,
+    CharType &type)
+{
+  int ret = OB_SUCCESS;
+  char_len = 0;
+  type = CharType::USELESS;
+  if (OB_ISNULL(buf) || OB_ISNULL(well_formed_len_fn) || OB_ISNULL(cs)
+      || OB_UNLIKELY(buf_size <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    STORAGE_FTS_LOG(WARN, "Invalid character buffer", K(ret), KP(buf), K(buf_size), KP(cs));
+  } else {
+    int error = 0;
+    char_len = static_cast<int64_t>(
+        well_formed_len_fn(cs, buf, buf + buf_size, 1, &error));
+    if (OB_UNLIKELY(0 != error || char_len <= 0)) {
+      ret = OB_ITER_END;
+    } else {
+      switch (cs_type) {
+        case CHARSET_UTF8MB4:
+          ret = do_classify<CHARSET_UTF8MB4>(buf, char_len, type);
+          break;
+        case CHARSET_UTF16:
+          ret = do_classify<CHARSET_UTF16>(buf, char_len, type);
+          break;
+        case CHARSET_UTF16LE:
+          ret = do_classify<CHARSET_UTF16LE>(buf, char_len, type);
+          break;
+        default:
+          ret = OB_NOT_SUPPORTED;
+          STORAGE_FTS_LOG(WARN, "Not supported charset type", K(ret), K(cs_type));
+          break;
+      }
+    }
   }
   return ret;
 }

--- a/src/storage/fts/ik/ob_ik_cjk_processor.h
+++ b/src/storage/fts/ik/ob_ik_cjk_processor.h
@@ -40,6 +40,7 @@ public:
                  const char *ch,
                  const uint8_t char_len,
                  const ObFTCharUtil::CharType type) override;
+  void reuse() override { hits_.clear(); }
 
 private:
   ObList<ObDATrieHit, ObIAllocator> hits_;

--- a/src/storage/fts/ik/ob_ik_letter_processor.h
+++ b/src/storage/fts/ik/ob_ik_letter_processor.h
@@ -33,6 +33,12 @@ public:
                  const char *ch,
                  const uint8_t char_len,
                  const ObFTCharUtil::CharType type) override;
+  void reuse() override
+  {
+    reset_english_state();
+    reset_arabic_state();
+    reset_mix_state();
+  }
 
 private:
   int process_english_letter(TokenizeContext &ctx,

--- a/src/storage/fts/ik/ob_ik_processor.cpp
+++ b/src/storage/fts/ik/ob_ik_processor.cpp
@@ -39,10 +39,10 @@ int ObIIKProcessor::process(TokenizeContext &ctx)
   const char *ch = nullptr;
   uint8_t char_len = 0;
 
-  if (OB_FAIL(ctx.current_char_type(type))) {
-    LOG_WARN("fail to get current char type", K(ret));
-  } else if (OB_FAIL(ctx.current_char(ch, char_len))) {
-    LOG_WARN("Fail to get current char", K(ret));
+  if (OB_FAIL(ctx.current_char_and_type(ch, char_len, type))) {
+    if (OB_ITER_END != ret) {
+      LOG_WARN("fail to get current char and type", K(ret));
+    }
   } else if (OB_FAIL(do_process(ctx, ch, char_len, type))) {
     LOG_WARN("Failed to do process char", K(ret));
   }
@@ -56,7 +56,8 @@ TokenizeContext::TokenizeContext(ObCollationType coll_type,
                                  bool is_smart)
     : coll_type_(coll_type), fulltext_(fulltext), fulltext_len_(fulltext_len), cursor_(0),
       next_char_len_(0), handle_size_(0), is_smart_(is_smart), token_list_(allocator),
-      result_list_(allocator)
+      results_(allocator), result_idx_(0), buffer_start_cursor_(0), charset_info_(nullptr),
+      charset_type_(CHARSET_INVALID), well_formed_len_(nullptr)
 {
 }
 
@@ -66,8 +67,38 @@ int TokenizeContext::init()
 
   if (OB_ISNULL(fulltext_) || fulltext_len_ <= 0) {
     ret = OB_INVALID_ARGUMENT;
+  } else if (OB_ISNULL(charset_info_ = static_cast<const ObCharsetInfo *>(
+                           ObCharset::get_charset(coll_type_)))) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_WARN("unsupported collation", K(ret), K(coll_type_));
+  } else if (OB_ISNULL(charset_info_->cset)
+             || OB_ISNULL(charset_info_->cset->well_formed_len)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid charset handler", K(ret), K(coll_type_));
+  } else if (FALSE_IT(charset_type_ = ObCharset::charset_type_by_coll(coll_type_))) {
+  } else if (FALSE_IT(well_formed_len_ = charset_info_->cset->well_formed_len)) {
   } else if (OB_FAIL(prepare_next_char())) {
     LOG_WARN("Failed to prepare next char", K(ret));
+  }
+  return ret;
+}
+
+int TokenizeContext::reuse_context(const char *fulltext, const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(fulltext) || OB_UNLIKELY(fulltext_len <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext for tokenize context reuse", K(ret), KP(fulltext), K(fulltext_len));
+  } else {
+    fulltext_ = fulltext;
+    fulltext_len_ = fulltext_len;
+    cursor_ = 0;
+    next_char_len_ = 0;
+    handle_size_ = 0;
+    buffer_start_cursor_ = 0;
+    if (OB_FAIL(prepare_next_char())) {
+      LOG_WARN("failed to prepare first character", K(ret));
+    }
   }
   return ret;
 }
@@ -75,12 +106,15 @@ int TokenizeContext::init()
 int TokenizeContext::reset_resource()
 {
   handle_size_ = 0;
-  result_list_.reset();
-  token_list_.reset();
+  results_.reuse();
+  result_idx_ = 0;
+  token_list_.tokens().reuse();
   return OB_SUCCESS;
 }
 
-int TokenizeContext::current_char(const char *&ch, uint8_t &char_len)
+int TokenizeContext::current_char_and_type(const char *&ch,
+                                           uint8_t &char_len,
+                                           ObFTCharUtil::CharType &type)
 {
   int ret = OB_SUCCESS;
   if (cursor_ >= fulltext_len_) {
@@ -88,16 +122,6 @@ int TokenizeContext::current_char(const char *&ch, uint8_t &char_len)
   } else {
     ch = fulltext_ + cursor_;
     char_len = next_char_len_;
-  }
-  return ret;
-}
-
-int TokenizeContext::current_char_type(ObFTCharUtil::CharType &type)
-{
-  int ret = OB_SUCCESS;
-  if (cursor_ >= fulltext_len_) {
-    ret = OB_ITER_END;
-  } else {
     type = next_char_type_;
   }
   return ret;
@@ -106,16 +130,16 @@ int TokenizeContext::current_char_type(ObFTCharUtil::CharType &type)
 int TokenizeContext::prepare_next_char()
 {
   int ret = OB_SUCCESS;
-  if (OB_FAIL(ObCharset::first_valid_char(coll_type_,
-                                          fulltext_ + cursor_,
-                                          fulltext_len_ - cursor_,
-                                          next_char_len_))) {
-    LOG_WARN("Failed to get first valid char, ", K(ret));
-  } else if (OB_FAIL(ObFTCharUtil::classify_first_char(coll_type_,
+  if (OB_FAIL(ObFTCharUtil::classify_first_valid_char(charset_type_,
                                                        fulltext_ + cursor_,
+                                                       fulltext_len_ - cursor_,
+                                                       well_formed_len_,
+                                                       charset_info_,
                                                        next_char_len_,
                                                        next_char_type_))) {
-    LOG_WARN("Failed to classify first char", K(ret));
+    if (OB_ITER_END != ret) {
+      LOG_WARN("Failed to classify first valid char", K(ret));
+    }
   }
   return ret;
 }
@@ -137,7 +161,11 @@ int TokenizeContext::step_next()
     cursor_ += next_char_len_;
     handle_size_++;
     if (OB_FAIL(prepare_next_char())) {
-      LOG_WARN("Failed to prepare next char", K(ret));
+      if (OB_ITER_END == ret) {
+        fulltext_len_ = cursor_;
+      } else {
+        LOG_WARN("Failed to prepare next char", K(ret));
+      }
     } else {
     }
   }
@@ -159,6 +187,8 @@ bool TokenizeContext::is_last() const { return cursor_ + next_char_len_ >= fullt
 bool TokenizeContext::iter_end() const { return cursor_ >= fulltext_len_; }
 
 bool TokenizeContext::is_smart() const { return is_smart_; }
+
+bool TokenizeContext::is_results_exhaust() const { return result_idx_ >= results_.count(); }
 
 int TokenizeContext::add_token(const char *fulltext,
                                int64_t offset,
@@ -182,7 +212,7 @@ int TokenizeContext::add_token(const char *fulltext,
 TokenizeContext::~TokenizeContext()
 {
   token_list_.reset();
-  result_list_.reset();
+  results_.reset();
 }
 
 int TokenizeContext::get_next_token(const char *&word,
@@ -191,10 +221,9 @@ int TokenizeContext::get_next_token(const char *&word,
                                     int64_t &char_cnt)
 {
   int ret = OB_SUCCESS;
-  if (!result_list_.empty()) {
-    ObIKToken &token = result_list_.get_first();
-    result_list_.pop_front();
-    if (!result_list_.empty()) {
+  if (result_idx_ < results_.count()) {
+    ObIKToken &token = results_.at(result_idx_++);
+    if (result_idx_ < results_.count()) {
       if (OB_FAIL(compound(token))) {
         LOG_WARN("Failed to compound", K(ret));
       } else {
@@ -216,11 +245,11 @@ int TokenizeContext::get_next_token(const char *&word,
 int TokenizeContext::compound(ObIKToken &token)
 {
   int ret = OB_SUCCESS;
-  ObList<ObIKToken, ObIAllocator> &list = result_list_;
+  ObFastSegmentArray<ObIKToken> &list = results_;
   if (is_smart_) {
-    if (!list.empty()) {
+    if (result_idx_ < list.count()) {
       if (ObIKTokenType::IK_ARABIC_TOKEN == token.type_) {
-        ObIKToken &next = list.get_first();
+        ObIKToken &next = list.at(result_idx_);
         bool append = false;
 
         if (ObIKTokenType::IK_CNNUM_TOKEN == next.type_) {
@@ -243,12 +272,12 @@ int TokenizeContext::compound(ObIKToken &token)
           // pass
         }
         if (append) {
-          list.pop_front();
+          ++result_idx_;
         }
       }
       // There may be another round of append
-      if (OB_SUCC(ret)) {
-        ObIKToken next = list.get_first();
+      if (OB_SUCC(ret) && result_idx_ < list.count()) {
+        ObIKToken &next = list.at(result_idx_);
         bool append = false;
         if (ObIKTokenType::IK_COUNT_TOKEN == next.type_) {
           if (token.offset_ + token.length_ == next.offset_) {
@@ -258,7 +287,7 @@ int TokenizeContext::compound(ObIKToken &token)
           }
         }
         if (append) {
-          list.pop_front();
+          ++result_idx_;
         }
       }
     }

--- a/src/storage/fts/ik/ob_ik_processor.h
+++ b/src/storage/fts/ik/ob_ik_processor.h
@@ -21,6 +21,7 @@
 #include "lib/charset/ob_charset.h"
 #include "lib/utility/ob_macro_utils.h"
 #include "storage/fts/ik/ob_ik_char_util.h"
+#include "storage/fts/ik/ob_fast_segment_array.h"
 #include "storage/fts/ik/ob_ik_token.h"
 
 namespace oceanbase
@@ -39,14 +40,16 @@ public:
   ~TokenizeContext();
 
   int init();
+  int reuse_context(const char *fulltext, const int64_t fulltext_len);
   int reset_resource();
 
   int get_next_token(const char *&word, int64_t &word_len, int64_t &offset, int64_t &char_cnt);
 
   int compound(ObIKToken &result);
 
-  int current_char(const char *&ch, uint8_t &char_len);
-  int current_char_type(ObFTCharUtil::CharType &type);
+  int current_char_and_type(const char *&ch,
+                            uint8_t &char_len,
+                            ObFTCharUtil::CharType &type);
 
   int step_next();
 
@@ -59,6 +62,7 @@ public:
   bool is_last() const;
   bool iter_end() const;
   bool is_smart() const;
+  bool is_results_exhaust() const;
 
   int add_chain(ObIKTokenChain *chain);
   int add_token(const char *fulltext,
@@ -67,11 +71,25 @@ public:
                 int64_t char_cnt,
                 ObIKTokenType type);
 
-  ObFTSortList &token_list() { return token_list_; }
+  ObFTFastSortList &token_list() { return token_list_; }
 
-  ObList<ObIKToken, ObIAllocator> &result_list() { return result_list_; }
+  ObFastSegmentArray<ObIKToken> &get_results() { return results_; }
 
   int32_t handle_size() const { return handle_size_; }
+
+  void set_buffer_start_cursor() { buffer_start_cursor_ = cursor_; }
+  int64_t get_buffer_start_cursor() const { return buffer_start_cursor_; }
+  int64_t get_buffer_end_cursor() const { return cursor_; }
+  const ObCharsetInfo *get_charset_info() const { return charset_info_; }
+  ObCharsetType get_charset_type() const { return charset_type_; }
+  size_t (*get_well_formed_len() const)(const ObCharsetInfo *,
+                                        const char *,
+                                        const char *,
+                                        size_t,
+                                        int *)
+  {
+    return well_formed_len_;
+  }
 
 private:
   int prepare_next_char();
@@ -87,8 +105,17 @@ private:
   uint32_t handle_size_;
   bool is_smart_;
 
-  ObFTSortList token_list_;
-  ObList<ObIKToken, ObIAllocator> result_list_;
+  ObFTFastSortList token_list_;
+  ObFastSegmentArray<ObIKToken> results_;
+  int64_t result_idx_;
+  int64_t buffer_start_cursor_;
+  const ObCharsetInfo *charset_info_;
+  ObCharsetType charset_type_;
+  size_t (*well_formed_len_)(const ObCharsetInfo *,
+                             const char *,
+                             const char *,
+                             size_t,
+                             int *);
 
 private:
   DISALLOW_COPY_AND_ASSIGN(TokenizeContext);
@@ -108,6 +135,7 @@ public:
                          const uint8_t char_len,
                          const ObFTCharUtil::CharType type)
       = 0;
+  virtual void reuse() = 0;
 };
 
 } // namespace storage

--- a/src/storage/fts/ik/ob_ik_quantifier_processor.h
+++ b/src/storage/fts/ik/ob_ik_quantifier_processor.h
@@ -40,6 +40,13 @@ public:
                  const char *ch,
                  const uint8_t char_len,
                  const ObFTCharUtil::CharType type);
+  void reuse() override
+  {
+    count_hits_.clear();
+    start_ = -1;
+    end_ = -1;
+    quan_char_cnt_ = 0;
+  }
 
 private:
   int process_CN_number(TokenizeContext &ctx,

--- a/src/storage/fts/ik/ob_ik_surrogate_processor.h
+++ b/src/storage/fts/ik/ob_ik_surrogate_processor.h
@@ -34,6 +34,7 @@ public:
                  const char *ch,
                  const uint8_t char_len,
                  const ObFTCharUtil::CharType type) override;
+  void reuse() override { reset(); }
 
 private:
   void reset()

--- a/src/storage/fts/ik/ob_ik_token.cpp
+++ b/src/storage/fts/ik/ob_ik_token.cpp
@@ -25,7 +25,8 @@ namespace oceanbase
 {
 namespace storage
 {
-int ObFTSortList::add_token(const ObIKToken &token)
+template <typename ListType>
+int ObFTSortListImpl<ListType>::add_token(const ObIKToken &token)
 {
   int ret = OB_SUCCESS;
 
@@ -44,7 +45,8 @@ int ObFTSortList::add_token(const ObIKToken &token)
       LOG_WARN("fail to push back token", K(ret));
     }
   } else {
-    for (ObFTSortList::CellIter iter = tokens_.last(); OB_SUCC(ret) && iter != tokens_.end();
+    for (typename ObFTSortListImpl<ListType>::CellIter iter = tokens_.last();
+         OB_SUCC(ret) && iter != tokens_.end();
          --iter) {
       if (token < *iter) {
         continue;
@@ -218,19 +220,24 @@ int ObIKTokenChain::pop_back(ObIKToken &token)
   return ret;
 }
 
-int64_t ObFTSortList::max()
+template <typename ListType>
+int64_t ObFTSortListImpl<ListType>::max()
 {
   if (tokens_.empty()) {
     return 0;
   }
   return tokens_.get_last().offset_ + tokens_.get_last().length_;
 }
-int64_t ObFTSortList::min()
+template <typename ListType>
+int64_t ObFTSortListImpl<ListType>::min()
 {
   if (tokens_.empty()) {
     return 0;
   }
   return tokens_.get_first().offset_;
 }
+
+template class ObFTSortListImpl<ObList<ObIKToken, ObIAllocator>>;
+template class ObFTSortListImpl<ObFastList<ObIKToken, IK_HANDLE_SIZE_LIMIT>>;
 } //  namespace storage
 } //  namespace oceanbase

--- a/src/storage/fts/ik/ob_ik_token.h
+++ b/src/storage/fts/ik/ob_ik_token.h
@@ -19,10 +19,12 @@
 
 #include "lib/allocator/ob_allocator.h"
 #include "lib/list/ob_list.h"
+#include "storage/fts/ik/ob_fast_list.h"
 namespace oceanbase
 {
 namespace storage
 {
+static constexpr int64_t IK_HANDLE_SIZE_LIMIT = 256;
 enum class ObIKTokenType : int8_t
 {
   IK_CHINESE_TOKEN = 0,
@@ -71,11 +73,12 @@ public:
   }
 };
 
-class ObFTSortList
+template <typename ListType>
+class ObFTSortListImpl
 {
 public:
-  ObFTSortList(ObIAllocator &alloc) : tokens_(alloc) {}
-  ~ObFTSortList() { tokens_.reset(); }
+  ObFTSortListImpl(ObIAllocator &alloc) : tokens_(alloc) {}
+  ~ObFTSortListImpl() { tokens_.reset(); }
 
   int add_token(const ObIKToken &token);
 
@@ -87,16 +90,19 @@ public:
 
   int64_t max();
 
-  ObList<ObIKToken, ObIAllocator> &tokens() { return tokens_; }
-  const ObList<ObIKToken, ObIAllocator> &tokens() const { return tokens_; }
+  ListType &tokens() { return tokens_; }
+  const ListType &tokens() const { return tokens_; }
 
 public:
-  typedef ObList<ObIKToken, ObIAllocator>::iterator CellIter;
-  typedef ObList<ObIKToken, ObIAllocator>::const_iterator ConstCellIter;
+  typedef typename ListType::iterator CellIter;
+  typedef typename ListType::const_iterator ConstCellIter;
 
 private:
-  ObList<ObIKToken, ObIAllocator> tokens_;
+  ListType tokens_;
 };
+
+typedef ObFTSortListImpl<ObList<ObIKToken, ObIAllocator>> ObFTSortList;
+typedef ObFTSortListImpl<ObFastList<ObIKToken, IK_HANDLE_SIZE_LIMIT>> ObFTFastSortList;
 
 class ObIKTokenChain
 {

--- a/src/storage/fts/ob_beng_ft_parser.cpp
+++ b/src/storage/fts/ob_beng_ft_parser.cpp
@@ -44,6 +44,8 @@ int ObBEngFTParser::get_next_token(
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("beng ft parser isn't initialized", K(ret), K(is_inited_));
+  } else if (use_ascii_fast_path_) {
+    ret = get_next_ascii_token(word, word_len, char_len, word_freq);
   } else if (OB_ISNULL(token_stream_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("token stream is nullptr", K(ret), KP(token_stream_));
@@ -68,6 +70,72 @@ int ObBEngFTParser::get_next_token(
   return ret;
 }
 
+bool ObBEngFTParser::is_ascii_alnum(const unsigned char ch)
+{
+  return ('0' <= ch && '9' >= ch)
+      || ('A' <= ch && 'Z' >= ch)
+      || ('a' <= ch && 'z' >= ch);
+}
+
+bool ObBEngFTParser::is_ascii_document(const char *text, const int64_t text_len)
+{
+  bool is_ascii = OB_NOT_NULL(text) && 0 < text_len;
+  for (int64_t i = 0; is_ascii && i < text_len; ++i) {
+    is_ascii = 0 == (static_cast<unsigned char>(text[i]) & 0x80);
+  }
+  return is_ascii;
+}
+
+int ObBEngFTParser::get_next_ascii_token(
+    const char *&word,
+    int64_t &word_len,
+    int64_t &char_len,
+    int64_t &word_freq)
+{
+  int ret = OB_SUCCESS;
+  const char *text = doc_.ptr_;
+  const int64_t text_len = doc_.len_;
+  while (ascii_pos_ < text_len
+      && !is_ascii_alnum(static_cast<unsigned char>(text[ascii_pos_]))) {
+    ++ascii_pos_;
+  }
+  if (ascii_pos_ >= text_len) {
+    ret = OB_ITER_END;
+  } else {
+    const int64_t token_start = ascii_pos_;
+    bool need_lower = false;
+    while (ascii_pos_ < text_len
+        && is_ascii_alnum(static_cast<unsigned char>(text[ascii_pos_]))) {
+      const unsigned char ch = static_cast<unsigned char>(text[ascii_pos_]);
+      need_lower = need_lower || ('A' <= ch && 'Z' >= ch);
+      ++ascii_pos_;
+    }
+    const int64_t token_len = ascii_pos_ - token_start;
+    if (need_lower) {
+      char *buf = static_cast<char *>(scratch_allocator_.alloc(token_len));
+      if (OB_ISNULL(buf)) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+        LOG_WARN("fail to allocate ascii token memory", K(ret), K(token_len));
+      } else {
+        for (int64_t i = 0; i < token_len; ++i) {
+          const unsigned char ch = static_cast<unsigned char>(text[token_start + i]);
+          buf[i] = ('A' <= ch && 'Z' >= ch)
+              ? static_cast<char>(ch + ('a' - 'A')) : static_cast<char>(ch);
+        }
+        word = buf;
+      }
+    } else {
+      word = text + token_start;
+    }
+    if (OB_SUCC(ret)) {
+      word_len = token_len;
+      char_len = token_len;
+      word_freq = 1;
+    }
+  }
+  return ret;
+}
+
 int ObBEngFTParser::reuse_parser(const char *fulltext, const int64_t fulltext_len)
 {
   int ret = OB_SUCCESS;
@@ -82,7 +150,11 @@ int ObBEngFTParser::reuse_parser(const char *fulltext, const int64_t fulltext_le
     LOG_WARN("document is too large for english analyzer", K(ret), K(fulltext_len));
   } else {
     doc_.set_string(fulltext, fulltext_len);
-    if (OB_FAIL(segment(doc_, token_stream_))) {
+    ascii_pos_ = 0;
+    use_ascii_fast_path_ = is_ascii_document(fulltext, fulltext_len);
+    if (use_ascii_fast_path_) {
+      token_stream_ = nullptr;
+    } else if (OB_FAIL(segment(doc_, token_stream_))) {
       LOG_WARN("fail to segment fulltext", K(ret));
     } else if (OB_ISNULL(token_stream_)) {
       ret = OB_ERR_UNEXPECTED;
@@ -109,11 +181,13 @@ int ObBEngFTParser::init(ObFTParserParam *param)
     analysis_ctx_.cs_ = param->cs_;
     analysis_ctx_.filter_stopword_ = false;
     analysis_ctx_.need_grouping_ = false;
+    ascii_pos_ = 0;
+    use_ascii_fast_path_ = is_ascii_document(param->fulltext_, param->ft_length_);
     if (OB_FAIL(english_analyzer_.init(analysis_ctx_, metadata_allocator_))) {
       LOG_WARN("fail to init english analyzer", K(ret), KPC(param), K(analysis_ctx_));
-    } else if (OB_FAIL(segment(doc_, token_stream_))) {
+    } else if (!use_ascii_fast_path_ && OB_FAIL(segment(doc_, token_stream_))) {
       LOG_WARN("fail to segment fulltext by parser", K(ret), KP(param->fulltext_), K(param->ft_length_));
-    } else if (OB_ISNULL(token_stream_)) {
+    } else if (!use_ascii_fast_path_ && OB_ISNULL(token_stream_)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("token stream is nullptr", K(ret), KP(token_stream_));
     } else {
@@ -150,6 +224,8 @@ void ObBEngFTParser::reset()
   english_analyzer_.reset();
   doc_.reset();
   token_stream_ = nullptr;
+  ascii_pos_ = 0;
+  use_ascii_fast_path_ = false;
   is_inited_ = false;
 }
 

--- a/src/storage/fts/ob_beng_ft_parser.cpp
+++ b/src/storage/fts/ob_beng_ft_parser.cpp
@@ -54,7 +54,7 @@ int ObBEngFTParser::get_next_token(
   } else if (OB_ISNULL(token.ptr_) || OB_UNLIKELY(0 >= token.len_ || 0 >= token_freq)) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid arguments", K(ret), KP(token.ptr_), K(token.len_), K(token_freq));
-  } else if (OB_ISNULL(buf = static_cast<char *>(allocator_.alloc(token.len_)))) {
+  } else if (OB_ISNULL(buf = static_cast<char *>(scratch_allocator_.alloc(token.len_)))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("fail to allocate word memory", K(ret), K(token.len_));
   } else {
@@ -64,6 +64,30 @@ int ObBEngFTParser::get_next_token(
     char_len = token.len_;
     word_freq = token_freq;
     LOG_DEBUG("succeed to add word", K(ObString(word_len, word)), K(word_freq));
+  }
+  return ret;
+}
+
+int ObBEngFTParser::reuse_parser(const char *fulltext, const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("basic english ft parser has not been initialized", K(ret));
+  } else if (OB_ISNULL(fulltext) || OB_UNLIKELY(fulltext_len <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext for parser reuse", K(ret), KP(fulltext), K(fulltext_len));
+  } else if (OB_UNLIKELY(UINT32_MAX < fulltext_len)) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_WARN("document is too large for english analyzer", K(ret), K(fulltext_len));
+  } else {
+    doc_.set_string(fulltext, fulltext_len);
+    if (OB_FAIL(segment(doc_, token_stream_))) {
+      LOG_WARN("fail to segment fulltext", K(ret));
+    } else if (OB_ISNULL(token_stream_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("token stream is null", K(ret));
+    }
   }
   return ret;
 }
@@ -85,7 +109,7 @@ int ObBEngFTParser::init(ObFTParserParam *param)
     analysis_ctx_.cs_ = param->cs_;
     analysis_ctx_.filter_stopword_ = false;
     analysis_ctx_.need_grouping_ = false;
-    if (OB_FAIL(english_analyzer_.init(analysis_ctx_, *param->allocator_))) {
+    if (OB_FAIL(english_analyzer_.init(analysis_ctx_, metadata_allocator_))) {
       LOG_WARN("fail to init english analyzer", K(ret), KPC(param), K(analysis_ctx_));
     } else if (OB_FAIL(segment(doc_, token_stream_))) {
       LOG_WARN("fail to segment fulltext by parser", K(ret), KP(param->fulltext_), K(param->ft_length_));
@@ -152,13 +176,25 @@ int ObBasicEnglishFTParserDesc::segment(
 {
   int ret = OB_SUCCESS;
   ObBEngFTParser *parser = nullptr;
+  ObIAllocator *metadata_allocator = nullptr;
+  ObIAllocator *scratch_allocator = nullptr;
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("default ft parser desc hasn't be initialized", K(ret), K(is_inited_));
   } else if (OB_ISNULL(param) || OB_ISNULL(param->fulltext_) || OB_UNLIKELY(!param->is_valid())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument", K(ret), KPC(param));
-  } else if (OB_ISNULL(parser = OB_NEWx(ObBEngFTParser, param->allocator_, *(param->allocator_)))) {
+  } else if (FALSE_IT(metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+          ? param->metadata_alloc_ : param->allocator_)) {
+  } else if (FALSE_IT(scratch_allocator = OB_NOT_NULL(param->scratch_alloc_)
+          ? param->scratch_alloc_ : param->allocator_)) {
+  } else if (OB_ISNULL(metadata_allocator) || OB_ISNULL(scratch_allocator)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("fulltext parser allocator is null", K(ret), KPC(param));
+  } else if (OB_ISNULL(parser = OB_NEWx(ObBEngFTParser,
+                                         metadata_allocator,
+                                         *metadata_allocator,
+                                         *scratch_allocator))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("fail to allocate basic english ft parser", K(ret));
   } else if (OB_FAIL(parser->init(param))) {
@@ -167,8 +203,8 @@ int ObBasicEnglishFTParserDesc::segment(
     iter = parser;
   }
 
-  if (OB_FAIL(ret)) {
-    OB_DELETEx(ObBEngFTParser, param->allocator_, parser);
+  if (OB_FAIL(ret) && OB_NOT_NULL(metadata_allocator)) {
+    OB_DELETEx(ObBEngFTParser, metadata_allocator, parser);
   }
 
   return ret;
@@ -180,9 +216,12 @@ void ObBasicEnglishFTParserDesc::free_token_iter(
 {
   if (OB_NOT_NULL(iter)) {
     abort_unless(nullptr != param);
-    abort_unless(nullptr != param->allocator_);
+    ObIAllocator *metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+        ? param->metadata_alloc_ : param->allocator_;
+    abort_unless(nullptr != metadata_allocator);
     iter->~ObITokenIterator();
-    param->allocator_->free(iter);
+    metadata_allocator->free(iter);
+    iter = nullptr;
   }
 }
 

--- a/src/storage/fts/ob_beng_ft_parser.h
+++ b/src/storage/fts/ob_beng_ft_parser.h
@@ -20,21 +20,23 @@
 #include "lib/utility/ob_macro_utils.h"
 #include "lib/utility/ob_print_utils.h"
 #include "share/text_analysis/ob_text_analyzer.h"
-#include "plugin/interface/ob_plugin_ftparser_intf.h"
+#include "storage/fts/ob_i_ft_parser.h"
 
 namespace oceanbase
 {
 namespace storage
 {
 
-class ObBEngFTParser final : public plugin::ObITokenIterator
+class ObBEngFTParser final : public ObIFTParser
 {
 public:
   static const int64_t FT_MIN_WORD_LEN = 3;
   static const int64_t FT_MAX_WORD_LEN = 84;
 public:
-  explicit ObBEngFTParser(common::ObIAllocator &allocator)
-    : allocator_(allocator),
+  ObBEngFTParser(common::ObIAllocator &metadata_allocator,
+                 common::ObIAllocator &scratch_allocator)
+    : metadata_allocator_(metadata_allocator),
+      scratch_allocator_(scratch_allocator),
       analysis_ctx_(),
       english_analyzer_(),
       doc_(),
@@ -45,6 +47,7 @@ public:
 
   int init(plugin::ObFTParserParam *param);
   void reset();
+  virtual int reuse_parser(const char *fulltext, const int64_t fulltext_len) override;
   virtual int get_next_token(
       const char *&word,
       int64_t &word_len,
@@ -57,7 +60,8 @@ private:
       const common::ObDatum &doc,
       share::ObITokenStream *&token_stream);
 private:
-  common::ObIAllocator &allocator_;
+  common::ObIAllocator &metadata_allocator_;
+  common::ObIAllocator &scratch_allocator_;
   share::ObTextAnalysisCtx analysis_ctx_;
   share::ObEnglishTextAnalyzer english_analyzer_;
   common::ObDatum doc_;

--- a/src/storage/fts/ob_beng_ft_parser.h
+++ b/src/storage/fts/ob_beng_ft_parser.h
@@ -41,6 +41,8 @@ public:
       english_analyzer_(),
       doc_(),
       token_stream_(nullptr),
+      ascii_pos_(0),
+      use_ascii_fast_path_(false),
       is_inited_(false)
   {}
   ~ObBEngFTParser() { reset(); }
@@ -59,6 +61,13 @@ private:
   int segment(
       const common::ObDatum &doc,
       share::ObITokenStream *&token_stream);
+  int get_next_ascii_token(
+      const char *&word,
+      int64_t &word_len,
+      int64_t &char_len,
+      int64_t &word_freq);
+  static bool is_ascii_document(const char *text, const int64_t text_len);
+  static bool is_ascii_alnum(const unsigned char ch);
 private:
   common::ObIAllocator &metadata_allocator_;
   common::ObIAllocator &scratch_allocator_;
@@ -66,6 +75,8 @@ private:
   share::ObEnglishTextAnalyzer english_analyzer_;
   common::ObDatum doc_;
   share::ObITokenStream *token_stream_;
+  int64_t ascii_pos_;
+  bool use_ascii_fast_path_;
   bool is_inited_;
 
   DISALLOW_COPY_AND_ASSIGN(ObBEngFTParser);

--- a/src/storage/fts/ob_ft_token_processor.cpp
+++ b/src/storage/fts/ob_ft_token_processor.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#define USING_LOG_PREFIX STORAGE_FTS
+
+#include "storage/fts/ob_ft_token_processor.h"
+
+#include "storage/fts/ob_fts_parser_property.h"
+#include "storage/fts/ob_fts_plugin_helper.h"
+
+namespace oceanbase
+{
+namespace storage
+{
+
+int ObFTTokenProcessor::init(
+    const ObFTParserProperty &property,
+    const ObObjMeta &meta,
+    const ObAddWordFlag &flag,
+    ObFTTokenMap *token_map)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(is_inited_)) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("fulltext token processor initialized twice", K(ret));
+  } else if (OB_ISNULL(token_map)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("fulltext token map is null", K(ret));
+  } else {
+    sql::ObExprBasicFuncs *basic_funcs =
+        ObDatumFuncs::get_basic_func(meta.get_type(), meta.get_collation_type());
+    ObDatumCmpFuncType cmp_func = get_datum_cmp_func(meta, meta);
+    if (OB_ISNULL(basic_funcs) || OB_ISNULL(basic_funcs->default_hash_)
+        || OB_ISNULL(cmp_func)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("failed to get token datum functions", K(ret), K(meta));
+    } else if (flag.stopword()
+        && OB_FAIL(ObFTParsePluginData::instance().get_stop_token_checker(
+            meta.get_collation_type(), stop_token_checker_))) {
+      LOG_WARN("failed to get stop token checker", K(ret), K(meta));
+    } else {
+      token_meta_ = meta;
+      token_map_ = token_map;
+      non_stop_token_cnt_ = 0;
+      min_token_size_ = property.min_token_size_;
+      max_token_size_ = property.max_token_size_;
+      flag_ = flag;
+      hash_func_ = basic_funcs->default_hash_;
+      cmp_func_ = cmp_func;
+      is_inited_ = true;
+    }
+  }
+  return ret;
+}
+
+void ObFTTokenProcessor::reset()
+{
+  token_meta_.reset();
+  token_map_ = nullptr;
+  non_stop_token_cnt_ = 0;
+  min_token_size_ = 0;
+  max_token_size_ = 0;
+  flag_.clear();
+  hash_func_ = nullptr;
+  cmp_func_ = nullptr;
+  stop_token_checker_.reset();
+  is_inited_ = false;
+}
+
+void ObFTTokenProcessor::reuse()
+{
+  non_stop_token_cnt_ = 0;
+}
+
+int ObFTTokenProcessor::process_token(
+    const char *token,
+    const int64_t token_len,
+    const int64_t char_cnt,
+    const int64_t token_freq)
+{
+  int ret = OB_SUCCESS;
+  bool is_stop_token = false;
+  ObFTToken ft_token;
+  ObString source(token_len, token);
+  ObString regularized;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("fulltext token processor is not initialized", K(ret));
+  } else if (OB_ISNULL(token) || OB_UNLIKELY(token_len <= 0 || char_cnt <= 0 || token_freq <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext token", K(ret), KP(token), K(token_len), K(char_cnt), K(token_freq));
+  } else if (flag_.casedown()
+      && OB_FAIL(ObCharset::tolower(token_meta_.get_collation_type(),
+                                    source,
+                                    regularized,
+                                    scratch_allocator_))) {
+    LOG_WARN("failed to lowercase fulltext token", K(ret), K(token_meta_), K(token_len));
+  } else if (flag_.casedown() && regularized.empty()) {
+    // Invalid token text is filtered, matching the legacy token processor.
+  } else if (OB_FAIL(ft_token.init(flag_.casedown() ? regularized.ptr() : token,
+                                   flag_.casedown() ? regularized.length() : token_len,
+                                   token_meta_,
+                                   hash_func_,
+                                   cmp_func_))) {
+    LOG_WARN("failed to initialize fulltext token", K(ret), K(token_len), K(char_cnt));
+  } else if (!ft_token.empty() && is_min_max_token(char_cnt)) {
+    // Filtered by configured token length.
+  } else if (!ft_token.empty() && flag_.stopword()
+      && OB_FAIL(stop_token_checker_.check_is_stop_token(ft_token, is_stop_token))) {
+    LOG_WARN("failed to check stop token", K(ret), K(ft_token));
+  } else if (!ft_token.empty() && is_stop_token) {
+    // Filtered by the immutable per-collation stop-token table.
+  } else if (!ft_token.empty() && OB_FAIL(groupby_token(ft_token, token_freq))) {
+    LOG_WARN("failed to aggregate fulltext token", K(ret), K(ft_token), K(token_freq));
+  } else if (!ft_token.empty()) {
+    non_stop_token_cnt_ += token_freq;
+  }
+  return ret;
+}
+
+bool ObFTTokenProcessor::is_min_max_token(const int64_t char_cnt) const
+{
+  return char_cnt > MAX_CHAR_COUNT_PER_TOKEN
+      || (flag_.min_max_word()
+          && (char_cnt < min_token_size_ || char_cnt > max_token_size_));
+}
+
+int ObFTTokenProcessor::groupby_token(const ObFTToken &token, const int64_t token_freq)
+{
+  int ret = OB_SUCCESS;
+  if (flag_.groupby_word()) {
+    ObFTTokenInfo token_info;
+    UpdateTokenCallback callback(token_freq);
+    token_info.count_ = token_freq;
+    if (OB_FAIL(token_map_->set_or_update(token, token_info, callback))) {
+      LOG_WARN("failed to set or update token", K(ret), K(token), K(token_freq));
+    }
+  }
+  return ret;
+}
+
+} // namespace storage
+} // namespace oceanbase

--- a/src/storage/fts/ob_ft_token_processor.h
+++ b/src/storage/fts/ob_ft_token_processor.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#ifndef OB_FT_TOKEN_PROCESSOR_H_
+#define OB_FT_TOKEN_PROCESSOR_H_
+
+#include "storage/fts/ob_fts_stop_token_check.h"
+
+namespace oceanbase
+{
+namespace storage
+{
+
+class ObFTParserProperty;
+
+class ObFTTokenProcessor final
+{
+public:
+  explicit ObFTTokenProcessor(ObIAllocator &scratch_allocator)
+      : is_inited_(false), token_meta_(), token_map_(nullptr),
+        non_stop_token_cnt_(0), min_token_size_(0), max_token_size_(0),
+        flag_(), hash_func_(nullptr), cmp_func_(nullptr), stop_token_checker_(),
+        scratch_allocator_(scratch_allocator)
+  {}
+  ~ObFTTokenProcessor() = default;
+
+  int init(const ObFTParserProperty &property,
+           const ObObjMeta &meta,
+           const ObAddWordFlag &flag,
+           ObFTTokenMap *token_map);
+  void reset();
+  void reuse();
+  int process_token(const char *token,
+                    const int64_t token_len,
+                    const int64_t char_cnt,
+                    const int64_t token_freq);
+  OB_INLINE int64_t get_non_stop_token_count() const { return non_stop_token_cnt_; }
+
+private:
+  class UpdateTokenCallback final
+  {
+  public:
+    explicit UpdateTokenCallback(const int64_t count) : count_(count) {}
+    int operator()(ObFTTokenPair &pair)
+    {
+      pair.second.count_ += count_;
+      return OB_SUCCESS;
+    }
+  private:
+    int64_t count_;
+  };
+
+  bool is_min_max_token(const int64_t char_cnt) const;
+  int groupby_token(const ObFTToken &token, const int64_t token_freq);
+
+private:
+  static const int64_t MAX_CHAR_COUNT_PER_TOKEN = 1024;
+  bool is_inited_;
+  ObObjMeta token_meta_;
+  ObFTTokenMap *token_map_;
+  int64_t non_stop_token_cnt_;
+  int64_t min_token_size_;
+  int64_t max_token_size_;
+  ObAddWordFlag flag_;
+  ObDatumHashFuncType hash_func_;
+  ObDatumCmpFuncType cmp_func_;
+  ObStopTokenChecker stop_token_checker_;
+  ObIAllocator &scratch_allocator_;
+};
+
+} // namespace storage
+} // namespace oceanbase
+
+#endif // OB_FT_TOKEN_PROCESSOR_H_

--- a/src/storage/fts/ob_fts_literal.h
+++ b/src/storage/fts/ob_fts_literal.h
@@ -18,6 +18,7 @@
 #define _OCEANBASE_STORAGE_FTS_OB_FTS_LITERAL_H_
 
 #include <cstdint>
+#include "share/inner_table/ob_inner_table_schema_constants.h"
 namespace oceanbase
 {
 namespace storage
@@ -36,7 +37,12 @@ public:
   static constexpr const char *CONFIG_NAME_NGRAM_TOKEN_SIZE = "ngram_token_size";
   static constexpr const char *CONFIG_NAME_STOPWORD_TABLE = "stopword_table";
   static constexpr const char *CONFIG_NAME_DICT_TABLE = "dict_table";
-  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE = "quanitfier_table";
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE = "quantifier_table";
+  // Compatibility for parser properties written before the spelling was fixed.
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE_LEGACY = "quanitfier_table";
+  static constexpr const char *CONFIG_NAME_STOPWORD_TABLE_ID = "stopword_table_id";
+  static constexpr const char *CONFIG_NAME_DICT_TABLE_ID = "dict_table_id";
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE_ID = "quantifier_table_id";
   static constexpr const char *CONFIG_NAME_IK_MODE = "ik_mode";
   static constexpr const char *CONFIG_NAME_MIN_NGRAM_SIZE = "min_ngram_size";
   static constexpr const char *CONFIG_NAME_MAX_NGRAM_SIZE = "max_ngram_size";

--- a/src/storage/fts/ob_fts_parser_property.cpp
+++ b/src/storage/fts/ob_fts_parser_property.cpp
@@ -27,6 +27,9 @@
 #include "lib/utility/ob_print_utils.h"
 #include "storage/fts/ob_fts_literal.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
+#include "share/ob_server_struct.h"
+#include "share/schema/ob_multi_version_schema_service.h"
+#include "sql/resolver/ddl/ob_fts_parser_resolver.h"
 
 #define USING_LOG_PREFIX STORAGE_FTS
 
@@ -203,6 +206,42 @@ int ObFTParserJsonProps::config_set_quantifier_table(const ObString &str)
   }
 
   return ret;
+}
+
+int ObFTParserJsonProps::config_set_table_id(const char *config_name, const uint64_t table_id)
+{
+  int ret = OB_SUCCESS;
+  ObJsonUint *table_id_node = nullptr;
+  if (!IS_INIT) {
+    ret = OB_NOT_INIT;
+  } else if (OB_ISNULL(config_name) || OB_INVALID_ID == table_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table id", K(ret), KP(config_name), K(table_id));
+  } else if (OB_ISNULL(table_id_node = OB_NEWx(ObJsonUint, &allocator_, table_id))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("fail to allocate dictionary table id node", K(ret), K(table_id));
+  } else if (OB_FAIL(root_->object_add(ObString(config_name), table_id_node))) {
+    LOG_WARN("fail to add dictionary table id", K(ret), KCSTRING(config_name), K(table_id));
+  }
+  if (OB_FAIL(ret)) {
+    OB_DELETEx(ObJsonUint, &allocator_, table_id_node);
+  }
+  return ret;
+}
+
+int ObFTParserJsonProps::config_set_stopword_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_set_dict_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_set_quantifier_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID, table_id);
 }
 
 int ObFTParserJsonProps::config_set_ik_mode(const ObString &ik_mode)
@@ -458,20 +497,67 @@ int ObFTParserJsonProps::config_get_quantifier_table(ObString &str) const
     if (OB_FAIL(
             root_->get_object_value(ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE), value))) {
       if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = root_->get_object_value(
+            ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_LEGACY), value);
+        if (OB_FAIL(ret) && OB_SEARCH_NOT_FOUND != ret) {
+          LOG_WARN("Fail to get legacy quanitfier_table", K(ret));
+        }
       } else {
         LOG_WARN("Fail to get quantifier_table", K(ret));
       }
-    } else if (OB_ISNULL(value)) {
+    }
+    if (OB_SUCC(ret) && OB_ISNULL(value)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("value is null", K(ret));
-    } else if (value->json_type() != ObJsonNodeType::J_STRING) {
+    } else if (OB_SUCC(ret) && value->json_type() != ObJsonNodeType::J_STRING) {
+      ret = OB_INVALID_ARGUMENT;
       LOG_WARN("value is not string", K(ret));
-    } else {
+    } else if (OB_SUCC(ret)) {
       ObJsonString *json_str = static_cast<ObJsonString *>(value);
       str = json_str->get_str();
     }
   }
   return ret;
+}
+
+int ObFTParserJsonProps::config_get_table_id(const char *config_name, uint64_t &table_id) const
+{
+  int ret = OB_SUCCESS;
+  ObIJsonBase *value = nullptr;
+  if (!IS_INIT) {
+    ret = OB_NOT_INIT;
+  } else if (OB_ISNULL(config_name)) {
+    ret = OB_INVALID_ARGUMENT;
+  } else if (OB_FAIL(root_->get_object_value(ObString(config_name), value))) {
+    if (OB_SEARCH_NOT_FOUND != ret) {
+      LOG_WARN("fail to get dictionary table id", K(ret), KCSTRING(config_name));
+    }
+  } else if (OB_ISNULL(value)) {
+    ret = OB_ERR_UNEXPECTED;
+  } else if (ObJsonNodeType::J_UINT == value->json_type()) {
+    table_id = value->get_uint();
+  } else if (ObJsonNodeType::J_INT == value->json_type() && value->get_int() >= 0) {
+    table_id = static_cast<uint64_t>(value->get_int());
+  } else {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("dictionary table id is not an unsigned integer", K(ret), KCSTRING(config_name));
+  }
+  return ret;
+}
+
+int ObFTParserJsonProps::config_get_stopword_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_get_dict_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_get_quantifier_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID, table_id);
 }
 
 int ObFTParserJsonProps::config_get_ik_mode(ObString &ik_mode) const
@@ -629,7 +715,11 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
   static const char *supported[] = {
       ObFTSLiteral::CONFIG_NAME_DICT_TABLE,
       ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE,
+      ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_LEGACY,
       ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE,
+      ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID,
+      ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID,
+      ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID,
       ObFTSLiteral::CONFIG_NAME_IK_MODE,
   };
 
@@ -658,6 +748,16 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
       // check dict table valid
     }
 
+    uint64_t table_id = OB_INVALID_ID;
+    if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_dict_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_dict_table_id(share::OB_FT_DICT_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default dictionary table id", K(ret));
+        }
+      }
+    }
+
     if (OB_FAIL(ret)) {
       // do nothing
     } else if (OB_FAIL(config_get_quantifier_table(table_name))) {
@@ -672,16 +772,34 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
     }
 
     if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_quantifier_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_quantifier_table_id(share::OB_FT_QUANTIFIER_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default quantifier table id", K(ret));
+        }
+      }
+    }
+
+    if (OB_FAIL(ret)) {
       // do nothing
-    } else if (OB_FAIL(config_get_quantifier_table(table_name))) {
+    } else if (OB_FAIL(config_get_stopword_table(table_name))) {
       if (OB_SEARCH_NOT_FOUND == ret) {
         if (OB_FAIL(
-                config_set_quantifier_table(ObFTSLiteral::FT_DEFAULT_IK_QUANTIFIER_UTF8_TABLE))) {
-          LOG_WARN("Failed to set default quantifier table", K(ret));
+                config_set_stopword_table(ObFTSLiteral::FT_DEFAULT_IK_STOPWORD_UTF8_TABLE))) {
+          LOG_WARN("Failed to set default stopword table", K(ret));
         }
       }
     } else {
-      // check quantifier table valid
+      // check stopword table valid
+    }
+
+    if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_stopword_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_stopword_table_id(share::OB_FT_STOPWORD_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default stopword table id", K(ret));
+        }
+      }
     }
 
     if (OB_FAIL(ret)) {
@@ -1138,6 +1256,54 @@ int ObFTParserJsonProps::show_parser_properties(const ObFTParserJsonProps &prope
       }
     }
 
+    ObString dict_table;
+    if (FAILEDx(properties.config_get_dict_table(dict_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get dict table", K(ret));
+      }
+    } else {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_DICT_TABLE,
+                                  dict_table.length(), dict_table.ptr()))) {
+        LOG_WARN("fail to print dict table", K(ret), K(dict_table));
+      }
+    }
+
+    ObString stopword_table;
+    if (OB_SUCC(ret) && FAILEDx(properties.config_get_stopword_table(stopword_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get stopword table", K(ret));
+      }
+    } else if (OB_SUCC(ret)) {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE,
+                                  stopword_table.length(), stopword_table.ptr()))) {
+        LOG_WARN("fail to print stopword table", K(ret), K(stopword_table));
+      }
+    }
+
+    ObString quantifier_table;
+    if (OB_SUCC(ret) && FAILEDx(properties.config_get_quantifier_table(quantifier_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get quantifier table", K(ret));
+      }
+    } else if (OB_SUCC(ret)) {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE,
+                                  quantifier_table.length(), quantifier_table.ptr()))) {
+        LOG_WARN("fail to print quantifier table", K(ret), K(quantifier_table));
+      }
+    }
+
     if (FAILEDx(databuff_printf(buf, buf_len, pos, ") "))) {
       LOG_WARN("fail to printf parser properties", K(ret), K(buf_len), K(pos), K(properties));
     }
@@ -1148,7 +1314,9 @@ int ObFTParserJsonProps::show_parser_properties(const ObFTParserJsonProps &prope
 
 #undef __FT_PARSER_PROPERTY_SHOW_COMMA
 
-int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser, const ObString &json_str)
+int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser,
+                                                const ObString &json_str,
+                                                ObIAllocator &allocator)
 {
   int ret = OB_SUCCESS;
   ObFTParserJsonProps props;
@@ -1158,12 +1326,55 @@ int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser, const 
     LOG_WARN("fail to parse from json str", K(ret), K(json_str));
   } else {
     if (parser.is_ik()) {
-      // set dict tables and copy dict name
-      dict_table_ = ObString(ObFTSLiteral::CONFIG_NAME_DICT_TABLE);
-      stopword_table_ = ObString(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE);
-      quantifier_table_ = ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE);
+      ObString table_name;
+      if (OB_FAIL(props.config_get_dict_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_DICT_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, dict_table_))) {
+        LOG_WARN("fail to copy dictionary table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret) && OB_FAIL(props.config_get_dict_table_id(dict_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          dict_table_id_ = share::OB_FT_DICT_IK_UTF8_TID;
+        }
+      }
+
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_stopword_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_STOPWORD_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, stopword_table_))) {
+        LOG_WARN("fail to copy stopword table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret) && OB_FAIL(props.config_get_stopword_table_id(stopword_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          stopword_table_id_ = share::OB_FT_STOPWORD_IK_UTF8_TID;
+        }
+      }
+
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_quantifier_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_QUANTIFIER_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, quantifier_table_))) {
+        LOG_WARN("fail to copy quantifier table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret)
+                 && OB_FAIL(props.config_get_quantifier_table_id(quantifier_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          quantifier_table_id_ = share::OB_FT_QUANTIFIER_IK_UTF8_TID;
+        }
+      }
+
       ObString ik_smart;
-      if (OB_FAIL(props.config_get_ik_mode(ik_smart))) {
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_ik_mode(ik_smart))) {
         if (OB_SEARCH_NOT_FOUND == ret) {
           // from old version, ik_mode is not set, so use default value
           ik_mode_smart_ = true;
@@ -1227,6 +1438,9 @@ ObFTParserProperty::ObFTParserProperty()
       stopword_table_(),
       dict_table_(),
       quantifier_table_(),
+      stopword_table_id_(share::OB_FT_STOPWORD_IK_UTF8_TID),
+      dict_table_id_(share::OB_FT_DICT_IK_UTF8_TID),
+      quantifier_table_id_(share::OB_FT_QUANTIFIER_IK_UTF8_TID),
       min_ngram_token_size_(ObFTSLiteral::FT_DEFAULT_MIN_NGRAM_SIZE),
       max_ngram_token_size_(ObFTSLiteral::FT_DEFAULT_MAX_NGRAM_SIZE)
 {
@@ -1236,10 +1450,22 @@ int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
                                                       ObIJsonBase *array,
                                                       ObString &json_str)
 {
+  return tokenize_array_to_props_json(
+      allocator, array, ObString(), OB_INVALID_TENANT_ID, json_str);
+}
+
+int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
+                                                      ObIJsonBase *array,
+                                                      const ObString &database_name,
+                                                      const uint64_t tenant_id,
+                                                      ObString &json_str)
+{
   int ret = OB_SUCCESS;
 
   ObArenaAllocator alloc;
   ObJsonObject properties_root(&alloc);
+  share::schema::ObSchemaGetterGuard schema_guard;
+  bool schema_guard_loaded = false;
 
   if (OB_ISNULL(array)) {
     ret = OB_INVALID_ARGUMENT;
@@ -1257,8 +1483,60 @@ int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
         ret = OB_INVALID_ARGUMENT;
       } else if (OB_FAIL(array_value_item->get_object_value(0, config_name, config_value))) {
         LOG_WARN("Fail to get object value", K(ret));
-      } else if (OB_FAIL(properties_root.object_add(config_name, config_value))) {
-        LOG_WARN("Fail to add object value", K(ret));
+      } else {
+        const bool is_dict_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_DICT_TABLE);
+        const bool is_stopword_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE);
+        const bool is_quantifier_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE);
+        if (!is_dict_table && !is_stopword_table && !is_quantifier_table) {
+          if (OB_FAIL(properties_root.object_add(config_name, config_value))) {
+            LOG_WARN("Fail to add object value", K(ret));
+          }
+        } else if (ObJsonNodeType::J_STRING != config_value->json_type()
+                   || OB_INVALID_TENANT_ID == tenant_id) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table config requires a valid string and tenant");
+        } else {
+          if (!schema_guard_loaded) {
+            if (OB_ISNULL(GCTX.schema_service_)) {
+              ret = OB_NOT_INIT;
+            } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+              LOG_WARN("fail to get schema guard for TOKENIZE", K(ret));
+            } else {
+              schema_guard_loaded = true;
+            }
+          }
+          uint64_t table_id = OB_INVALID_ID;
+          ObString full_table_name;
+          const ObString input_table_name(config_value->get_data_length(), config_value->get_data());
+          if (OB_FAIL(ret)) {
+          } else if (OB_FAIL(sql::ObFTParserResolverHelper::resolve_dict_table_name_and_id(
+                                 database_name,
+                                 input_table_name,
+                                 tenant_id,
+                                 schema_guard,
+                                 alloc,
+                                 table_id,
+                                 full_table_name))) {
+            LOG_WARN("fail to resolve TOKENIZE dictionary table", K(ret), K(input_table_name));
+          } else {
+            ObJsonString *table_name_node = OB_NEWx(ObJsonString, &alloc, full_table_name);
+            ObJsonUint *table_id_node = OB_NEWx(ObJsonUint, &alloc, table_id);
+            const char *id_config_name = is_dict_table
+                ? ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID
+                : (is_stopword_table ? ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID
+                                     : ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID);
+            if (OB_ISNULL(table_name_node) || OB_ISNULL(table_id_node)) {
+              ret = OB_ALLOCATE_MEMORY_FAILED;
+            } else if (OB_FAIL(properties_root.object_add(config_name, table_name_node))) {
+              LOG_WARN("fail to add TOKENIZE dictionary table name", K(ret));
+            } else if (OB_FAIL(properties_root.object_add(ObString(id_config_name), table_id_node))) {
+              LOG_WARN("fail to add TOKENIZE dictionary table id", K(ret));
+            }
+          }
+        }
       }
     }
     ObJsonBuffer j_buf(&allocator);

--- a/src/storage/fts/ob_fts_parser_property.h
+++ b/src/storage/fts/ob_fts_parser_property.h
@@ -51,6 +51,9 @@ public:
   int config_set_stopword_table(const ObString &str);
   int config_set_dict_table(const ObString &str);
   int config_set_quantifier_table(const ObString &str);
+  int config_set_stopword_table_id(const uint64_t table_id);
+  int config_set_dict_table_id(const uint64_t table_id);
+  int config_set_quantifier_table_id(const uint64_t table_id);
   int config_set_ik_mode(const ObString &ik_mode);
   int config_set_min_ngram_token_size(const int64_t size);
   int config_set_max_ngram_token_size(const int64_t size);
@@ -61,6 +64,9 @@ public:
   int config_get_stopword_table(ObString &str) const;
   int config_get_dict_table(ObString &str) const;
   int config_get_quantifier_table(ObString &str) const;
+  int config_get_stopword_table_id(uint64_t &table_id) const;
+  int config_get_dict_table_id(uint64_t &table_id) const;
+  int config_get_quantifier_table_id(uint64_t &table_id) const;
   int config_get_ik_mode(ObString &ik_mode) const;
   int config_get_min_ngram_token_size(int64_t &size) const;
   int config_get_max_ngram_token_size(int64_t &size) const;
@@ -108,6 +114,11 @@ public:
   static int tokenize_array_to_props_json(ObIAllocator &allocator,
                                           ObIJsonBase *array,
                                           ObString &json_str);
+  static int tokenize_array_to_props_json(ObIAllocator &allocator,
+                                          ObIJsonBase *array,
+                                          const ObString &database_name,
+                                          const uint64_t tenant_id,
+                                          ObString &json_str);
 
   static int show_parser_properties(const ObFTParserJsonProps &properties,
                                     char *buf,
@@ -117,6 +128,8 @@ public:
   TO_STRING_KV(K_(is_inited));
 
 private:
+  int config_set_table_id(const char *config_name, const uint64_t table_id);
+  int config_get_table_id(const char *config_name, uint64_t &table_id) const;
   int ik_rebuild_props_for_ddl(bool log_to_user);
   int ngram_rebuild_props_for_ddl(bool log_to_user);
   int space_rebuild_props_for_ddl(bool log_to_user);
@@ -137,7 +150,9 @@ struct ObFTParserProperty final
 public:
   ObFTParserProperty();
   ~ObFTParserProperty() = default;
-  int parse_for_parser_helper(const ObFTParser &parser, const ObString &json_str);
+  int parse_for_parser_helper(const ObFTParser &parser,
+                              const ObString &json_str,
+                              common::ObIAllocator &allocator);
 
   bool is_equal(const ObFTParserProperty &other) const
   {
@@ -145,6 +160,9 @@ public:
            && ngram_token_size_ == other.ngram_token_size_ && ik_mode_smart_ == other.ik_mode_smart_
            && stopword_table_ == other.stopword_table_ && dict_table_ == other.dict_table_
            && quantifier_table_ == other.quantifier_table_
+           && stopword_table_id_ == other.stopword_table_id_
+           && dict_table_id_ == other.dict_table_id_
+           && quantifier_table_id_ == other.quantifier_table_id_
            && min_ngram_token_size_ == other.min_ngram_token_size_
            && max_ngram_token_size_ == other.max_ngram_token_size_;
   }
@@ -155,6 +173,9 @@ public:
                K_(stopword_table),
                K_(dict_table),
                K_(quantifier_table),
+               K_(stopword_table_id),
+               K_(dict_table_id),
+               K_(quantifier_table_id),
                K_(min_ngram_token_size),
                K_(max_ngram_token_size),
                K_(ik_mode_smart));
@@ -167,6 +188,9 @@ public:
   common::ObString stopword_table_;
   common::ObString dict_table_;
   common::ObString quantifier_table_;
+  uint64_t stopword_table_id_;
+  uint64_t dict_table_id_;
+  uint64_t quantifier_table_id_;
   int64_t min_ngram_token_size_;
   int64_t max_ngram_token_size_;
 };

--- a/src/storage/fts/ob_fts_plugin_helper.cpp
+++ b/src/storage/fts/ob_fts_plugin_helper.cpp
@@ -21,12 +21,15 @@
 #include "storage/fts/ob_fts_plugin_helper.h"
 
 #include "common/json_type/ob_json_tree.h"
+#include "lib/worker.h"
 #include "plugin/interface/ob_plugin_ftparser_intf.h"
 #include "plugin/sys/ob_plugin_helper.h"
 #include "share/ob_force_print_log.h"
 #include "share/rc/ob_tenant_base.h"
 #include "storage/fts/dict/ob_ft_dict_hub.h"
 #include "storage/fts/ob_fts_parser_property.h"
+#include "storage/fts/ob_ft_token_processor.h"
+#include "storage/fts/ob_fts_stop_token_check.h"
 #include "storage/fts/ob_fts_stop_word.h"
 
 using namespace oceanbase::plugin;
@@ -152,6 +155,8 @@ int ObFTParsePluginData::init()
     LOG_WARN("fail to init tenant plugin handler allocator", K(ret));
   } else if (OB_FAIL(init_and_set_stopword_list())) {
     LOG_WARN("fail to init and set stopword list", K(ret));
+  } else if (OB_FAIL(init_stop_token_checker_gen())) {
+    LOG_WARN("fail to initialize stop token checker generator", K(ret));
   } else if (OB_FAIL(init_dict_hub())) {
     LOG_WARN("fail to init dict hub", K(ret));
   } else {
@@ -183,6 +188,23 @@ int ObFTParsePluginData::init_and_set_stopword_list()
   return ret;
 }
 
+int ObFTParsePluginData::init_stop_token_checker_gen()
+{
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(stop_token_checker_gen_ =
+          OB_NEWx(ObStopTokenCheckerGen, &handler_allocator_))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate stop token checker generator", K(ret));
+  } else if (OB_FAIL(stop_token_checker_gen_->init())) {
+    LOG_WARN("failed to initialize stop token checker generator", K(ret));
+  }
+  if (OB_FAIL(ret) && OB_NOT_NULL(stop_token_checker_gen_)) {
+    OB_DELETEx(ObStopTokenCheckerGen, &handler_allocator_, stop_token_checker_gen_);
+    stop_token_checker_gen_ = nullptr;
+  }
+  return ret;
+}
+
 int ObFTParsePluginData::init_dict_hub()
 {
   // make dict
@@ -198,6 +220,11 @@ int ObFTParsePluginData::init_dict_hub()
 
 void ObFTParsePluginData::destroy()
 {
+  if (OB_NOT_NULL(stop_token_checker_gen_)) {
+    stop_token_checker_gen_->reset();
+    OB_DELETEx(ObStopTokenCheckerGen, &handler_allocator_, stop_token_checker_gen_);
+    stop_token_checker_gen_ = nullptr;
+  }
   if (OB_NOT_NULL(stop_word_checker_)) {
     stop_word_checker_->destroy();
     OB_DELETEx(ObStopWordChecker, &handler_allocator_, stop_word_checker_);
@@ -213,6 +240,21 @@ void ObFTParsePluginData::destroy()
 
   handler_allocator_.reset();
   is_inited_ = false;
+}
+
+int ObFTParsePluginData::get_stop_token_checker(
+    const ObCollationType coll,
+    ObStopTokenChecker &stop_token_checker)
+{
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(stop_token_checker_gen_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("stop token checker generator is null", K(ret));
+  } else if (OB_FAIL(stop_token_checker_gen_->get_stop_token_checker_by_coll(
+      coll, stop_token_checker))) {
+    LOG_WARN("failed to get stop token checker", K(ret), K(coll));
+  }
+  return ret;
 }
 
 int ObFTParsePluginData::get_dict_hub(ObFTDictHub *&hub)
@@ -248,6 +290,8 @@ int ObFTParseHelper::segment(
     ObFTParserParam param;
     ObITokenIterator *iter = nullptr;
     param.allocator_ = &allocator;
+    param.metadata_alloc_ = &allocator;
+    param.scratch_alloc_ = &allocator;
     param.cs_ = cs;
     param.fulltext_ = ft;
     param.ft_length_ = ft_len;
@@ -294,6 +338,130 @@ int ObFTParseHelper::segment(
       iter = nullptr;
     }
   }
+  return ret;
+}
+
+int ObFTParseHelper::segment(
+    const ObObjMeta &meta,
+    const char *fulltext,
+    const int64_t fulltext_len,
+    int64_t &doc_length,
+    ObFTTokenMap &tokens) const
+{
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(allocator_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("fulltext parser helper allocator is null", K(ret), K_(is_inited));
+  } else if (OB_FAIL(segment(meta, fulltext, fulltext_len, doc_length,
+                             tokens, *allocator_))) {
+    LOG_WARN("failed to segment fulltext", K(ret), K(meta), K(fulltext_len));
+  }
+  return ret;
+}
+
+int ObFTParseHelper::segment(
+    const ObObjMeta &meta,
+    const char *fulltext,
+    const int64_t fulltext_len,
+    int64_t &doc_length,
+    ObFTTokenMap &tokens,
+    common::ObIAllocator &scratch_allocator) const
+{
+  int ret = OB_SUCCESS;
+  const ObCharsetInfo *cs = nullptr;
+  const ObCollationType type = meta.get_collation_type();
+  const bool need_tolower = parser_name_.is_builtin_parser() && add_word_flag_.casedown();
+  ObString source(fulltext_len, fulltext);
+  ObString regularized;
+  doc_length = 0;
+  tokens.reuse();
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("fulltext parser helper is not initialized", K(ret));
+  } else if (OB_ISNULL(allocator_) || OB_ISNULL(fulltext)
+      || OB_UNLIKELY(fulltext_len <= 0 || CS_TYPE_INVALID == type
+          || type >= CS_TYPE_PINYIN_BEGIN_MARK)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext segment arguments", K(ret), KP_(allocator),
+        KP(fulltext), K(fulltext_len), K(type));
+  } else if (OB_ISNULL(cs = ObCharset::get_charset(type))) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("failed to get fulltext charset", K(ret), K(type));
+  } else if (need_tolower
+      && OB_FAIL(ObCharset::tolower(cs, source, regularized, scratch_allocator))) {
+    LOG_WARN("failed to lowercase fulltext once", K(ret), K(type));
+  } else if (need_tolower && regularized.empty()) {
+    // Invalid source text yields no token, matching the old per-token path.
+  } else {
+    ObFTTokenProcessor token_processor(scratch_allocator);
+    ObFTParserParam param;
+    ObITokenIterator *iter = nullptr;
+    param.allocator_ = &scratch_allocator;
+    param.metadata_alloc_ = &scratch_allocator;
+    param.scratch_alloc_ = &scratch_allocator;
+    param.cs_ = cs;
+    param.fulltext_ = need_tolower ? regularized.ptr() : fulltext;
+    param.ft_length_ = need_tolower ? regularized.length() : fulltext_len;
+    param.parser_version_ = parser_name_.get_parser_version();
+    param.plugin_param_ = plugin_param_;
+    param.ngram_token_size_ = parser_property_.ngram_token_size_;
+    param.ik_param_.mode_ = parser_property_.ik_mode_smart_
+        ? ObFTIKParam::Mode::SMART : ObFTIKParam::Mode::MAX_WORD;
+    param.ik_param_.main_dict_ = parser_property_.dict_table_;
+    param.ik_param_.quan_dict_ = parser_property_.quantifier_table_;
+    param.ik_param_.stopword_dict_ = parser_property_.stopword_table_;
+    param.ik_param_.main_dict_id_ = parser_property_.dict_table_id_;
+    param.ik_param_.quan_dict_id_ = parser_property_.quantifier_table_id_;
+    param.ik_param_.stopword_dict_id_ = parser_property_.stopword_table_id_;
+    param.min_ngram_size_ = parser_property_.min_ngram_token_size_;
+    param.max_ngram_size_ = parser_property_.max_ngram_token_size_;
+    param.tenant_id_ = common::OB_SERVER_TENANT_ID;
+
+    ObAddWordFlag token_flag = add_word_flag_;
+    if (need_tolower) {
+      token_flag.clear_casedown();
+    }
+    if (OB_FAIL(token_processor.init(parser_property_, meta, token_flag, &tokens))) {
+      LOG_WARN("failed to initialize fulltext token processor", K(ret));
+    } else if (OB_FAIL(parser_desc_->segment(&param, iter))) {
+      LOG_WARN("failed to create token iterator", K(ret), K(param));
+    } else if (OB_ISNULL(iter)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("token iterator is null", K(ret));
+    } else {
+      const char *token = nullptr;
+      int64_t token_len = 0;
+      int64_t char_cnt = 0;
+      int64_t token_freq = 0;
+      int64_t check_interval = 0;
+      while (OB_SUCC(ret)) {
+        if (OB_FAIL(iter->get_next_token(token, token_len, char_cnt, token_freq))) {
+          if (OB_ITER_END != ret) {
+            LOG_WARN("failed to get next fulltext token", K(ret), KPC(iter));
+          }
+        } else if (OB_FAIL(token_processor.process_token(
+            token, token_len, char_cnt, token_freq))) {
+          LOG_WARN("failed to process fulltext token", K(ret), K(token_len), K(char_cnt));
+        } else if (++check_interval >= 100) {
+          if (OB_FAIL(THIS_WORKER.check_status())) {
+            LOG_WARN("worker interrupted during fulltext segmentation", K(ret));
+          } else {
+            check_interval = 0;
+          }
+        }
+      }
+      if (OB_ITER_END == ret) {
+        doc_length = token_processor.get_non_stop_token_count();
+        ret = OB_SUCCESS;
+      }
+    }
+    if (OB_NOT_NULL(iter)) {
+      parser_desc_->free_token_iter(&param, iter);
+      iter = nullptr;
+    }
+  }
+  LOG_DEBUG("optimized fulltext segment", K(ret), K(type), K(parser_name_),
+      K(fulltext_len), K(tokens.size()), K(doc_length));
   return ret;
 }
 
@@ -502,6 +670,53 @@ int ObFTParseHelper::make_detail_json(
   return ret;
 }
 
+int ObFTParseHelper::make_detail_json(
+    const ObFTTokenMap &tokens,
+    const int64_t doc_length,
+    common::ObIJsonBase *&json_root)
+{
+  int ret = OB_SUCCESS;
+  ObJsonObject *root_obj = nullptr;
+  ObJsonInt *cnt = nullptr;
+  ObJsonArray *token_array = nullptr;
+  if (OB_ISNULL(root_obj = OB_NEWx(ObJsonObject, allocator_, allocator_))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate token detail object", K(ret));
+  } else if (OB_ISNULL(cnt = OB_NEWx(ObJsonInt, allocator_, doc_length))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate document length", K(ret));
+  } else if (OB_ISNULL(token_array = OB_NEWx(ObJsonArray, allocator_, allocator_))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate token array", K(ret));
+  }
+  for (ObFTTokenMap::const_iterator iter = tokens.begin();
+       OB_SUCC(ret) && iter != tokens.end(); ++iter) {
+    ObJsonObject *node = nullptr;
+    ObJsonInt *token_cnt = nullptr;
+    const ObString key = iter->first.get_token().get_string();
+    if (OB_ISNULL(node = OB_NEWx(ObJsonObject, allocator_, allocator_))) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate token node", K(ret));
+    } else if (OB_ISNULL(token_cnt = OB_NEWx(ObJsonInt, allocator_, iter->second.count_))) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate token count", K(ret));
+    } else if (OB_FAIL(node->add(key, token_cnt))) {
+      LOG_WARN("failed to add token count", K(ret));
+    } else if (OB_FAIL(token_array->append(node))) {
+      LOG_WARN("failed to append token node", K(ret));
+    }
+  }
+  if (OB_SUCC(ret) && OB_FAIL(root_obj->add(ENTRY_NAME_TOKENS, token_array))) {
+    LOG_WARN("failed to add token array", K(ret));
+  } else if (OB_SUCC(ret) && OB_FAIL(root_obj->add(ENTRY_NAME_DOC_LEN, cnt))) {
+    LOG_WARN("failed to add document length", K(ret));
+  }
+  if (OB_SUCC(ret)) {
+    json_root = root_obj;
+  }
+  return ret;
+}
+
 int ObFTParseHelper::make_token_array_json(
     const ObFTWordMap &words,
     common::ObIJsonBase *&json_root)
@@ -531,6 +746,33 @@ int ObFTParseHelper::make_token_array_json(
     json_root = token_array;
   } else {
     OB_DELETEx(ObJsonArray, allocator_, token_array);
+  }
+  return ret;
+}
+
+int ObFTParseHelper::make_token_array_json(
+    const ObFTTokenMap &tokens,
+    common::ObIJsonBase *&json_root)
+{
+  int ret = OB_SUCCESS;
+  ObJsonArray *token_array = nullptr;
+  if (OB_ISNULL(token_array = OB_NEWx(ObJsonArray, allocator_, allocator_))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate token array", K(ret));
+  }
+  for (ObFTTokenMap::const_iterator iter = tokens.begin();
+       OB_SUCC(ret) && iter != tokens.end(); ++iter) {
+    ObJsonString *token = nullptr;
+    if (OB_ISNULL(token = OB_NEWx(ObJsonString, allocator_,
+        iter->first.get_token().get_string()))) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate token json string", K(ret));
+    } else if (OB_FAIL(token_array->append(token))) {
+      LOG_WARN("failed to append token json string", K(ret));
+    }
+  }
+  if (OB_SUCC(ret)) {
+    json_root = token_array;
   }
   return ret;
 }

--- a/src/storage/fts/ob_fts_plugin_helper.cpp
+++ b/src/storage/fts/ob_fts_plugin_helper.cpp
@@ -24,6 +24,7 @@
 #include "plugin/interface/ob_plugin_ftparser_intf.h"
 #include "plugin/sys/ob_plugin_helper.h"
 #include "share/ob_force_print_log.h"
+#include "share/rc/ob_tenant_base.h"
 #include "storage/fts/dict/ob_ft_dict_hub.h"
 #include "storage/fts/ob_fts_parser_property.h"
 #include "storage/fts/ob_fts_stop_word.h"
@@ -255,8 +256,15 @@ int ObFTParseHelper::segment(
     param.ngram_token_size_ = property.ngram_token_size_;
     param.ik_param_.mode_
         = (property.ik_mode_smart_ ? ObFTIKParam::Mode::SMART : ObFTIKParam::Mode::MAX_WORD);
+    param.ik_param_.main_dict_ = property.dict_table_;
+    param.ik_param_.quan_dict_ = property.quantifier_table_;
+    param.ik_param_.stopword_dict_ = property.stopword_table_;
+    param.ik_param_.main_dict_id_ = property.dict_table_id_;
+    param.ik_param_.quan_dict_id_ = property.quantifier_table_id_;
+    param.ik_param_.stopword_dict_id_ = property.stopword_table_id_;
     param.min_ngram_size_ = property.min_ngram_token_size_;
     param.max_ngram_size_ = property.max_ngram_token_size_;
+    param.tenant_id_ = common::OB_SERVER_TENANT_ID;
 
     if (OB_FAIL(parser_desc->segment(&param, iter))) {
       LOG_WARN("fail to segment", K(ret), K(param));
@@ -319,7 +327,8 @@ int ObFTParseHelper::init(
     LOG_WARN("invalid argument", K(ret), KP(allocator), K(plugin_name));
   } else if (OB_FAIL(parser_name_.parse_from_str(plugin_name.ptr(), plugin_name.length()))) {
     LOG_WARN("fail to parse name from cstring", K(ret), K(plugin_name));
-  } else if (OB_FAIL(parser_property_.parse_for_parser_helper(parser_name_, plugin_properties))) {
+  } else if (OB_FAIL(parser_property_.parse_for_parser_helper(
+                         parser_name_, plugin_properties, *allocator))) {
     LOG_WARN("fail to parse parser property from cstring", K(ret), K(plugin_properties), K(parser_name_));
   } else if (OB_FAIL(ObPluginHelper::find_ftparser(parser_name_.get_parser_name().str(),
                                                    parser_desc_, plugin_param_))) {
@@ -409,12 +418,14 @@ int ObFTParseHelper::check_is_the_same(
   if (is_inited_) {
     storage::ObFTParser parser_name;
     ObFTParserProperty parser_property;
+    ObArenaAllocator property_allocator("FTPropCmp");
     if (OB_UNLIKELY(plugin_name.empty())) {
       ret = OB_INVALID_ARGUMENT;
       LOG_WARN("invalid argument", K(ret), K(plugin_name));
     } else if (OB_FAIL(parser_name.parse_from_str(plugin_name.ptr(), plugin_name.length()))) {
       LOG_WARN("fail to parse name from cstring", K(ret), K(plugin_name));
-    } else if (OB_FAIL(parser_property.parse_for_parser_helper(parser_name, plugin_properties))) {
+    } else if (OB_FAIL(parser_property.parse_for_parser_helper(
+                           parser_name, plugin_properties, property_allocator))) {
       LOG_WARN("fail to parse parser property from cstring", K(ret), K(plugin_properties), K(parser_name_));
     } else if (parser_name == parser_name_ && parser_property.is_equal(parser_property_)) {
       is_same = true;

--- a/src/storage/fts/ob_fts_plugin_helper.h
+++ b/src/storage/fts/ob_fts_plugin_helper.h
@@ -42,6 +42,8 @@ namespace storage
 {
 
 class ObStopWordChecker;
+class ObStopTokenChecker;
+class ObStopTokenCheckerGen;
 class ObFTDictHub;
 class ObAddWord;
 
@@ -82,6 +84,10 @@ public:
   OB_INLINE int64_t get_parser_version() const { return parser_version_; }
   OB_INLINE bool is_valid() const { return parser_name_.is_valid() && parser_version_ >= 0; }
   OB_INLINE bool is_type_before_4_3_5_1() const { return is_space() || is_beng() || is_ngram(); }
+  OB_INLINE bool is_builtin_parser() const
+  {
+    return is_space() || is_ngram() || is_beng() || is_ik() || is_ngram2();
+  }
   OB_INLINE void set_name_and_version(const share::ObPluginName &name, const int64_t version)
   {
     parser_name_ = name;
@@ -120,14 +126,18 @@ public:
 
 public:
   ObStopWordChecker *stop_word_checker() const { return stop_word_checker_; }
+  int get_stop_token_checker(const ObCollationType coll,
+                             ObStopTokenChecker &stop_token_checker);
   int get_dict_hub(ObFTDictHub *&hub);
 
 private:
   int init_and_set_stopword_list();
+  int init_stop_token_checker_gen();
   int init_dict_hub();
 
 private:
   ObStopWordChecker *     stop_word_checker_ = nullptr;
+  ObStopTokenCheckerGen * stop_token_checker_gen_ = nullptr;
   ObFTDictHub *           dict_hub_          = nullptr;
   common::ObFIFOAllocator handler_allocator_;
   bool                    is_inited_         = false;
@@ -178,6 +188,19 @@ public:
       const int64_t fulltext_len,
       int64_t &doc_length,
       ObFTWordMap &words) const;
+  int segment(
+      const common::ObObjMeta &meta,
+      const char *fulltext,
+      const int64_t fulltext_len,
+      int64_t &doc_length,
+      ObFTTokenMap &tokens) const;
+  int segment(
+      const common::ObObjMeta &meta,
+      const char *fulltext,
+      const int64_t fulltext_len,
+      int64_t &doc_length,
+      ObFTTokenMap &tokens,
+      common::ObIAllocator &scratch_allocator) const;
   int check_is_the_same(
       const common::ObString &plugin_name,
       const common::ObString &plugin_properties,
@@ -193,6 +216,10 @@ public:
       const ObFTWordMap &words,
       const int64_t doc_length,
       common::ObIJsonBase *&json_root);
+  int make_detail_json(
+      const ObFTTokenMap &tokens,
+      const int64_t doc_length,
+      common::ObIJsonBase *&json_root);
 
   /**
    * Make json document for fulltext search
@@ -203,8 +230,18 @@ public:
   int make_token_array_json(
       const ObFTWordMap &words,
       common::ObIJsonBase *&json_root);
+  int make_token_array_json(
+      const ObFTTokenMap &tokens,
+      common::ObIJsonBase *&json_root);
 
   void reset();
+
+  OB_INLINE const ObFTParser &get_parser_name() const { return parser_name_; }
+  OB_INLINE plugin::ObPluginParam *get_plugin_param() const { return plugin_param_; }
+  OB_INLINE const ObFTParserProperty &get_parser_property() const { return parser_property_; }
+  OB_INLINE const plugin::ObIFTParserDesc *get_parser_desc() const { return parser_desc_; }
+  OB_INLINE const ObAddWordFlag &get_process_token_flags() const { return add_word_flag_; }
+  OB_INLINE bool is_builtin_parser() const { return parser_name_.is_builtin_parser(); }
 
   TO_STRING_KV(KP_(allocator), K_(parser_name), KP_(parser_desc), K_(is_inited));
 

--- a/src/storage/fts/ob_fts_stop_token_check.cpp
+++ b/src/storage/fts/ob_fts_stop_token_check.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#define USING_LOG_PREFIX STORAGE_FTS
+
+#include "storage/fts/ob_fts_stop_token_check.h"
+
+#include "share/datum/ob_datum_funcs.h"
+
+namespace oceanbase
+{
+namespace storage
+{
+
+int ObStopTokenChecker::init(const ObCollationType coll, ObStopTokenTable *stop_token_table)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(is_inited_)) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("stop token checker initialized twice", K(ret));
+  } else if (OB_UNLIKELY(CS_TYPE_INVALID == coll || coll >= CS_TYPE_PINYIN_BEGIN_MARK)
+      || OB_ISNULL(stop_token_table)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid stop token checker arguments", K(ret), K(coll), KP(stop_token_table));
+  } else {
+    collation_type_ = coll;
+    stop_token_table_ = stop_token_table;
+    is_inited_ = true;
+  }
+  return ret;
+}
+
+int ObStopTokenChecker::check_is_stop_token(const ObFTToken &token, bool &is_stop_token) const
+{
+  int ret = OB_SUCCESS;
+  is_stop_token = false;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("stop token checker is not initialized", K(ret));
+  } else if (OB_UNLIKELY(token.get_collation_type() != collation_type_)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("stop token collation does not match checker", K(ret),
+        K(collation_type_), K(token));
+  } else {
+    ret = stop_token_table_->exist_refactored(token);
+    if (OB_HASH_EXIST == ret) {
+      is_stop_token = true;
+      ret = OB_SUCCESS;
+    } else if (OB_HASH_NOT_EXIST == ret) {
+      ret = OB_SUCCESS;
+    } else {
+      LOG_WARN("failed to check stop token", K(ret), K(token));
+    }
+  }
+  return ret;
+}
+
+int ObStopTokenCheckerGen::init()
+{
+  int ret = OB_SUCCESS;
+  common::TCWLockGuard guard(lock_);
+  if (OB_UNLIKELY(is_inited_)) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("stop token checker generator initialized twice", K(ret));
+  } else if (OB_FAIL(stop_token_tables_.create(ObCharset::VALID_COLLATION_TYPES,
+                                               "FTStopTokenMap"))) {
+    LOG_WARN("failed to create stop token table map", K(ret));
+  } else if (OB_FAIL(generate_stop_token_table(CS_TYPE_UTF8MB4_GENERAL_CI))) {
+    LOG_WARN("failed to generate general-ci stop token table", K(ret));
+  } else if (OB_FAIL(generate_stop_token_table(CS_TYPE_UTF8MB4_BIN))) {
+    LOG_WARN("failed to generate binary stop token table", K(ret));
+  } else {
+    is_inited_ = true;
+  }
+  return ret;
+}
+
+void ObStopTokenCheckerGen::reset()
+{
+  common::TCWLockGuard guard(lock_);
+  if (stop_token_tables_.created()) {
+    for (StopTokenHashMap::iterator iter = stop_token_tables_.begin();
+         iter != stop_token_tables_.end(); ++iter) {
+      if (OB_NOT_NULL(iter->second)) {
+        iter->second->destroy();
+        OB_DELETE(ObStopTokenTable, &allocator_, iter->second);
+        iter->second = nullptr;
+      }
+    }
+    stop_token_tables_.destroy();
+  }
+  allocator_.reset();
+  is_inited_ = false;
+}
+
+int ObStopTokenCheckerGen::convert_charset(
+    const ObString &src,
+    const ObCollationType from_coll,
+    const ObCollationType to_coll,
+    ObString &converted)
+{
+  int ret = OB_SUCCESS;
+  converted.reset();
+  if (CHARSET_UTF8MB4 == ObCharset::charset_type_by_coll(to_coll)) {
+    converted = src;
+  } else if (OB_FAIL(ObCharset::charset_convert(allocator_, src, from_coll, to_coll, converted))) {
+    LOG_WARN("failed to convert stop token charset", K(ret), K(from_coll), K(to_coll));
+  }
+  return ret;
+}
+
+int ObStopTokenCheckerGen::generate_stop_token_table(const ObCollationType coll)
+{
+  int ret = OB_SUCCESS;
+  ObStopTokenTable *table = OB_NEWx(ObStopTokenTable, &allocator_);
+  if (OB_ISNULL(table)) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate stop token table", K(ret));
+  } else if (OB_FAIL(table->create(DEFAULT_STOP_TOKEN_TABLE_CAPACITY,
+                                   "FTStopBucket",
+                                   "FTStopNode"))) {
+    LOG_WARN("failed to create stop token table", K(ret), K(coll));
+  } else {
+    ObObjMeta meta;
+    meta.set_varchar();
+    meta.set_collation_type(coll);
+    sql::ObExprBasicFuncs *basic_funcs = ObDatumFuncs::get_basic_func(meta.get_type(), coll);
+    ObDatumCmpFuncType cmp_func = get_datum_cmp_func(meta, meta);
+    if (OB_ISNULL(basic_funcs) || OB_ISNULL(basic_funcs->default_hash_) || OB_ISNULL(cmp_func)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("failed to get stop token datum functions", K(ret), K(meta));
+    }
+    const int64_t token_count = ARRAYSIZEOF(OB_STOP_TOKEN_TABLE_UTF8);
+    for (int64_t i = 0; OB_SUCC(ret) && i < token_count; ++i) {
+      ObString converted;
+      ObFTToken token;
+      uint64_t hash_val = 0;
+      if (OB_FAIL(convert_charset(OB_STOP_TOKEN_TABLE_UTF8[i],
+                                  CS_TYPE_UTF8MB4_GENERAL_CI, coll, converted))) {
+        LOG_WARN("failed to convert stop token", K(ret), K(i), K(coll));
+      } else if (OB_FAIL(token.init(converted.ptr(), converted.length(), meta,
+                                    basic_funcs->default_hash_, cmp_func))) {
+        LOG_WARN("failed to initialize stop token", K(ret), K(i), K(coll));
+      } else if (OB_FAIL(token.hash(hash_val))) {
+        LOG_WARN("failed to precompute stop token hash", K(ret), K(token));
+      } else if (OB_FAIL(table->set_refactored(token))) {
+        LOG_WARN("failed to insert stop token", K(ret), K(token));
+      }
+    }
+    if (OB_SUCC(ret)
+        && OB_FAIL(stop_token_tables_.set_refactored(static_cast<uint64_t>(coll), table))) {
+      LOG_WARN("failed to register stop token table", K(ret), K(coll));
+    }
+  }
+  if (OB_FAIL(ret) && OB_NOT_NULL(table)) {
+    table->destroy();
+    OB_DELETE(ObStopTokenTable, &allocator_, table);
+  }
+  return ret;
+}
+
+int ObStopTokenCheckerGen::get_stop_token_checker_by_coll(
+    const ObCollationType coll,
+    ObStopTokenChecker &checker)
+{
+  int ret = OB_SUCCESS;
+  ObStopTokenTable *table = nullptr;
+  checker.reset();
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("stop token checker generator is not initialized", K(ret));
+  } else if (OB_UNLIKELY(CS_TYPE_INVALID == coll || coll >= CS_TYPE_PINYIN_BEGIN_MARK)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid stop token collation", K(ret), K(coll));
+  } else {
+    {
+      common::TCRLockGuard guard(lock_);
+      ret = stop_token_tables_.get_refactored(static_cast<uint64_t>(coll), table);
+      if (OB_HASH_NOT_EXIST == ret) {
+        ret = OB_SUCCESS;
+      } else if (OB_SUCC(ret) && OB_FAIL(checker.init(coll, table))) {
+        LOG_WARN("failed to initialize stop token checker", K(ret), K(coll));
+      }
+    }
+    if (OB_SUCC(ret) && OB_ISNULL(table)) {
+      common::TCWLockGuard guard(lock_);
+      ret = stop_token_tables_.get_refactored(static_cast<uint64_t>(coll), table);
+      if (OB_HASH_NOT_EXIST == ret) {
+        ret = generate_stop_token_table(coll);
+        if (OB_SUCC(ret)) {
+          ret = stop_token_tables_.get_refactored(static_cast<uint64_t>(coll), table);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(checker.init(coll, table))) {
+        LOG_WARN("failed to initialize generated stop token checker", K(ret), K(coll));
+      }
+    }
+  }
+  return ret;
+}
+
+} // namespace storage
+} // namespace oceanbase

--- a/src/storage/fts/ob_fts_stop_token_check.h
+++ b/src/storage/fts/ob_fts_stop_token_check.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+#ifndef OB_FTS_STOP_TOKEN_CHECK_H_
+#define OB_FTS_STOP_TOKEN_CHECK_H_
+
+#include "lib/allocator/page_arena.h"
+#include "lib/hash/ob_hashmap.h"
+#include "lib/hash/ob_hashset.h"
+#include "lib/lock/ob_tc_rwlock.h"
+#include "storage/fts/ob_fts_struct.h"
+
+namespace oceanbase
+{
+namespace storage
+{
+
+static const int64_t FTS_STOP_TOKEN_MAX_LENGTH = 10;
+static const char OB_STOP_TOKEN_TABLE_UTF8[][FTS_STOP_TOKEN_MAX_LENGTH] = {
+  u8"a", u8"about", u8"an", u8"are", u8"as", u8"at", u8"be", u8"by",
+  u8"com", u8"de", u8"en", u8"for", u8"from", u8"how", u8"i", u8"in",
+  u8"is", u8"it", u8"la", u8"of", u8"on", u8"or", u8"that", u8"the",
+  u8"this", u8"to", u8"was", u8"what", u8"when", u8"where", u8"who",
+  u8"will", u8"with", u8"und", u8"www"
+};
+
+typedef common::hash::ObHashSet<
+    ObFTToken,
+    common::hash::NoPthreadDefendMode,
+    common::hash::hash_func<ObFTToken>,
+    common::hash::equal_to<ObFTToken>,
+    common::hash::SimpleAllocer<
+        typename common::hash::HashSetTypes<ObFTToken>::AllocType,
+        common::hash::NodeNumTraits<
+            typename common::hash::HashSetTypes<ObFTToken>::AllocType>::NODE_NUM,
+        common::hash::NoPthreadDefendMode>> ObStopTokenTable;
+
+class ObStopTokenChecker final
+{
+public:
+  ObStopTokenChecker()
+      : is_inited_(false), collation_type_(CS_TYPE_INVALID), stop_token_table_(nullptr)
+  {}
+  ~ObStopTokenChecker() { reset(); }
+  int init(const ObCollationType coll, ObStopTokenTable *stop_token_table);
+  void reset()
+  {
+    is_inited_ = false;
+    collation_type_ = CS_TYPE_INVALID;
+    stop_token_table_ = nullptr;
+  }
+  int check_is_stop_token(const ObFTToken &token, bool &is_stop_token) const;
+
+private:
+  bool is_inited_;
+  ObCollationType collation_type_;
+  ObStopTokenTable *stop_token_table_;
+};
+
+class ObStopTokenCheckerGen final
+{
+public:
+  ObStopTokenCheckerGen()
+      : is_inited_(false), allocator_("FTStopToken"), lock_(), stop_token_tables_()
+  {}
+  ~ObStopTokenCheckerGen() { reset(); }
+
+  int init();
+  void reset();
+  int get_stop_token_checker_by_coll(const ObCollationType coll,
+                                     ObStopTokenChecker &stop_token_checker);
+
+private:
+  static const int64_t DEFAULT_STOP_TOKEN_TABLE_CAPACITY = 64;
+  typedef common::hash::ObHashMap<uint64_t, ObStopTokenTable *> StopTokenHashMap;
+
+  int generate_stop_token_table(const ObCollationType coll);
+  int convert_charset(const ObString &src,
+                      const ObCollationType from_coll,
+                      const ObCollationType to_coll,
+                      ObString &converted);
+
+private:
+  bool is_inited_;
+  ObArenaAllocator allocator_;
+  common::TCRWLock lock_;
+  StopTokenHashMap stop_token_tables_;
+};
+
+} // namespace storage
+} // namespace oceanbase
+
+#endif // OB_FTS_STOP_TOKEN_CHECK_H_

--- a/src/storage/fts/ob_fts_struct.cpp
+++ b/src/storage/fts/ob_fts_struct.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#define USING_LOG_PREFIX STORAGE_FTS
+
 #include "storage/fts/ob_fts_struct.h"
 
 #include "lib/charset/ob_charset.h"
@@ -52,6 +54,76 @@ bool ObFTWord::operator==(const ObFTWord &other) const
     is_equal = (cmp_ret == 0);
   }
   return is_equal;
+}
+
+int ObFTToken::init(
+    const char *ptr,
+    const int64_t length,
+    const ObObjMeta &meta,
+    const ObDatumHashFuncType hash_func,
+    const ObDatumCmpFuncType cmp_func)
+{
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(ptr) || OB_UNLIKELY(length <= 0)
+      || OB_ISNULL(hash_func) || OB_ISNULL(cmp_func)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext token arguments", K(ret), KP(ptr), K(length),
+        K(meta), KP(hash_func), KP(cmp_func));
+  } else {
+    token_.set_string(ptr, length);
+    meta_ = meta;
+    hash_func_ = hash_func;
+    cmp_func_ = cmp_func;
+    is_calc_hash_val_ = false;
+    hash_val_ = 0;
+  }
+  return ret;
+}
+
+int ObFTToken::hash(uint64_t &hash_val) const
+{
+  int ret = OB_SUCCESS;
+  if (is_calc_hash_val_) {
+    hash_val = hash_val_;
+  } else if (OB_ISNULL(hash_func_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("fulltext token hash function is null", K(ret), KPC(this));
+  } else if (OB_FAIL(hash_func_(token_, 0, hash_val_))) {
+    LOG_WARN("failed to calculate fulltext token hash", K(ret), KPC(this));
+  } else {
+    is_calc_hash_val_ = true;
+    hash_val = hash_val_;
+  }
+  return ret;
+}
+
+bool ObFTToken::operator==(const ObFTToken &other) const
+{
+  bool is_equal = false;
+  int ret = do_compare(other, is_equal);
+  if (OB_FAIL(ret)) {
+    LOG_WARN("failed to compare fulltext tokens", K(ret), KPC(this), K(other));
+    ob_abort();
+  }
+  return is_equal;
+}
+
+int ObFTToken::do_compare(const ObFTToken &other, bool &is_equal) const
+{
+  int ret = OB_SUCCESS;
+  int cmp_ret = 0;
+  is_equal = false;
+  if (is_calc_hash_val_ && other.is_calc_hash_val_ && hash_val_ != other.hash_val_) {
+    // Different cached hashes cannot represent equal values.
+  } else if (OB_ISNULL(cmp_func_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("fulltext token compare function is null", K(ret), KPC(this));
+  } else if (OB_FAIL(cmp_func_(token_, other.token_, cmp_ret))) {
+    LOG_WARN("failed to compare fulltext token datum", K(ret), KPC(this), K(other));
+  } else {
+    is_equal = (0 == cmp_ret);
+  }
+  return ret;
 }
 } // namespace storage
 } // namespace oceanbase

--- a/src/storage/fts/ob_fts_struct.h
+++ b/src/storage/fts/ob_fts_struct.h
@@ -20,7 +20,6 @@
 #include "lib/charset/ob_charset.h"
 #include "lib/hash/ob_hashmap.h"
 #include "object/ob_object.h"
-#include "plugin/interface/ob_plugin_ftparser_intf.h"
 #include "share/datum/ob_datum_funcs.h"
 
 namespace oceanbase
@@ -53,6 +52,73 @@ private:
 };
 
 typedef common::hash::ObHashMap<ObFTWord, int64_t> ObFTWordMap;
+
+// Token representation used by the optimized full-text hot path.  Unlike
+// ObFTWord, it caches the datum hash and the collation functions selected for
+// the indexed column, so hash-table probes do not rediscover them per token.
+class ObFTToken final
+{
+public:
+  ObFTToken()
+      : is_calc_hash_val_(false), hash_val_(0), hash_func_(nullptr),
+        cmp_func_(nullptr), meta_(), token_()
+  {}
+  ~ObFTToken() = default;
+
+  int init(const char *ptr,
+           const int64_t length,
+           const ObObjMeta &meta,
+           const ObDatumHashFuncType hash_func,
+           const ObDatumCmpFuncType cmp_func);
+  OB_INLINE const ObDatum &get_token() const { return token_; }
+  OB_INLINE ObCollationType get_collation_type() const { return meta_.get_collation_type(); }
+  OB_INLINE bool empty() const { return token_.get_string().empty(); }
+  int hash(uint64_t &hash_val) const;
+  bool operator==(const ObFTToken &other) const;
+  OB_INLINE bool operator!=(const ObFTToken &other) const { return !(other == *this); }
+
+  TO_STRING_KV(K_(is_calc_hash_val), K_(hash_val), KP_(hash_func),
+      KP_(cmp_func), K_(meta), K_(token));
+
+private:
+  int do_compare(const ObFTToken &other, bool &is_equal) const;
+
+private:
+  mutable bool is_calc_hash_val_;
+  mutable uint64_t hash_val_;
+  ObDatumHashFuncType hash_func_;
+  ObDatumCmpFuncType cmp_func_;
+  ObObjMeta meta_;
+  ObDatum token_;
+};
+
+class ObFTTokenInfo final
+{
+public:
+  ObFTTokenInfo() : count_(0) {}
+  ~ObFTTokenInfo() = default;
+  int update_without_pos_list()
+  {
+    ++count_;
+    return OB_SUCCESS;
+  }
+  TO_STRING_KV(K_(count));
+public:
+  int64_t count_;
+};
+
+typedef common::hash::HashMapPair<ObFTToken, ObFTTokenInfo> ObFTTokenPair;
+typedef common::hash::ObHashMap<
+    ObFTToken,
+    ObFTTokenInfo,
+    common::hash::NoPthreadDefendMode,
+    common::hash::hash_func<ObFTToken>,
+    common::hash::equal_to<ObFTToken>,
+    common::hash::SimpleAllocer<
+        typename common::hash::HashMapTypes<ObFTToken, ObFTTokenInfo>::AllocType,
+        common::hash::NodeNumTraits<
+            typename common::hash::HashMapTypes<ObFTToken, ObFTTokenInfo>::AllocType>::NODE_NUM,
+        common::hash::NoPthreadDefendMode>> ObFTTokenMap;
 
 class ObAddWordFlag final
 {

--- a/src/storage/fts/ob_i_ft_parser.h
+++ b/src/storage/fts/ob_i_ft_parser.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#ifndef OB_I_FT_PARSER_H_
+#define OB_I_FT_PARSER_H_
+
+#include "plugin/interface/ob_plugin_ftparser_intf.h"
+
+namespace oceanbase
+{
+namespace storage
+{
+
+// Internal built-in parsers can retain immutable metadata between documents.
+class ObIFTParser : public plugin::ObITokenIterator
+{
+public:
+  ObIFTParser() = default;
+  virtual ~ObIFTParser() = default;
+  virtual int reuse_parser(const char *fulltext, const int64_t fulltext_len) = 0;
+};
+
+} // namespace storage
+} // namespace oceanbase
+
+#endif // OB_I_FT_PARSER_H_

--- a/src/storage/fts/ob_ik_ft_parser.cpp
+++ b/src/storage/fts/ob_ik_ft_parser.cpp
@@ -29,6 +29,7 @@
 #include "storage/fts/dict/ob_ft_dict_def.h"
 #include "storage/fts/dict/ob_ft_dict_hub.h"
 #include "storage/fts/dict/ob_ft_range_dict.h"
+#include "share/inner_table/ob_inner_table_schema_constants.h"
 #include "storage/fts/ik/ob_ik_arbitrator.h"
 #include "storage/fts/ik/ob_ik_cjk_processor.h"
 #include "storage/fts/ik/ob_ik_letter_processor.h"
@@ -103,11 +104,10 @@ int ObIKFTParser::get_next_token(const char *&word,
         }
       } else {
         bool is_stop = false;
-        // if (!OB_ISNULL(dict_stop_)
-        //     && OB_FAIL(dict_stop_->match(ObString(len, output_word + offset), is_stop))) {
-        //   LOG_WARN("Failed to match stopwords", K(ret));
-        // } else
-        if (!is_stop) {
+        if (!OB_ISNULL(dict_stop_)
+            && OB_FAIL(dict_stop_->match(ObString(len, output_word + offset), is_stop))) {
+          LOG_WARN("Failed to match stopwords", K(ret));
+        } else if (!is_stop) {
           word = output_word + offset;
           word_len = len;
           char_cnt = cnt;
@@ -277,21 +277,56 @@ int ObIKFTParser::init_dict(const plugin::ObFTParserParam &param)
     LOG_WARN("Dict hub is not inited", K(ret));
   }
 
-  ObFTRangeDict *dict = nullptr;
-  ObFTDictDesc main_dict_desc("main_dict",
+  const ObCharsetType charset = ObCharsetType::CHARSET_UTF8MB4;
+  const ObCollationType collation = ObCollationType::CS_TYPE_UTF8MB4_BIN;
+  const bool need_casedown = true;
+  const uint64_t tenant_id = OB_INVALID_TENANT_ID == param.tenant_id_
+                                 ? common::OB_SERVER_TENANT_ID
+                                 : param.tenant_id_;
+  const uint64_t main_dict_id = OB_INVALID_ID == param.ik_param_.main_dict_id_
+                                    ? share::OB_FT_DICT_IK_UTF8_TID
+                                    : param.ik_param_.main_dict_id_;
+  const uint64_t quan_dict_id = OB_INVALID_ID == param.ik_param_.quan_dict_id_
+                                    ? share::OB_FT_QUANTIFIER_IK_UTF8_TID
+                                    : param.ik_param_.quan_dict_id_;
+  const uint64_t stopword_dict_id = OB_INVALID_ID == param.ik_param_.stopword_dict_id_
+                                        ? share::OB_FT_STOPWORD_IK_UTF8_TID
+                                        : param.ik_param_.stopword_dict_id_;
+  const ObString main_dict_name = param.ik_param_.main_dict_.empty()
+                                      ? ObString(share::OB_FT_DICT_IK_UTF8_TNAME)
+                                      : param.ik_param_.main_dict_;
+  const ObString quan_dict_name = param.ik_param_.quan_dict_.empty()
+                                      ? ObString(share::OB_FT_QUANTIFIER_IK_UTF8_TNAME)
+                                      : param.ik_param_.quan_dict_;
+  const ObString stopword_dict_name = param.ik_param_.stopword_dict_.empty()
+                                          ? ObString(share::OB_FT_STOPWORD_IK_UTF8_TNAME)
+                                          : param.ik_param_.stopword_dict_;
+  ObFTDictDesc main_dict_desc(tenant_id,
+                              main_dict_id,
+                              main_dict_name,
                               ObFTDictType::DICT_IK_MAIN,
-                              ObCharsetType::CHARSET_UTF8MB4,
-                              ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                              charset,
+                              collation,
+                              main_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                              need_casedown);
 
-  ObFTDictDesc quan_dict_desc("quan_dict",
+  ObFTDictDesc quan_dict_desc(tenant_id,
+                              quan_dict_id,
+                              quan_dict_name,
                               ObFTDictType::DICT_IK_QUAN,
-                              ObCharsetType::CHARSET_UTF8MB4,
-                              ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                              charset,
+                              collation,
+                              quan_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                              need_casedown);
 
-  ObFTDictDesc stopword_dict_desc("stopword",
+  ObFTDictDesc stopword_dict_desc(tenant_id,
+                                  stopword_dict_id,
+                                  stopword_dict_name,
                                   ObFTDictType::DICT_IK_STOP,
-                                  ObCharsetType::CHARSET_UTF8MB4,
-                                  ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                                  charset,
+                                  collation,
+                                  stopword_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                                  need_casedown);
 
   if (should_read_newest_table()) {
     // clear dict cache, always false now

--- a/src/storage/fts/ob_ik_ft_parser.cpp
+++ b/src/storage/fts/ob_ik_ft_parser.cpp
@@ -65,6 +65,8 @@ int ObIKFTParser::init(const ObFTParserParam &param)
       LOG_WARN("Failed to init ctx", K(ret));
     } else if (OB_FAIL(init_segmenter(param))) {
       LOG_WARN("Failed to init segmenters", K(ret));
+    } else if (OB_FAIL(arb_.prepare())) {
+      LOG_WARN("Failed to prepare arbitrator", K(ret));
     }
 
     if (OB_FAIL(ret)) {
@@ -122,11 +124,39 @@ int ObIKFTParser::get_next_token(const char *&word,
   return ret;
 }
 
+int ObIKFTParser::reuse_parser(const char *fulltext, const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("ik ft parser has not been initialized", K(ret));
+  } else if (OB_ISNULL(fulltext) || OB_UNLIKELY(fulltext_len <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext for ik parser reuse", K(ret), KP(fulltext), K(fulltext_len));
+  } else if (OB_ISNULL(ctx_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("ik tokenize context is null", K(ret));
+  } else if (OB_FAIL(ctx_->reset_resource())) {
+    LOG_WARN("failed to reset tokenize context", K(ret));
+  } else {
+    for (ObList<ObIIKProcessor *, ObIAllocator>::iterator iter = segmenters_.begin();
+         iter != segmenters_.end();
+         ++iter) {
+      (*iter)->reuse();
+    }
+    scratch_allocator_.reset_remain_one_page();
+    if (OB_FAIL(ctx_->reuse_context(fulltext, fulltext_len))) {
+      LOG_WARN("failed to reuse tokenize context", K(ret));
+    }
+  }
+  return ret;
+}
+
 int ObIKFTParser::produce()
 {
   int ret = OB_SUCCESS;
   // Loop until end or has data to output
-  while (OB_SUCC(ret) && ctx_->result_list().empty() && !ctx_->iter_end()) {
+  while (OB_SUCC(ret) && ctx_->is_results_exhaust() && !ctx_->iter_end()) {
     if (OB_FAIL(process_next_batch())) {
       if (OB_ITER_END == ret) {
         // ok
@@ -169,19 +199,21 @@ int ObIKFTParser::process_next_batch()
   if (ctx_->iter_end()) {
     ret = OB_ITER_END;
   } else {
+    ctx_->set_buffer_start_cursor();
     while (OB_SUCC(ret) && !do_seg && !ctx_->iter_end()) {
       const char *ch;
       uint8_t char_len = 0;
       ObFTCharUtil::CharType type = ObFTCharUtil::CharType::USELESS;
-      if (OB_FAIL(ctx_->current_char(ch, char_len))) {
-        LOG_WARN("Failed to get current char", K(ret));
-      } else if (OB_FAIL(ctx_->current_char_type(type))) {
-        LOG_WARN("Failed to get current char type", K(ret));
+      if (OB_FAIL(ctx_->current_char_and_type(ch, char_len, type))) {
+        if (OB_ITER_END != ret) {
+          LOG_WARN("Failed to get current char and type", K(ret));
+        }
       } else if (OB_FAIL(process_one_char(*ctx_, ch, char_len, type))) {
         LOG_WARN("Failed to process one char", K(ret));
       } else {
         // 1. check segmention
-        if (ctx_->handle_size() > SEGMENT_LIMIT && type == ObFTCharUtil::CharType::USELESS) {
+        if (ctx_->handle_size() >= SEGMENT_LIMIT
+            && type == ObFTCharUtil::CharType::USELESS) {
           do_seg = true;
         }
 
@@ -196,11 +228,12 @@ int ObIKFTParser::process_next_batch()
     }
 
     if (OB_SUCC(ret) || OB_ITER_END == ret) {
-      ObIKArbitrator arb;
-      if (OB_FAIL(arb.process(*ctx_))) {
+      if (OB_FAIL(arb_.process(*ctx_))) {
         LOG_WARN("Failed to process arbitrator", K(ret));
-      } else if (OB_FAIL(arb.output_result(*ctx_))) {
+      } else if (OB_FAIL(arb_.output_result(*ctx_))) {
         LOG_WARN("Failed to make result list");
+      } else {
+        arb_.reuse();
       }
     } else {
       // Already logged.
@@ -227,6 +260,7 @@ int ObIKFTParserDesc::segment(ObFTParserParam *param, ObITokenIterator *&iter) c
   int ret = OB_SUCCESS;
   ObIKFTParser *parser = nullptr;
   ObFTDictHub *hub = nullptr;
+  ObIAllocator *metadata_allocator = nullptr;
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("default ft parser desc hasn't be initialized", K(ret), K(is_inited_));
@@ -235,7 +269,15 @@ int ObIKFTParserDesc::segment(ObFTParserParam *param, ObITokenIterator *&iter) c
     LOG_WARN("invalid argument", K(ret), KPC(param));
   } else if (OB_FAIL(ObFTParsePluginData::instance().get_dict_hub(hub))) {
     LOG_WARN("Failed to get dict hub.", K(ret));
-  } else if (OB_ISNULL(parser = OB_NEWx(ObIKFTParser, param->allocator_, *(param->allocator_), hub))) {
+  } else if (FALSE_IT(metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+          ? param->metadata_alloc_ : param->allocator_)) {
+  } else if (OB_ISNULL(metadata_allocator)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("ik parser metadata allocator is null", K(ret), KPC(param));
+  } else if (OB_ISNULL(parser = OB_NEWx(ObIKFTParser,
+                                         metadata_allocator,
+                                         *metadata_allocator,
+                                         hub))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("fail to allocate ik ft parser", K(ret));
   } else if (OB_FAIL(parser->init(*param))) {
@@ -244,8 +286,8 @@ int ObIKFTParserDesc::segment(ObFTParserParam *param, ObITokenIterator *&iter) c
     iter = parser;
   }
 
-  if (OB_FAIL(ret)) {
-    OB_DELETEx(ObIKFTParser, param->allocator_, parser);
+  if (OB_FAIL(ret) && OB_NOT_NULL(metadata_allocator)) {
+    OB_DELETEx(ObIKFTParser, metadata_allocator, parser);
   }
 
   return ret;
@@ -254,8 +296,15 @@ int ObIKFTParserDesc::segment(ObFTParserParam *param, ObITokenIterator *&iter) c
 void ObIKFTParserDesc::free_token_iter(ObFTParserParam *param,
                                        ObITokenIterator *&iter) const
 {
-  iter->~ObITokenIterator();
-  param->allocator_->free(iter);
+  if (OB_NOT_NULL(iter)) {
+    abort_unless(nullptr != param);
+    ObIAllocator *metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+        ? param->metadata_alloc_ : param->allocator_;
+    abort_unless(nullptr != metadata_allocator);
+    iter->~ObITokenIterator();
+    metadata_allocator->free(iter);
+    iter = nullptr;
+  }
 }
 
 
@@ -376,9 +425,9 @@ int ObIKFTParser::init_ctx(const ObFTParserParam &param)
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Illegal collation type", K(ret));
   } else if (OB_ISNULL(ctx_ = OB_NEWx(TokenizeContext,
-                                      &allocator_,
+                                      &metadata_allocator_,
                                       coll_type_,
-                                      allocator_,
+                                      metadata_allocator_,
                                       param.fulltext_,
                                       param.ft_length_,
                                       param.ik_param_.mode_ == ObFTIKParam::Mode::SMART))) {
@@ -388,7 +437,7 @@ int ObIKFTParser::init_ctx(const ObFTParserParam &param)
     LOG_WARN("Failed to init ctx", K(ret));
   }
   if (OB_FAIL(ret)) {
-    OB_DELETEx(TokenizeContext, &allocator_, ctx_);
+    OB_DELETEx(TokenizeContext, &metadata_allocator_, ctx_);
   }
   return ret;
 }
@@ -401,22 +450,28 @@ int ObIKFTParser::init_segmenter(const ObFTParserParam &param)
   ObIKQuantifierProcessor *cnqsg = nullptr;
   ObIKCJKProcessor *cjksg = nullptr;
   ObIKSurrogateProcessor *surrogate_seg = nullptr;
-  if (OB_ISNULL(letter_seg = OB_NEWx(ObIKLetterProcessor, &allocator_))) {
+  if (OB_ISNULL(letter_seg = OB_NEWx(ObIKLetterProcessor, &metadata_allocator_))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("Failed to alloc letter segmenter", K(ret));
   } else if (OB_ISNULL(dict_quan_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("Dict quan is null.", K(ret));
-  } else if (OB_ISNULL(cnqsg = OB_NEWx(ObIKQuantifierProcessor, &allocator_, *dict_quan_, allocator_))) {
+  } else if (OB_ISNULL(cnqsg = OB_NEWx(ObIKQuantifierProcessor,
+                                       &metadata_allocator_,
+                                       *dict_quan_,
+                                       scratch_allocator_))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("Failed to alloc cn quantifier segmenter", K(ret));
   } else if (OB_ISNULL(dict_main_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("Dict main is null.", K(ret));
-  } else if (OB_ISNULL(cjksg = OB_NEWx(ObIKCJKProcessor, &allocator_, *dict_main_, allocator_))) {
+  } else if (OB_ISNULL(cjksg = OB_NEWx(ObIKCJKProcessor,
+                                       &metadata_allocator_,
+                                       *dict_main_,
+                                       scratch_allocator_))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("Failed to alloc cjk segmenter", K(ret));
-  } else if (OB_ISNULL(surrogate_seg = OB_NEWx(ObIKSurrogateProcessor, &allocator_))) {
+  } else if (OB_ISNULL(surrogate_seg = OB_NEWx(ObIKSurrogateProcessor, &metadata_allocator_))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("Failed to alloc surrogate segmenter", K(ret));
   } else if (OB_FAIL(segmenters_.push_back(letter_seg))) {
@@ -435,10 +490,10 @@ int ObIKFTParser::init_segmenter(const ObFTParserParam &param)
   // push back by order, quantifier is before cjk
 
   if (OB_FAIL(ret)) {
-    OB_DELETEx(ObIKLetterProcessor, &allocator_, letter_seg);
-    OB_DELETEx(ObIKQuantifierProcessor, &allocator_, cnqsg);
-    OB_DELETEx(ObIKCJKProcessor, &allocator_, cjksg);
-    OB_DELETEx(ObIKSurrogateProcessor, &allocator_, surrogate_seg);
+    OB_DELETEx(ObIKLetterProcessor, &metadata_allocator_, letter_seg);
+    OB_DELETEx(ObIKQuantifierProcessor, &metadata_allocator_, cnqsg);
+    OB_DELETEx(ObIKCJKProcessor, &metadata_allocator_, cjksg);
+    OB_DELETEx(ObIKSurrogateProcessor, &metadata_allocator_, surrogate_seg);
   }
   return ret;
 }
@@ -447,13 +502,14 @@ void ObIKFTParser::reset()
 {
   if (!OB_ISNULL(ctx_)) {
     ctx_->~TokenizeContext();
-    allocator_.free(ctx_);
+    metadata_allocator_.free(ctx_);
+    ctx_ = nullptr;
   }
 
   for (ObIIKProcessor *segmenter : segmenters_) {
     if (!OB_ISNULL(segmenter)) {
       segmenter->~ObIIKProcessor();
-      allocator_.free(segmenter);
+      metadata_allocator_.free(segmenter);
     }
   }
   segmenters_.clear();
@@ -464,17 +520,21 @@ void ObIKFTParser::reset()
 
   if (!OB_ISNULL(dict_main_)) {
     dict_main_->~ObIFTDict();
-    allocator_.free(dict_main_);
+    metadata_allocator_.free(dict_main_);
+    dict_main_ = nullptr;
   }
   if (!OB_ISNULL(dict_quan_)) {
     dict_quan_->~ObIFTDict();
-    allocator_.free(dict_quan_);
+    metadata_allocator_.free(dict_quan_);
+    dict_quan_ = nullptr;
   }
   if (!OB_ISNULL(dict_stop_)) {
     dict_stop_->~ObIFTDict();
-    allocator_.free(dict_stop_);
+    metadata_allocator_.free(dict_stop_);
+    dict_stop_ = nullptr;
   }
 
+  scratch_allocator_.reset();
   is_inited_ = false;
 }
 
@@ -487,14 +547,18 @@ int ObIKFTParser::build_dict_from_cache(const ObFTDictDesc &desc,
   if (OB_ISNULL(hub_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("Hub is null", K(ret));
-  } else if (OB_ISNULL(dict = OB_NEWx(ObFTRangeDict, &allocator_, allocator_, &container, desc))) {
+  } else if (OB_ISNULL(dict = OB_NEWx(ObFTRangeDict,
+                                      &metadata_allocator_,
+                                      metadata_allocator_,
+                                      &container,
+                                      desc))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("Failed to alloc dict", K(ret));
   } else if (OB_FAIL(dict->init())) {
     LOG_WARN("Failed to init dict", K(ret));
   }
   if (OB_FAIL(ret)) {
-    OB_DELETEx(ObIFTDict, &allocator_, dict);
+    OB_DELETEx(ObIFTDict, &metadata_allocator_, dict);
   }
   return ret;
 }

--- a/src/storage/fts/ob_ik_ft_parser.h
+++ b/src/storage/fts/ob_ik_ft_parser.h
@@ -21,8 +21,10 @@
 #include "storage/fts/dict/ob_ft_cache_container.h"
 #include "storage/fts/dict/ob_ft_dict.h"
 #include "storage/fts/dict/ob_ft_dict_def.h"
+#include "storage/fts/ik/ob_ik_arbitrator.h"
 #include "storage/fts/ik/ob_ik_processor.h"
-#include "plugin/interface/ob_plugin_ftparser_intf.h"
+#include "storage/fts/ob_i_ft_parser.h"
+#include "lib/allocator/page_arena.h"
 
 #include <cstdint>
 namespace oceanbase
@@ -31,22 +33,24 @@ namespace storage
 {
 class ObFTDictHub;
 
-class ObIKFTParser final : public plugin::ObITokenIterator
+class ObIKFTParser final : public ObIFTParser
 {
 public:
-  ObIKFTParser(ObIAllocator &allocator, ObFTDictHub *hub)
-      : allocator_(allocator),
-        is_inited_(false),
+  ObIKFTParser(ObIAllocator &metadata_allocator, ObFTDictHub *hub)
+      : is_inited_(false),
+        metadata_allocator_(metadata_allocator),
         coll_type_(ObCollationType::CS_TYPE_INVALID),
         ctx_(nullptr),
         hub_(hub),
-        segmenters_(allocator_),
-        cache_main_(allocator),
-        cache_quan_(allocator),
-        cache_stop_(allocator),
+        segmenters_(metadata_allocator),
+        cache_main_(metadata_allocator),
+        cache_quan_(metadata_allocator),
+        cache_stop_(metadata_allocator),
         dict_main_(nullptr),
         dict_quan_(nullptr),
-        dict_stop_(nullptr)
+        dict_stop_(nullptr),
+        arb_(),
+        scratch_allocator_("FTIKScratch")
   {
   }
 
@@ -58,6 +62,7 @@ public:
                      int64_t &word_len,
                      int64_t &char_cnt,
                      int64_t &word_freq) override;
+  virtual int reuse_parser(const char *fulltext, const int64_t fulltext_len) override;
 
   VIRTUAL_TO_STRING_KV(K(is_inited_));
 
@@ -89,9 +94,9 @@ private:
                             ObIFTDict *&dict);
 
 private:
-  static constexpr int SEGMENT_LIMIT = 1000;
-  ObIAllocator &allocator_;
+  static constexpr int SEGMENT_LIMIT = IK_HANDLE_SIZE_LIMIT;
   bool is_inited_;
+  ObIAllocator &metadata_allocator_;
 
   ObCollationType coll_type_;
   TokenizeContext *ctx_;
@@ -106,6 +111,8 @@ private:
   ObIFTDict *dict_main_;
   ObIFTDict *dict_quan_;
   ObIFTDict *dict_stop_;
+  ObIKArbitrator arb_;
+  ObArenaAllocator scratch_allocator_;
 
   DISABLE_COPY_ASSIGN(ObIKFTParser);
 };

--- a/src/storage/fts/ob_ngram2_ft_parser.cpp
+++ b/src/storage/fts/ob_ngram2_ft_parser.cpp
@@ -87,6 +87,18 @@ int ObNgram2FTParser::get_next_token(const char *&word,
   return ret;
 }
 
+int ObNgram2FTParser::reuse_parser(const char *fulltext, const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("ngram2 ft parser has not been initialized", K(ret));
+  } else if (OB_FAIL(ngram_impl_.reuse_parser(fulltext, fulltext_len))) {
+    LOG_WARN("fail to reuse ngram2 parser", K(ret));
+  }
+  return ret;
+}
+
 ObNgram2FTParserDesc::ObNgram2FTParserDesc() : is_inited_(false) {}
 
 int ObNgram2FTParserDesc::init(ObPluginParam *param)
@@ -105,26 +117,31 @@ int ObNgram2FTParserDesc::segment(ObFTParserParam *param, ObITokenIterator *&ite
 {
   int ret = OB_SUCCESS;
   ObNgram2FTParser *parser = nullptr;
+  ObIAllocator *metadata_allocator = nullptr;
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("ngram ft parser desc hasn't be initialized", K(ret), K(is_inited_));
   } else if (OB_ISNULL(param) || OB_ISNULL(param->fulltext_) || OB_UNLIKELY(!param->is_valid())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument", K(ret), KPC(param));
-  } else if (OB_ISNULL(parser = OB_NEWx(ObNgram2FTParser, param->allocator_))) {
+  } else if (FALSE_IT(metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+          ? param->metadata_alloc_ : param->allocator_)) {
+  } else if (OB_ISNULL(metadata_allocator)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("ngram2 parser metadata allocator is null", K(ret), KPC(param));
+  } else if (OB_ISNULL(parser = OB_NEWx(ObNgram2FTParser, metadata_allocator))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("fail to allocate ngram ft parser", K(ret));
   } else {
     if (OB_FAIL(parser->init(param))) {
       LOG_WARN("fail to init ngram fulltext parser", K(ret), KPC(param));
-      param->allocator_->free(parser);
     } else {
       iter = parser;
     }
   }
 
-  if (OB_FAIL(ret)) {
-    OB_DELETEx(ObNgram2FTParser, param->allocator_, parser);
+  if (OB_FAIL(ret) && OB_NOT_NULL(metadata_allocator)) {
+    OB_DELETEx(ObNgram2FTParser, metadata_allocator, parser);
   }
 
   return ret;
@@ -134,9 +151,12 @@ void ObNgram2FTParserDesc::free_token_iter(ObFTParserParam *param, ObITokenItera
 {
   if (OB_NOT_NULL(iter)) {
     abort_unless(nullptr != param);
-    abort_unless(nullptr != param->allocator_);
+    ObIAllocator *metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+        ? param->metadata_alloc_ : param->allocator_;
+    abort_unless(nullptr != metadata_allocator);
     iter->~ObITokenIterator();
-    param->allocator_->free(iter);
+    metadata_allocator->free(iter);
+    iter = nullptr;
   }
 }
 

--- a/src/storage/fts/ob_ngram2_ft_parser.h
+++ b/src/storage/fts/ob_ngram2_ft_parser.h
@@ -17,14 +17,14 @@
 #ifndef _OCEANBASE_STORAGE_FTS_OB_NGRAM2_FT_PARSER_H_
 #define _OCEANBASE_STORAGE_FTS_OB_NGRAM2_FT_PARSER_H_
 
-#include "plugin/interface/ob_plugin_ftparser_intf.h"
+#include "storage/fts/ob_i_ft_parser.h"
 #include "storage/fts/utils/ob_ft_ngram_impl.h"
 
 namespace oceanbase
 {
 namespace storage
 {
-class ObNgram2FTParser final : public plugin::ObITokenIterator
+class ObNgram2FTParser final : public ObIFTParser
 {
 public:
   ObNgram2FTParser();
@@ -36,6 +36,7 @@ public:
                              int64_t &word_len,
                              int64_t &char_len,
                              int64_t &word_freq) override;
+  virtual int reuse_parser(const char *fulltext, const int64_t fulltext_len) override;
 
   VIRTUAL_TO_STRING_KV(K_(is_inited));
 

--- a/src/storage/fts/ob_ngram_ft_parser.cpp
+++ b/src/storage/fts/ob_ngram_ft_parser.cpp
@@ -91,6 +91,18 @@ int ObNgramFTParser::get_next_token(
   return ret;
 }
 
+int ObNgramFTParser::reuse_parser(const char *fulltext, const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("ngram ft parser has not been initialized", K(ret));
+  } else if (OB_FAIL(ngram_impl_.reuse_parser(fulltext, fulltext_len))) {
+    LOG_WARN("fail to reuse ngram parser", K(ret));
+  }
+  return ret;
+}
+
 ObNgramFTParserDesc::ObNgramFTParserDesc()
   : is_inited_(false)
 {
@@ -114,13 +126,19 @@ int ObNgramFTParserDesc::segment(
 {
   int ret = OB_SUCCESS;
   ObNgramFTParser *parser = nullptr;
+  ObIAllocator *metadata_allocator = nullptr;
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("ngram ft parser desc hasn't be initialized", K(ret), K(is_inited_));
   } else if (OB_ISNULL(param) || OB_ISNULL(param->fulltext_) || OB_UNLIKELY(!param->is_valid())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument", K(ret), KPC(param));
-  } else if (OB_ISNULL(parser = OB_NEWx(ObNgramFTParser, param->allocator_))) {
+  } else if (FALSE_IT(metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+          ? param->metadata_alloc_ : param->allocator_)) {
+  } else if (OB_ISNULL(metadata_allocator)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("ngram parser metadata allocator is null", K(ret), KPC(param));
+  } else if (OB_ISNULL(parser = OB_NEWx(ObNgramFTParser, metadata_allocator))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("fail to allocate ngram ft parser", K(ret));
   } else {
@@ -130,8 +148,8 @@ int ObNgramFTParserDesc::segment(
       iter = parser;
     }
   }
-  if (OB_FAIL(ret)) {
-    OB_DELETEx(ObNgramFTParser, param->allocator_, parser);
+  if (OB_FAIL(ret) && OB_NOT_NULL(metadata_allocator)) {
+    OB_DELETEx(ObNgramFTParser, metadata_allocator, parser);
   }
   return ret;
 }
@@ -142,9 +160,12 @@ void ObNgramFTParserDesc::free_token_iter(
 {
   if (OB_NOT_NULL(iter)) {
     abort_unless(nullptr != param);
-    abort_unless(nullptr != param->allocator_);
+    ObIAllocator *metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+        ? param->metadata_alloc_ : param->allocator_;
+    abort_unless(nullptr != metadata_allocator);
     iter->~ObITokenIterator();
-    param->allocator_->free(iter);
+    metadata_allocator->free(iter);
+    iter = nullptr;
   }
 }
 

--- a/src/storage/fts/ob_ngram_ft_parser.h
+++ b/src/storage/fts/ob_ngram_ft_parser.h
@@ -19,7 +19,7 @@
 
 #include "lib/utility/ob_macro_utils.h"
 #include "lib/utility/ob_print_utils.h"
-#include "plugin/interface/ob_plugin_ftparser_intf.h"
+#include "storage/fts/ob_i_ft_parser.h"
 #include "storage/fts/utils/ob_ft_ngram_impl.h"
 
 namespace oceanbase
@@ -27,7 +27,7 @@ namespace oceanbase
 namespace storage
 {
 
-class ObNgramFTParser final : public plugin::ObITokenIterator
+class ObNgramFTParser final : public ObIFTParser
 {
 public:
   ObNgramFTParser();
@@ -40,6 +40,7 @@ public:
       int64_t &word_len,
       int64_t &char_len,
       int64_t &word_freq) override;
+  virtual int reuse_parser(const char *fulltext, const int64_t fulltext_len) override;
 
   VIRTUAL_TO_STRING_KV(K_(is_inited));
 

--- a/src/storage/fts/ob_whitespace_ft_parser.cpp
+++ b/src/storage/fts/ob_whitespace_ft_parser.cpp
@@ -54,6 +54,23 @@ void ObSpaceFTParser::reset()
   is_inited_ = false;
 }
 
+int ObSpaceFTParser::reuse_parser(const char *fulltext, const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("space ft parser has not been initialized", K(ret));
+  } else if (OB_ISNULL(fulltext) || OB_UNLIKELY(fulltext_len <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext for parser reuse", K(ret), KP(fulltext), K(fulltext_len));
+  } else {
+    start_ = fulltext;
+    next_ = start_;
+    end_ = start_ + fulltext_len;
+  }
+  return ret;
+}
+
 int ObSpaceFTParser::init(ObFTParserParam *param)
 {
   int ret = OB_SUCCESS;
@@ -166,13 +183,19 @@ int ObWhiteSpaceFTParserDesc::segment(
 {
   int ret = OB_SUCCESS;
   ObSpaceFTParser *parser = nullptr;
+  ObIAllocator *metadata_allocator = nullptr;
   if (OB_UNLIKELY(!is_inited_)) {
     ret = OB_NOT_INIT;
     LOG_WARN("default ft parser desc hasn't be initialized", K(ret), K(is_inited_));
   } else if (OB_ISNULL(param) || OB_ISNULL(param->fulltext_) || OB_UNLIKELY(!param->is_valid())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument", K(ret), KPC(param));
-  } else if (OB_ISNULL(parser = OB_NEWx(ObSpaceFTParser, param->allocator_))) {
+  } else if (FALSE_IT(metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+          ? param->metadata_alloc_ : param->allocator_)) {
+  } else if (OB_ISNULL(metadata_allocator)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("space parser metadata allocator is null", K(ret), KPC(param));
+  } else if (OB_ISNULL(parser = OB_NEWx(ObSpaceFTParser, metadata_allocator))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_WARN("fail to allocate space ft parser", K(ret));
   } else {
@@ -183,8 +206,8 @@ int ObWhiteSpaceFTParserDesc::segment(
     }
   }
 
-  if (OB_FAIL(ret)) {
-    OB_DELETEx(ObSpaceFTParser, param->allocator_, parser);
+  if (OB_FAIL(ret) && OB_NOT_NULL(metadata_allocator)) {
+    OB_DELETEx(ObSpaceFTParser, metadata_allocator, parser);
   }
 
   return ret;
@@ -196,9 +219,12 @@ void ObWhiteSpaceFTParserDesc::free_token_iter(
 {
   if (OB_NOT_NULL(iter)) {
     abort_unless(nullptr != param);
-    abort_unless(nullptr != param->allocator_);
+    ObIAllocator *metadata_allocator = OB_NOT_NULL(param->metadata_alloc_)
+        ? param->metadata_alloc_ : param->allocator_;
+    abort_unless(nullptr != metadata_allocator);
     iter->~ObITokenIterator();
-    param->allocator_->free(iter);
+    metadata_allocator->free(iter);
+    iter = nullptr;
   }
 }
 

--- a/src/storage/fts/ob_whitespace_ft_parser.h
+++ b/src/storage/fts/ob_whitespace_ft_parser.h
@@ -20,14 +20,14 @@
 #include "lib/utility/ob_macro_utils.h"
 #include "lib/utility/ob_print_utils.h"
 #include "share/text_analysis/ob_text_analyzer.h"
-#include "plugin/interface/ob_plugin_ftparser_intf.h"
+#include "storage/fts/ob_i_ft_parser.h"
 
 namespace oceanbase
 {
 namespace storage
 {
 
-class ObSpaceFTParser final : public plugin::ObITokenIterator
+class ObSpaceFTParser final : public ObIFTParser
 {
 public:
   ObSpaceFTParser();
@@ -35,6 +35,7 @@ public:
 
   int init(plugin::ObFTParserParam *param);
   void reset();
+  virtual int reuse_parser(const char *fulltext, const int64_t fulltext_len) override;
   virtual int get_next_token(
       const char *&word,
       int64_t &word_len,

--- a/src/storage/fts/utils/ob_ft_ngram_impl.cpp
+++ b/src/storage/fts/utils/ob_ft_ngram_impl.cpp
@@ -73,6 +73,24 @@ void ObFTNgramImpl::reset()
   is_inited_ = false;
 }
 
+int ObFTNgramImpl::reuse_parser(const char *fulltext, const int64_t fulltext_len)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(!is_inited_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("ngram parser has not been initialized", K(ret));
+  } else if (OB_ISNULL(fulltext) || OB_UNLIKELY(fulltext_len <= 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid fulltext for ngram parser reuse", K(ret), KP(fulltext), K(fulltext_len));
+  } else {
+    fulltext_start_ = fulltext;
+    fulltext_end_ = fulltext + fulltext_len;
+    cur_ = fulltext_start_;
+    window_.reset();
+  }
+  return ret;
+}
+
 
 int ObFTNgramImpl::get_next_token(const char *&word,
                                   int64_t &word_len,

--- a/src/storage/fts/utils/ob_ft_ngram_impl.h
+++ b/src/storage/fts/utils/ob_ft_ngram_impl.h
@@ -41,6 +41,8 @@ public:
 
   void reset();
 
+  int reuse_parser(const char *fulltext, const int64_t fulltext_len);
+
   int get_next_token(const char *&word, int64_t &word_len, int64_t &char_cnt, int64_t &word_freq);
 
 private:

--- a/src/storage/retrieval/ob_i_sparse_retrieval_iter.h
+++ b/src/storage/retrieval/ob_i_sparse_retrieval_iter.h
@@ -108,7 +108,8 @@ struct ObSparseRetrievalMergeParam
       filter_expr_(nullptr),
       topk_limit_(0),
       field_boost_(1.0),
-      max_batch_size_(1)
+      max_batch_size_(1),
+      need_collect_dims_(true)
   {}
   ~ObSparseRetrievalMergeParam() {}
   bool need_project_relevance() const { return relevance_proj_expr_ != nullptr; }
@@ -117,7 +118,7 @@ struct ObSparseRetrievalMergeParam
   bool need_pushdown_topk() const { return topk_limit_ > 0; }
   TO_STRING_KV(KPC_(dim_weights), KPC(limit_param_), KP_(eval_ctx),
       KP_(id_proj_expr), KP_(relevance_expr), KP_(relevance_proj_expr), KP_(filter_expr),
-      K_(topk_limit), K_(max_batch_size));
+      K_(topk_limit), K_(max_batch_size), K_(need_collect_dims));
   const ObIArray<double> *dim_weights_; // score weight for each dimension
   const common::ObLimitParam *limit_param_;
   sql::ObEvalCtx *eval_ctx_;
@@ -128,6 +129,7 @@ struct ObSparseRetrievalMergeParam
   int64_t topk_limit_;
   double field_boost_;
   int64_t max_batch_size_;
+  bool need_collect_dims_;
 };
 
 class ObISparseRetrievalMergeIter

--- a/src/storage/retrieval/ob_i_sparse_retrieval_iter.h
+++ b/src/storage/retrieval/ob_i_sparse_retrieval_iter.h
@@ -113,6 +113,7 @@ struct ObSparseRetrievalMergeParam
   ~ObSparseRetrievalMergeParam() {}
   bool need_project_relevance() const { return relevance_proj_expr_ != nullptr; }
   bool need_filter() const { return filter_expr_ != nullptr; }
+  bool need_calc_relevance() const { return need_project_relevance() || need_filter(); }
   bool need_pushdown_topk() const { return topk_limit_ > 0; }
   TO_STRING_KV(KPC_(dim_weights), KPC(limit_param_), KP_(eval_ctx),
       KP_(id_proj_expr), KP_(relevance_expr), KP_(relevance_proj_expr), KP_(filter_expr),

--- a/src/storage/retrieval/ob_sparse_daat_iter.cpp
+++ b/src/storage/retrieval/ob_sparse_daat_iter.cpp
@@ -130,10 +130,13 @@ int ObSRDaaTIterImpl::init(
       LOG_WARN("failed to init buffered domain ids array", K(ret));
     } else if (OB_FAIL(buffered_domain_ids_.prepare_allocate(max_batch_size))) {
       LOG_WARN("failed to prepare allocate buffered domain ids array", K(ret));
-    } else if (FALSE_IT(buffered_relevances_.set_allocator(iter_allocator_))) {
-    } else if (OB_FAIL(buffered_relevances_.init(max_batch_size))) {
+    } else if (iter_param_->need_project_relevance()
+        && FALSE_IT(buffered_relevances_.set_allocator(iter_allocator_))) {
+    } else if (iter_param_->need_project_relevance()
+        && OB_FAIL(buffered_relevances_.init(max_batch_size))) {
       LOG_WARN("failed to init buffered relevances array", K(ret));
-    } else if (OB_FAIL(buffered_relevances_.prepare_allocate(max_batch_size))) {
+    } else if (iter_param_->need_project_relevance()
+        && OB_FAIL(buffered_relevances_.prepare_allocate(max_batch_size))) {
       LOG_WARN("failed to prepare allocate buffered relevances array", K(ret));
     } else if (OB_FAIL(merge_cmp_.init(iter_param_->id_proj_expr_->datum_meta_, &iter_domain_ids_))) {
       LOG_WARN("failed to init loser tree comparator", K(ret));
@@ -314,9 +317,12 @@ int ObSRDaaTIterImpl::fill_merge_heap()
       } else {
         ret = OB_SUCCESS;
       }
-    } else if (OB_FAIL(dim_iter->get_curr_score(item.relevance_))) {
+    } else if (iter_param_->need_calc_relevance()
+        && OB_FAIL(dim_iter->get_curr_score(item.relevance_))) {
       LOG_WARN("fail to get current score", K(ret));
-    } else if (OB_NOT_NULL(iter_param_->dim_weights_) && FALSE_IT(item.relevance_ = item.relevance_ * iter_param_->field_boost_ * iter_param_->dim_weights_->at(iter_idx))) {
+    } else if (iter_param_->need_calc_relevance()
+        && OB_NOT_NULL(iter_param_->dim_weights_)
+        && FALSE_IT(item.relevance_ = item.relevance_ * iter_param_->field_boost_ * iter_param_->dim_weights_->at(iter_idx))) {
     } else if (OB_FAIL(dim_iter->get_curr_id(iter_domain_ids_[iter_idx]))) {
       LOG_WARN("fail to get current doc id", K(ret));
     } else if (FALSE_IT(item.iter_idx_ = iter_idx)) {
@@ -435,12 +441,15 @@ int ObSRDaaTIterImpl::cache_result(int64_t &count, const ObDatum &id_datum, cons
   if (limit_param->is_valid() && input_row_cnt_ <= offset) {
     // TODO: Maybe we should not process offset logic here
     // don't need to project
-  } else if (OB_UNLIKELY(count >= buffered_domain_ids_.count() || count >= buffered_relevances_.count())) {
+  } else if (OB_UNLIKELY(count >= buffered_domain_ids_.count()
+      || (iter_param_->need_project_relevance() && count >= buffered_relevances_.count()))) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid buffered idx", K(ret), K(count), K(buffered_domain_ids_.count()), K(buffered_relevances_.count()));
   } else {
     buffered_domain_ids_[count].from_datum(id_datum);
-    buffered_relevances_[count] = relevance;
+    if (iter_param_->need_project_relevance()) {
+      buffered_relevances_[count] = relevance;
+    }
     ++count;
     ++output_row_cnt_;
     if (limit_param->is_valid() && output_row_cnt_ >= limit) {
@@ -485,9 +494,11 @@ int ObSRDaaTIterImpl::project_results(const int64_t count)
     ObDatum &id_proj_datum = id_proj_expr->locate_datum_for_write(*eval_ctx);
     set_datum_func_(id_proj_datum, buffered_domain_ids_[0]);
     id_proj_expr->set_evaluated_projected(*eval_ctx);
-    ObDatum &relevance_proj_datum = relevance_proj_expr->locate_datum_for_write(*eval_ctx);
-    relevance_proj_datum.set_double(buffered_relevances_[0]);
-    relevance_proj_expr->set_evaluated_projected(*eval_ctx);
+    if (iter_param_->need_project_relevance()) {
+      ObDatum &relevance_proj_datum = relevance_proj_expr->locate_datum_for_write(*eval_ctx);
+      relevance_proj_datum.set_double(buffered_relevances_[0]);
+      relevance_proj_expr->set_evaluated_projected(*eval_ctx);
+    }
   }
   return ret;
 }

--- a/src/storage/retrieval/ob_sparse_daat_iter.cpp
+++ b/src/storage/retrieval/ob_sparse_daat_iter.cpp
@@ -25,6 +25,7 @@ namespace storage
 
 ObSRMergeCmp::ObSRMergeCmp()
   : cmp_func_(nullptr),
+    fast_cmp_type_(GENERIC_CMP),
     iter_ids_(nullptr),
     is_inited_(false)
 {
@@ -39,11 +40,21 @@ int ObSRMergeCmp::init(ObDatumMeta id_meta, const ObFixedArray<const ObDatum *, 
   } else {
     iter_ids_ = iter_ids;
     sql::ObExprBasicFuncs *basic_funcs = ObDatumFuncs::get_basic_func(id_meta.type_, id_meta.cs_type_);
-    cmp_func_ = basic_funcs->null_first_cmp_;
-    if (OB_ISNULL(cmp_func_)) {
+    if (OB_ISNULL(basic_funcs)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("failed to get basic datum functions", K(ret), K(id_meta));
+    } else if (FALSE_IT(cmp_func_ = basic_funcs->null_first_cmp_)) {
+    } else if (OB_ISNULL(cmp_func_)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("failed to init IRIterLoserTreeCmp", K(ret));
     } else {
+      if (common::ObIntType == id_meta.type_) {
+        fast_cmp_type_ = INT_CMP;
+      } else if (common::ObUInt64Type == id_meta.type_) {
+        fast_cmp_type_ = UINT64_CMP;
+      } else if (CS_TYPE_BINARY == id_meta.cs_type_ && ob_is_string_type(id_meta.type_)) {
+        fast_cmp_type_ = BINARY_STRING_CMP;
+      }
       is_inited_ = true;
     }
   }
@@ -61,7 +72,21 @@ int ObSRMergeCmp::cmp(
     LOG_WARN("not inited", K(ret));
   } else {
     int tmp_ret = 0;
-    if (OB_FAIL(cmp_func_(get_id_datum(l.iter_idx_), get_id_datum(r.iter_idx_), tmp_ret))) {
+    const ObDatum &left = get_id_datum(l.iter_idx_);
+    const ObDatum &right = get_id_datum(r.iter_idx_);
+    if (OB_UNLIKELY(left.is_null() || right.is_null())) {
+      ret = cmp_func_(left, right, tmp_ret);
+    } else if (INT_CMP == fast_cmp_type_) {
+      tmp_ret = left.get_int() < right.get_int() ? -1 : left.get_int() > right.get_int() ? 1 : 0;
+    } else if (UINT64_CMP == fast_cmp_type_) {
+      tmp_ret = left.get_uint64() < right.get_uint64()
+          ? -1 : left.get_uint64() > right.get_uint64() ? 1 : 0;
+    } else if (BINARY_STRING_CMP == fast_cmp_type_) {
+      tmp_ret = left.get_string().compare(right.get_string());
+    } else {
+      ret = cmp_func_(left, right, tmp_ret);
+    }
+    if (OB_FAIL(ret)) {
       LOG_WARN("failed to compare doc id by datum", K(ret));
     } else {
       cmp_ret = tmp_ret;
@@ -360,7 +385,8 @@ int ObSRDaaTIterImpl::collect_dims_by_id(const ObDatum *&id_datum, double &relev
     }
     if (OB_FAIL(merge_heap_->top(top_item))) {
       LOG_WARN("failed to get top item from merge heap", K(ret));
-    } else if (OB_FAIL(relevance_collector_->collect_one_dim(top_item->iter_idx_, top_item->relevance_))) {
+    } else if (iter_param_->need_collect_dims_
+        && OB_FAIL(relevance_collector_->collect_one_dim(top_item->iter_idx_, top_item->relevance_))) {
       LOG_WARN("failed to collect one dimension", K(ret));
     } else if (FALSE_IT(iter_idx = top_item->iter_idx_)) {
     } else if (OB_FAIL(merge_heap_->pop())) {
@@ -376,7 +402,10 @@ int ObSRDaaTIterImpl::collect_dims_by_id(const ObDatum *&id_datum, double &relev
     if (OB_ISNULL(id_datum)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("unexpected null id datum", K(ret));
-    } else if (OB_FAIL(relevance_collector_->get_result(relevance, got_valid_id))) {
+    } else if (!iter_param_->need_collect_dims_
+        && FALSE_IT(got_valid_id = true)) {
+    } else if (iter_param_->need_collect_dims_
+        && OB_FAIL(relevance_collector_->get_result(relevance, got_valid_id))) {
       LOG_WARN("failed to get result", K(ret));
     } else if (got_valid_id && OB_FAIL(process_collected_row(*id_datum, relevance))) {
       LOG_WARN("failed to process collected row", K(ret));

--- a/src/storage/retrieval/ob_sparse_daat_iter.h
+++ b/src/storage/retrieval/ob_sparse_daat_iter.h
@@ -40,6 +40,14 @@ struct ObSRMergeItem
 
 struct ObSRMergeCmp
 {
+  enum FastCmpType : int8_t
+  {
+    GENERIC_CMP = 0,
+    INT_CMP,
+    UINT64_CMP,
+    BINARY_STRING_CMP
+  };
+
   ObSRMergeCmp();
   virtual ~ObSRMergeCmp() {}
 
@@ -54,6 +62,7 @@ private:
   }
 private:
   common::ObDatumCmpFuncType cmp_func_;
+  FastCmpType fast_cmp_type_;
   // TODO: if memory lifetime of docid datum is guaranteed by dim_iters, we can use pointer to datum directly
   //       and avoid deep copy into merge heap here
   const ObFixedArray<const ObDatum *, ObIAllocator> *iter_ids_;

--- a/src/storage/retrieval/ob_text_daat_iter.cpp
+++ b/src/storage/retrieval/ob_text_daat_iter.cpp
@@ -33,7 +33,8 @@ int ObTextDaaTIter::init(const ObTextDaaTParam &param)
   } else if (OB_FAIL(ObSRDaaTIterImpl::init(*param.base_param_, *param.dim_iters_,
                                             *param.allocator_, *param.relevance_collector_))) {
     LOG_WARN("failed to init sr daat iter", K(ret));
-  } else if (OB_FAIL(bm25_param_estimator_.init(param.bm25_param_est_ctx_))) {
+  } else if (param.base_param_->need_calc_relevance() && !param.dim_iters_->empty()
+      && OB_FAIL(bm25_param_estimator_.init(param.bm25_param_est_ctx_))) {
     LOG_WARN("failed to init bm25 param estimator", K(ret));
   } else {
     mode_flag_ = param.mode_flag_;
@@ -74,7 +75,7 @@ int ObTextDaaTIter::pre_process()
   int ret = OB_SUCCESS;
   if (dim_iters_->count() == 0) {
     ret = OB_ITER_END;
-  } else if (iter_param_->need_project_relevance()) {
+  } else if (iter_param_->need_calc_relevance()) {
     if (OB_FAIL(bm25_param_estimator_.do_estimation(*iter_param_->eval_ctx_))) {
       LOG_WARN("failed to do bm25 param estimation", K(ret));
     }

--- a/src/storage/retrieval/ob_text_daat_iter.cpp
+++ b/src/storage/retrieval/ob_text_daat_iter.cpp
@@ -39,12 +39,175 @@ int ObTextDaaTIter::init(const ObTextDaaTParam &param)
   } else {
     mode_flag_ = param.mode_flag_;
     function_lookup_mode_ = param.function_lookup_mode_;
+    use_batch_union_ = param.base_param_->eval_ctx_->is_vectorized()
+        && !param.base_param_->need_collect_dims_
+        && !param.base_param_->need_calc_relevance()
+        && !param.function_lookup_mode_;
+    for (int64_t i = 0; OB_SUCC(ret) && use_batch_union_ && i < param.dim_iters_->count(); ++i) {
+      if (OB_FAIL(batch_union_finished_.push_back(false))) {
+        LOG_WARN("failed to initialize batch union state", K(ret), K(i));
+      }
+    }
+  }
+  return ret;
+}
+
+int ObTextDaaTIter::get_next_rows(const int64_t capacity, int64_t &count)
+{
+  return use_batch_union_
+      ? get_next_rows_batch_union(capacity, count)
+      : ObSRDaaTIterImpl::get_next_rows(capacity, count);
+}
+
+int ObTextDaaTIter::get_next_rows_batch_union(const int64_t capacity, int64_t &count)
+{
+  int ret = OB_SUCCESS;
+  count = 0;
+  if (IS_NOT_INIT) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("text DaaT iterator is not initialized", K(ret));
+  } else if (OB_UNLIKELY(capacity < 0)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid batch capacity", K(ret), K(capacity));
+  } else if (0 == capacity) {
+  } else if (0 == dim_iters_->count()) {
+    ret = OB_ITER_END;
+  } else if (iter_param_->limit_param_->is_valid()
+      && output_row_cnt_ >= iter_param_->limit_param_->limit_) {
+    ret = OB_ITER_END;
+  } else if (OB_FAIL(pre_process())) {
+    if (OB_ITER_END != ret) {
+      LOG_WARN("failed to prepare text batch union", K(ret));
+    }
+  } else {
+    const int64_t real_capacity = MIN(capacity, iter_param_->max_batch_size_);
+    while (OB_SUCC(ret) && count < real_capacity) {
+      ObDocIdExt doc_id;
+      if (OB_FAIL(get_next_union_doc_id(doc_id))) {
+        if (OB_ITER_END != ret) {
+          LOG_WARN("failed to get next union document id", K(ret), K(count));
+        }
+      } else {
+        const common::ObLimitParam *limit_param = iter_param_->limit_param_;
+        ++input_row_cnt_;
+        if (!limit_param->is_valid() || input_row_cnt_ > limit_param->offset_) {
+          buffered_domain_ids_[count] = doc_id;
+          ++count;
+          ++output_row_cnt_;
+          if (limit_param->is_valid() && output_row_cnt_ >= limit_param->limit_) {
+            ret = OB_ITER_END;
+          }
+        }
+      }
+    }
+    if ((OB_SUCC(ret) || OB_ITER_END == ret)
+        && count > 0
+        && OB_FAIL(project_results(count))) {
+      LOG_WARN("failed to project batch-union results", K(ret), K(count));
+    }
+  }
+  return ret;
+}
+
+int ObTextDaaTIter::get_next_union_doc_id(ObDocIdExt &doc_id)
+{
+  int ret = OB_SUCCESS;
+  int64_t min_idx = -1;
+  for (int64_t i = 0; OB_SUCC(ret) && i < dim_iters_->count(); ++i) {
+    if (batch_union_finished_[i]) {
+      continue;
+    }
+    ObTextRetrievalDaaTTokenIter *iter =
+        static_cast<ObTextRetrievalDaaTTokenIter *>(dim_iters_->at(i));
+    if (OB_ISNULL(iter)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected null text dimension iterator", K(ret), K(i));
+    } else if (!iter->has_current_doc_id()) {
+      ret = iter->load_next_doc_id_batch();
+      if (OB_ITER_END == ret) {
+        batch_union_finished_[i] = true;
+        ret = OB_SUCCESS;
+      } else if (OB_FAIL(ret)) {
+        LOG_WARN("failed to load text dimension batch", K(ret), K(i));
+      }
+    }
+    if (OB_SUCC(ret) && !batch_union_finished_[i]) {
+      if (min_idx < 0) {
+        min_idx = i;
+      } else {
+        int64_t cmp_ret = 0;
+        const ObDocIdExt &candidate = iter->get_current_doc_id();
+        const ObDocIdExt &minimum = static_cast<ObTextRetrievalDaaTTokenIter *>(
+            dim_iters_->at(min_idx))->get_current_doc_id();
+        if (OB_FAIL(compare_doc_id(candidate, minimum, cmp_ret))) {
+          LOG_WARN("failed to compare text document ids", K(ret), K(i), K(min_idx));
+        } else if (cmp_ret < 0) {
+          min_idx = i;
+        }
+      }
+    }
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (min_idx < 0) {
+    ret = OB_ITER_END;
+  } else {
+    ObTextRetrievalDaaTTokenIter *min_iter =
+        static_cast<ObTextRetrievalDaaTTokenIter *>(dim_iters_->at(min_idx));
+    const ObDocIdExt &minimum = min_iter->get_current_doc_id();
+    doc_id = minimum;
+    for (int64_t i = 0; OB_SUCC(ret) && i < dim_iters_->count(); ++i) {
+      if (!batch_union_finished_[i]) {
+        ObTextRetrievalDaaTTokenIter *iter =
+            static_cast<ObTextRetrievalDaaTTokenIter *>(dim_iters_->at(i));
+        int64_t cmp_ret = 0;
+        if (OB_FAIL(compare_doc_id(iter->get_current_doc_id(), minimum, cmp_ret))) {
+          LOG_WARN("failed to compare duplicate document id", K(ret), K(i), K(min_idx));
+        } else if (0 == cmp_ret) {
+          iter->advance_current_doc_id();
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObTextDaaTIter::compare_doc_id(
+    const ObDocIdExt &left,
+    const ObDocIdExt &right,
+    int64_t &cmp_ret) const
+{
+  int ret = OB_SUCCESS;
+  const ObDatum &left_datum = left.get_datum();
+  const ObDatum &right_datum = right.get_datum();
+  if (common::ObUInt64Type == iter_param_->id_proj_expr_->datum_meta_.type_) {
+    const uint64_t left_id = left_datum.get_uint64();
+    const uint64_t right_id = right_datum.get_uint64();
+    cmp_ret = left_id < right_id ? -1 : left_id > right_id ? 1 : 0;
+  } else if (CS_TYPE_BINARY == iter_param_->id_proj_expr_->datum_meta_.cs_type_
+      && ob_is_string_type(iter_param_->id_proj_expr_->datum_meta_.type_)) {
+    cmp_ret = left_datum.get_string().compare(right_datum.get_string());
+  } else {
+    sql::ObExprBasicFuncs *basic_funcs = ObDatumFuncs::get_basic_func(
+        iter_param_->id_proj_expr_->datum_meta_.type_,
+        iter_param_->id_proj_expr_->datum_meta_.cs_type_);
+    int datum_cmp_ret = 0;
+    if (OB_ISNULL(basic_funcs) || OB_ISNULL(basic_funcs->null_first_cmp_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("failed to get document id comparator", K(ret));
+    } else if (OB_FAIL(basic_funcs->null_first_cmp_(left_datum, right_datum, datum_cmp_ret))) {
+      LOG_WARN("failed to compare document id datums", K(ret));
+    } else {
+      cmp_ret = datum_cmp_ret;
+    }
   }
   return ret;
 }
 
 void ObTextDaaTIter::reset()
 {
+  batch_union_finished_.reset();
+  use_batch_union_ = false;
   bm25_param_estimator_.reset();
   // this class can know the type of dim_iters_, but ObSRDaaTIterImpl maybe not
   if (OB_NOT_NULL(dim_iters_)) {
@@ -65,6 +228,9 @@ void ObTextDaaTIter::reuse(const bool switch_tablet)
   if (OB_NOT_NULL(dim_iters_)) {
     for (int64_t i = 0; i < dim_iters_->count(); ++i) {
       static_cast<ObTextRetrievalDaaTTokenIter *>(dim_iters_->at(i))->reuse();
+      if (use_batch_union_) {
+        batch_union_finished_[i] = false;
+      }
     }
   }
   ObSRDaaTIterImpl::reuse(switch_tablet);

--- a/src/storage/retrieval/ob_text_daat_iter.h
+++ b/src/storage/retrieval/ob_text_daat_iter.h
@@ -54,18 +54,27 @@ public:
   ObTextDaaTIter() : ObSRDaaTIterImpl(),
       bm25_param_estimator_(),
       mode_flag_(ObMatchAgainstMode::NATURAL_LANGUAGE_MODE),
-      function_lookup_mode_(false) {}
+      function_lookup_mode_(false),
+      batch_union_finished_(),
+      use_batch_union_(false) {}
   virtual ~ObTextDaaTIter() { reset(); }
 
   int init(const ObTextDaaTParam &param);
+  virtual int get_next_rows(const int64_t capacity, int64_t &count) override;
   virtual void reuse(const bool switch_tablet = false) override;
   virtual void reset() override;
 protected:
   virtual int pre_process() override;
+private:
+  int get_next_rows_batch_union(const int64_t capacity, int64_t &count);
+  int get_next_union_doc_id(ObDocIdExt &doc_id);
+  int compare_doc_id(const ObDocIdExt &left, const ObDocIdExt &right, int64_t &cmp_ret) const;
 protected:
   ObBM25ParamEstimator bm25_param_estimator_;
   ObMatchAgainstMode mode_flag_;
   bool function_lookup_mode_;
+  common::ObSEArray<uint8_t, 4> batch_union_finished_;
+  bool use_batch_union_;
 private:
   DISALLOW_COPY_AND_ASSIGN(ObTextDaaTIter);
 };

--- a/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
+++ b/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
@@ -836,6 +836,40 @@ int ObTextRetrievalDaaTTokenIter::get_next_batch(const int64_t capacity, int64_t
   return OB_NOT_IMPLEMENT;
 }
 
+int ObTextRetrievalDaaTTokenIter::load_next_doc_id_batch()
+{
+  int ret = OB_SUCCESS;
+  count_ = 0;
+  cur_idx_ = 0;
+  if (OB_FAIL(token_iter_->get_next_batch(max_batch_size_, count_))) {
+    if (OB_ITER_END == ret && count_ > 0) {
+      ret = OB_SUCCESS;
+    } else if (OB_ITER_END != ret) {
+      LOG_WARN("failed to load inverted-index document batch", K(ret), K_(count));
+    }
+  }
+  if (OB_SUCC(ret) && count_ > 0 && OB_FAIL(save_union_docids())) {
+    LOG_WARN("failed to materialize union document ids", K(ret), K_(count));
+  } else if (OB_SUCC(ret) && 0 == count_) {
+    ret = OB_ITER_END;
+  }
+  return ret;
+}
+
+int ObTextRetrievalDaaTTokenIter::save_union_docids()
+{
+  int ret = OB_SUCCESS;
+  cur_idx_ = 0;
+  const ObDatumVector &doc_id_datum =
+      inv_scan_domain_id_col_->locate_expr_datumvector(*eval_ctx_);
+  for (int64_t i = 0; OB_SUCC(ret) && i < count_; ++i) {
+    if (OB_FAIL(doc_id_[i].from_datum(*doc_id_datum.at(i)))) {
+      LOG_WARN("failed to copy union document id", K(ret), K(i));
+    }
+  }
+  return ret;
+}
+
 int ObTextRetrievalDaaTTokenIter::advance_to(const ObDatum &id_datum)
 {
   int ret = OB_SUCCESS;

--- a/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
+++ b/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
@@ -717,10 +717,13 @@ int ObTextRetrievalDaaTTokenIter::init(const ObTextRetrievalScanIterParam &iter_
       if (OB_ISNULL(cmp_func_)) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("failed to init IRIterLoserTreeCmp", K(ret));
-      } else if (FALSE_IT(relevance_.set_allocator(allocator_))) {
-      } else if (OB_FAIL(relevance_.init(max_batch_size_))) {
+      } else if (OB_NOT_NULL(relevance_expr_)
+          && FALSE_IT(relevance_.set_allocator(allocator_))) {
+      } else if (OB_NOT_NULL(relevance_expr_)
+          && OB_FAIL(relevance_.init(max_batch_size_))) {
         LOG_WARN("failed to init next batch iter idxes array", K(ret));
-      } else if (OB_FAIL(relevance_.prepare_allocate(max_batch_size_))) {
+      } else if (OB_NOT_NULL(relevance_expr_)
+          && OB_FAIL(relevance_.prepare_allocate(max_batch_size_))) {
         LOG_WARN("failed to prepare allocate next batch iter idxes array", K(ret));
       } else if (FALSE_IT(doc_id_.set_allocator(allocator_))) {
       } else if (OB_FAIL(doc_id_.init(max_batch_size_))) {
@@ -820,7 +823,7 @@ int ObTextRetrievalDaaTTokenIter::save_docids()
       if (OB_LIKELY(!token_iter_->get_skip()->at(i))) {
         if (OB_FAIL(doc_id_[i].from_datum(*doc_id_datum.at(i)))) {
           LOG_WARN("failed to get doc id", K(ret));
-        };
+        }
       }
     }
   }

--- a/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
+++ b/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
@@ -111,7 +111,8 @@ void ObTextRetrievalTokenIter::reset()
 
 void ObTextRetrievalTokenIter::reuse()
 {
-  if (inv_idx_agg_cache_mode_ && !inv_idx_agg_param_->need_switch_param_) {
+  if (inv_idx_agg_cache_mode_ && OB_NOT_NULL(inv_idx_agg_param_)
+      && !inv_idx_agg_param_->need_switch_param_) {
     // do nothing
   } else {
     token_doc_cnt_calculated_ = false;
@@ -370,7 +371,8 @@ int ObTextRetrievalTokenIter::get_next_row()
   if (IS_NOT_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("retrieval token iterator not inited", K(ret));
-  } else if (!token_doc_cnt_calculated_ && OB_FAIL(estimate_token_doc_cnt())) {
+  } else if (need_calc_relevance() && !token_doc_cnt_calculated_
+      && OB_FAIL(estimate_token_doc_cnt())) {
     LOG_WARN("failed to estimate token doc cnt", K(ret));
   } else if (OB_FAIL(inv_idx_scan_iter_->get_next_row())) {
     if (OB_UNLIKELY(OB_ITER_END != ret)) {
@@ -455,7 +457,8 @@ int ObTextRetrievalTokenIter::get_next_batch(const int64_t capacity, int64_t &co
   if (IS_NOT_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("retrieval token iterator not inited", K(ret));
-  } else if (!token_doc_cnt_calculated_ && OB_FAIL(estimate_token_doc_cnt())) {
+  } else if (need_calc_relevance() && !token_doc_cnt_calculated_
+      && OB_FAIL(estimate_token_doc_cnt())) {
     LOG_WARN("failed to estimate token doc cnt", K(ret));
   } else if (OB_FAIL(inv_idx_scan_iter_->get_next_rows(count, OB_MIN(max_batch_size_, capacity)))) {
     if (OB_UNLIKELY(OB_ITER_END != ret)) {
@@ -820,10 +823,8 @@ int ObTextRetrievalDaaTTokenIter::save_docids()
     cur_idx_ = 0;
     const ObDatumVector &doc_id_datum = inv_scan_domain_id_col_->locate_expr_datumvector(*eval_ctx_);
     for (int64_t i = 0; OB_SUCC(ret) && i < count_; ++i) {
-      if (OB_LIKELY(!token_iter_->get_skip()->at(i))) {
-        if (OB_FAIL(doc_id_[i].from_datum(*doc_id_datum.at(i)))) {
-          LOG_WARN("failed to get doc id", K(ret));
-        }
+      if (OB_FAIL(doc_id_[i].from_datum(*doc_id_datum.at(i)))) {
+        LOG_WARN("failed to get doc id", K(ret));
       }
     }
   }

--- a/src/storage/retrieval/ob_text_retrieval_token_iter.h
+++ b/src/storage/retrieval/ob_text_retrieval_token_iter.h
@@ -155,6 +155,12 @@ public:
   virtual int get_curr_score(double &score) const override;
   virtual int get_curr_id(const ObDatum *&id_datum) const override;
 public:
+  // Plain DaaT union can consume the vectorized inverted-index batch directly.
+  // This avoids one virtual get_next_row()/get_curr_id() pair for every hit.
+  int load_next_doc_id_batch();
+  bool has_current_doc_id() const { return cur_idx_ >= 0 && cur_idx_ < count_; }
+  const ObDocIdExt &get_current_doc_id() const { return doc_id_[cur_idx_]; }
+  void advance_current_doc_id() { ++cur_idx_; }
   int get_token_doc_cnt(int64_t &token_doc_cnt) const { return token_iter_->get_token_doc_cnt(token_doc_cnt); }
   virtual int get_dim_max_score(double &score) override {
     int ret = OB_SUCCESS;
@@ -168,6 +174,7 @@ public:
 private:
   int save_relevances_and_docids();
   int save_docids();
+  int save_union_docids();
   ObArenaAllocator *allocator_;
   ObTextRetrievalTokenIter *token_iter_;
   sql::ObEvalCtx *eval_ctx_;

--- a/unittest/storage/fts/test_ft_parser.cpp
+++ b/unittest/storage/fts/test_ft_parser.cpp
@@ -29,6 +29,8 @@
 #include "storage/fts/dict/ob_ft_range_dict.h"
 #include "storage/fts/dict/ob_ft_trie.h"
 #include "storage/fts/dict/ob_ik_dic.h"
+#include "storage/fts/ik/ob_fast_list.h"
+#include "storage/fts/ik/ob_fast_segment_array.h"
 #include "storage/fts/ik/ob_ik_char_util.h"
 #include "storage/fts/ik/ob_ik_token.h"
 #include "storage/fts/ob_ik_ft_parser.h"
@@ -184,6 +186,87 @@ TEST(FTWordTest, test_hash)
     ASSERT_EQ(OB_SUCCESS, ret);
     ASSERT_NE(hash_val2, hash_val);
   }
+}
+
+TEST(FTTokenTest, cached_hash_and_collation_compare)
+{
+  ObObjMeta meta;
+  meta.set_varchar();
+  meta.set_collation_type(CS_TYPE_UTF8MB4_GENERAL_CI);
+  sql::ObExprBasicFuncs *basic_funcs =
+      ObDatumFuncs::get_basic_func(meta.get_type(), meta.get_collation_type());
+  ObDatumCmpFuncType cmp_func = get_datum_cmp_func(meta, meta);
+  ASSERT_NE(nullptr, basic_funcs);
+  ASSERT_NE(nullptr, basic_funcs->default_hash_);
+  ASSERT_NE(nullptr, cmp_func);
+
+  ObFTToken lower;
+  ObFTToken upper;
+  ObFTToken different;
+  ASSERT_EQ(OB_SUCCESS,
+            lower.init("oceanbase", 9, meta, basic_funcs->default_hash_, cmp_func));
+  ASSERT_EQ(OB_SUCCESS,
+            upper.init("OceanBase", 9, meta, basic_funcs->default_hash_, cmp_func));
+  ASSERT_EQ(OB_SUCCESS,
+            different.init("seekdb", 6, meta, basic_funcs->default_hash_, cmp_func));
+
+  uint64_t first_hash = 0;
+  uint64_t cached_hash = 0;
+  uint64_t upper_hash = 0;
+  ASSERT_EQ(OB_SUCCESS, lower.hash(first_hash));
+  ASSERT_EQ(OB_SUCCESS, lower.hash(cached_hash));
+  ASSERT_EQ(OB_SUCCESS, upper.hash(upper_hash));
+  ASSERT_EQ(first_hash, cached_hash);
+  ASSERT_EQ(first_hash, upper_hash);
+  ASSERT_TRUE(lower == upper);
+  ASSERT_FALSE(lower == different);
+}
+
+TEST(FTFastContainerTest, cross_block_and_reuse)
+{
+  ObArenaAllocator allocator(ObModIds::TEST);
+  ObFastSegmentArray<int64_t, 4> array(allocator);
+  for (int64_t i = 0; i < 11; ++i) {
+    ASSERT_EQ(OB_SUCCESS, array.push_back(i * 3));
+  }
+  ASSERT_EQ(11, array.count());
+  ASSERT_EQ(0, array.at(0));
+  ASSERT_EQ(30, array.at(10));
+
+  array.reuse();
+  ASSERT_TRUE(array.empty());
+  for (int64_t i = 0; i < 6; ++i) {
+    ASSERT_EQ(OB_SUCCESS, array.push_back(100 + i));
+  }
+  ASSERT_EQ(6, array.count());
+  ASSERT_EQ(100, array.at(0));
+  ASSERT_EQ(105, array.at(5));
+
+  ObFastList<int64_t, 4> list(allocator);
+  ASSERT_EQ(OB_SUCCESS, list.push_back(2));
+  ASSERT_EQ(OB_SUCCESS, list.push_front(1));
+  ASSERT_EQ(OB_SUCCESS, list.push_back(4));
+  ObFastList<int64_t, 4>::iterator pos = list.begin();
+  ++pos;
+  ++pos;
+  ASSERT_EQ(OB_SUCCESS, list.insert(pos, 3));
+  ASSERT_EQ(4, list.size());
+  int64_t expected = 1;
+  for (const int64_t value : list) {
+    ASSERT_EQ(expected++, value);
+  }
+  ASSERT_EQ(OB_SUCCESS, list.pop_front());
+  ASSERT_EQ(OB_SUCCESS, list.pop_back());
+  ASSERT_EQ(2, list.size());
+  ASSERT_EQ(2, list.get_first());
+  ASSERT_EQ(3, list.get_last());
+
+  list.reuse();
+  ASSERT_TRUE(list.empty());
+  ASSERT_EQ(OB_SUCCESS, list.push_back(7));
+  ASSERT_EQ(7, list.get_first());
+  list.reset();
+  ASSERT_TRUE(list.empty());
 }
 
 TEST_F(FTParserTest, test_cache)

--- a/unittest/storage/fts/test_ft_parser.cpp
+++ b/unittest/storage/fts/test_ft_parser.cpp
@@ -194,7 +194,7 @@ TEST_F(FTParserTest, test_cache)
   dat.mem_block_size_ = sizeof(ObFTDAT);
   ObFTDAT *ptr = &dat;
 
-  ObDictCacheKey key(1, ObFTDictType::DICT_IK_MAIN, 0);
+  ObDictCacheKey key(1, 500001, 1, 0);
   ObDictCacheValue value(ptr);
   ret = cache.put(key, value);
   ASSERT_EQ(OB_SUCCESS, ret);
@@ -205,6 +205,23 @@ TEST_F(FTParserTest, test_cache)
 
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(new_value->dat_block_->mem_block_size_, dat.mem_block_size_);
+}
+
+TEST(FTDictCacheKeyTest, distinguishes_table_generation_and_range)
+{
+  ObDictCacheKey base(1, 500001, 1, 0);
+  ObDictCacheKey same(1, 500001, 1, 0);
+  ObDictCacheKey another_tenant(2, 500001, 1, 0);
+  ObDictCacheKey another_table(1, 500002, 1, 0);
+  ObDictCacheKey another_generation(1, 500001, 2, 0);
+  ObDictCacheKey another_range(1, 500001, 1, 1);
+
+  ASSERT_TRUE(base == same);
+  ASSERT_FALSE(base == another_tenant);
+  ASSERT_FALSE(base == another_table);
+  ASSERT_FALSE(base == another_generation);
+  ASSERT_FALSE(base == another_range);
+  ASSERT_EQ(base.hash(), same.hash());
 }
 
 TEST_F(FTParserTest, test_trie)
@@ -328,8 +345,8 @@ TEST_F(FTParserTest, test_trie)
     }
 
     ObArenaAllocator allocator(ObModIds::TEST);
-    size_t size = ObArrayHashMap::estimate_size(words.size());
-    ObArrayHashMap *map = static_cast<ObArrayHashMap *>(allocator.alloc(size));
+    size_t size = ObFTArrayHashMap::estimate_size(words.size());
+    ObFTArrayHashMap *map = static_cast<ObFTArrayHashMap *>(allocator.alloc(size));
     map->init(words.size());
     for (int i = 0; i < words.size(); i++) {
       ObString str(words[i].size(), words[i].data());

--- a/unittest/storage/test_fts_plugin.cpp
+++ b/unittest/storage/test_fts_plugin.cpp
@@ -260,6 +260,35 @@ TEST_F(TestDefaultFTParser, test_space_ft_parser_segment)
   LOG_INFO("after space segment", KCSTRING(fulltext), K(ft_len), K(ft_parser_param_));
 }
 
+TEST_F(TestDefaultFTParser, test_space_ft_parser_reuse)
+{
+  ObSpaceFTParser parser;
+  const char *first_doc = "alpha beta";
+  ft_parser_param_.fulltext_ = first_doc;
+  ft_parser_param_.ft_length_ = strlen(first_doc);
+  ASSERT_EQ(OB_SUCCESS, parser.init(&ft_parser_param_));
+
+  const char *word = nullptr;
+  int64_t word_len = 0;
+  int64_t char_len = 0;
+  int64_t word_freq = 0;
+  std::vector<std::string> tokens;
+  while (OB_SUCCESS == parser.get_next_token(
+             word, word_len, char_len, word_freq)) {
+    tokens.push_back(std::string(word, word_len));
+  }
+  ASSERT_EQ((std::vector<std::string>{"alpha", "beta"}), tokens);
+
+  const char *second_doc = "gamma delta epsilon";
+  ASSERT_EQ(OB_SUCCESS, parser.reuse_parser(second_doc, strlen(second_doc)));
+  tokens.clear();
+  while (OB_SUCCESS == parser.get_next_token(
+             word, word_len, char_len, word_freq)) {
+    tokens.push_back(std::string(word, word_len));
+  }
+  ASSERT_EQ((std::vector<std::string>{"gamma", "delta", "epsilon"}), tokens);
+}
+
 TEST_F(TestDefaultFTParser, test_space_ft_parser_segment_bug_56324268)
 {
   ObSpaceFTParser parser;
@@ -883,6 +912,15 @@ TEST(ObTestNgramImpl, test_ngram_impl)
     iter_words.push_back(std::string(word, word_len));
   }
   ASSERT_EQ(expected_words, iter_words);
+
+  ObString reused_fulltext = ObString::make_string("ab cde");
+  ASSERT_EQ(OB_SUCCESS,
+            ngram_impl.reuse_parser(reused_fulltext.ptr(), reused_fulltext.length()));
+  iter_words.clear();
+  while (ngram_impl.get_next_token(word, word_len, char_cnt, word_freq) != OB_ITER_END) {
+    iter_words.push_back(std::string(word, word_len));
+  }
+  ASSERT_EQ((std::vector<std::string>{"ab", "cd", "cde", "de"}), iter_words);
 }
 
 } // end namespace storage

--- a/unittest/storage/test_fts_plugin.cpp
+++ b/unittest/storage/test_fts_plugin.cpp
@@ -29,6 +29,7 @@
 #include "plugin/sys/ob_plugin_mgr.h"
 #include "share/rc/ob_tenant_base.h"
 #include "sql/das/ob_das_utils.h"
+#include "storage/fts/ob_beng_ft_parser.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
 #include "storage/fts/ob_fts_stop_word.h"
 #include "storage/fts/ob_whitespace_ft_parser.h"
@@ -287,6 +288,48 @@ TEST_F(TestDefaultFTParser, test_space_ft_parser_reuse)
     tokens.push_back(std::string(word, word_len));
   }
   ASSERT_EQ((std::vector<std::string>{"gamma", "delta", "epsilon"}), tokens);
+}
+
+TEST_F(TestDefaultFTParser, test_beng_ft_parser_ascii_fast_path_reuse)
+{
+  common::ObArenaAllocator metadata_allocator;
+  common::ObArenaAllocator scratch_allocator;
+  ObBEngFTParser parser(metadata_allocator, scratch_allocator);
+  const char *first_doc = "OceanBase, FULL-text 123";
+  ft_parser_param_.fulltext_ = first_doc;
+  ft_parser_param_.ft_length_ = strlen(first_doc);
+  ft_parser_param_.metadata_alloc_ = &metadata_allocator;
+  ft_parser_param_.scratch_alloc_ = &scratch_allocator;
+  ASSERT_EQ(OB_SUCCESS, parser.init(&ft_parser_param_));
+
+  const char *word = nullptr;
+  int64_t word_len = 0;
+  int64_t char_len = 0;
+  int64_t word_freq = 0;
+  std::vector<std::string> tokens;
+  while (OB_SUCCESS == parser.get_next_token(
+             word, word_len, char_len, word_freq)) {
+    tokens.push_back(std::string(word, word_len));
+  }
+  ASSERT_EQ((std::vector<std::string>{"oceanbase", "full", "text", "123"}), tokens);
+
+  const char *second_doc = "数据库";
+  ASSERT_EQ(OB_SUCCESS, parser.reuse_parser(second_doc, strlen(second_doc)));
+  tokens.clear();
+  while (OB_SUCCESS == parser.get_next_token(
+             word, word_len, char_len, word_freq)) {
+    tokens.push_back(std::string(word, word_len));
+  }
+  ASSERT_EQ((std::vector<std::string>{"数据库"}), tokens);
+
+  const char *third_doc = "Already lower";
+  ASSERT_EQ(OB_SUCCESS, parser.reuse_parser(third_doc, strlen(third_doc)));
+  tokens.clear();
+  while (OB_SUCCESS == parser.get_next_token(
+             word, word_len, char_len, word_freq)) {
+    tokens.push_back(std::string(word, word_len));
+  }
+  ASSERT_EQ((std::vector<std::string>{"already", "lower"}), tokens);
 }
 
 TEST_F(TestDefaultFTParser, test_space_ft_parser_segment_bug_56324268)

--- a/unittest/storage/test_fts_property.cpp
+++ b/unittest/storage/test_fts_property.cpp
@@ -23,6 +23,7 @@
 #include "storage/fts/ob_fts_plugin_helper.h"
 
 #include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
 
 #define USING_LOG_PREFIX STORAGE_FTS
@@ -122,6 +123,9 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   static const ObString K_TEST_DICT_TABLE = "a_dict_table_name";
   static const ObString K_TEST_STOPWORD_TABLE = "a_stopword_table_name";
   static const ObString K_TEST_QUANTIFIER_TABLE = "a_quantifier_table_name";
+  static const uint64_t K_TEST_DICT_TABLE_ID = 500001;
+  static const uint64_t K_TEST_STOPWORD_TABLE_ID = 500002;
+  static const uint64_t K_TEST_QUANTIFIER_TABLE_ID = 500003;
 
   ret = json_props.init();
   ASSERT_EQ(OB_SUCCESS, ret);
@@ -142,6 +146,15 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   ASSERT_EQ(OB_SUCCESS, ret);
 
   ret = json_props.config_set_quantifier_table(K_TEST_QUANTIFIER_TABLE);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_dict_table_id(K_TEST_DICT_TABLE_ID);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_stopword_table_id(K_TEST_STOPWORD_TABLE_ID);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_quantifier_table_id(K_TEST_QUANTIFIER_TABLE_ID);
   ASSERT_EQ(OB_SUCCESS, ret);
 
   ObArenaAllocator allocator;
@@ -190,6 +203,21 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   ret = json_props.config_get_quantifier_table(quantifier_table);
   ASSERT_EQ(ret, OB_SUCCESS);
   ASSERT_EQ(quantifier_table, K_TEST_QUANTIFIER_TABLE);
+
+  uint64_t dict_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_dict_table_id(dict_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_DICT_TABLE_ID, dict_table_id);
+
+  uint64_t stopword_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_stopword_table_id(stopword_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_STOPWORD_TABLE_ID, stopword_table_id);
+
+  uint64_t quantifier_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_quantifier_table_id(quantifier_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_QUANTIFIER_TABLE_ID, quantifier_table_id);
 }
 
 TEST_F(TestFTParserJsonProperty, test_parse_from_string)
@@ -564,12 +592,14 @@ TEST_F(TestFTParserProperty, test_parse_for_ddl)
     ObString new_json;
     ret = json_props.to_format_json(tmp_alloc, new_json);
 
-    char output[] = R"(PARSER_PROPERTIES=(ik_mode="smart") )";
-    char output_buf[128];
+    char output_buf[512];
     int64_t pos = 0;
-    ret = json_props.show_parser_properties(json_props, output_buf, 128, pos);
+    ret = json_props.show_parser_properties(json_props, output_buf, sizeof(output_buf), pos);
     ASSERT_EQ(OB_SUCCESS, ret);
-    ASSERT_EQ(ObString(output), ObString(output_buf));
+    ASSERT_NE(nullptr, strstr(output_buf, "ik_mode=\"smart\""));
+    ASSERT_NE(nullptr, strstr(output_buf, "dict_table="));
+    ASSERT_NE(nullptr, strstr(output_buf, "stopword_table="));
+    ASSERT_NE(nullptr, strstr(output_buf, "quantifier_table="));
   }
   {
     int ret = OB_SUCCESS;


### PR DESCRIPTION
### Task Description

VLDB 2026 training Task 4: improve full-text index construction, tokenization, and query hot paths.

### Solution Description

- Reuse IK parser metadata and processors while resetting per-document scratch state.
- Add ASCII and Unicode classification fast paths for English and IK tokenization.
- Reduce stop-word, word-frequency, repeated tokenization, and index-build overhead.
- Reduce BM25/DAAT/BMW hot-loop datum, comparator, iterator, and debug-log overhead.
- Detect predicate-only natural-language MATCH expressions conservatively, skip unused BM25 relevance work, and use streaming DaaT.
- Preserve scoring for projections, ORDER BY / Top-K, numeric comparisons, shared expressions, and Boolean mode.

### Passed Regressions

- `make -j20 observer`
- `git diff --check` and module-layer checks
- English and IK tokenization results remain unchanged.
- Official benchmark hit counts remain unchanged: 8001 / 11000 / 7332 / 20.
- Score projection and Top-10 ordering remain unchanged.
- Numeric comparisons `MATCH > 0` and `MATCH > 0.1`, Boolean mode, and empty-query cases pass.

### Official Result

- Commit: `81cc59f`
- Workflow: https://github.com/oceanbase/seekdb/actions/runs/29476175839
- FTS score: **66.87 / 100**
- Build improvement: **6.27%**
- Tokenize improvement: **46.49%**
- Query improvement: **47.56%**

### Upgrade Compatibility

No SQL syntax, public API, BM25 formula, or on-disk format changes.

### Other Information

This is a Task 4 scoring PR targeting `vldb_2026`. It is not the final team submission and must not be merged as a team submission.

### Release Note

Improve full-text indexing, tokenization, and predicate-only MATCH query performance without changing result semantics.
