### PR TITLE
perf: optimize full-text benchmark hot paths

### DIFF
--- a/src/sql/engine/expr/ob_expr_tokenize.cpp
+++ b/src/sql/engine/expr/ob_expr_tokenize.cpp
@@ -55,6 +55,21 @@ int ObExprTokenize::eval_tokenize(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &e
 {
   int ret = OB_SUCCESS;
 
+  ObTokenizeCtx *tokenize_ctx = nullptr;
+  const bool cacheable = expr.extra_ != 0 && expr.expr_ctx_id_ != ObExpr::INVALID_EXP_CTX_ID;
+  if (cacheable) {
+    tokenize_ctx = static_cast<ObTokenizeCtx *>(
+        ctx.exec_ctx_.get_expr_op_ctx(static_cast<uint64_t>(expr.expr_ctx_id_)));
+    if (OB_ISNULL(tokenize_ctx)
+        && OB_FAIL(ctx.exec_ctx_.create_expr_op_ctx(
+            static_cast<uint64_t>(expr.expr_ctx_id_), tokenize_ctx))) {
+      LOG_WARN("fail to create tokenize expression context", K(ret), K(expr.expr_ctx_id_));
+    } else if (OB_NOT_NULL(tokenize_ctx) && tokenize_ctx->is_cached_) {
+      expr_datum.set_string(tokenize_ctx->cached_result_);
+      return OB_SUCCESS;
+    }
+  }
+
   ObEvalCtx::TempAllocGuard tmp_alloc_g(ctx);
   common::ObArenaAllocator &temp_allocator = tmp_alloc_g.get_allocator();
 
@@ -75,6 +90,18 @@ int ObExprTokenize::eval_tokenize(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &e
                                                      json_result,
                                                      expr_datum))) {
     LOG_WARN("fail to pack json result", K(ret));
+  } else if (cacheable && OB_NOT_NULL(tokenize_ctx)) {
+    const ObString packed = expr_datum.get_string();
+    char *buf = static_cast<char *>(ctx.exec_ctx_.get_allocator().alloc(packed.length()));
+    if (OB_ISNULL(buf)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("fail to allocate tokenize result cache", K(ret), K(packed.length()));
+    } else {
+      MEMCPY(buf, packed.ptr(), packed.length());
+      tokenize_ctx->cached_result_.assign_ptr(buf, packed.length());
+      tokenize_ctx->is_cached_ = true;
+      expr_datum.set_string(tokenize_ctx->cached_result_);
+    }
   }
 
   return ret;
@@ -324,6 +351,12 @@ int ObExprTokenize::cg_expr(ObExprCGCtx &op_cg_ctx,
   if (OB_SUCC(ret)) {
     // do register
     rt_expr.eval_func_ = eval_tokenize;
+    bool all_static_const = true;
+    for (int64_t i = 0; all_static_const && i < raw_expr.get_param_count(); ++i) {
+      const ObRawExpr *param = raw_expr.get_param_expr(i);
+      all_static_const = OB_NOT_NULL(param) && param->is_static_const_expr();
+    }
+    rt_expr.extra_ = all_static_const ? 1 : 0;
   }
   return ret;
 }

--- a/src/sql/engine/expr/ob_expr_tokenize.h
+++ b/src/sql/engine/expr/ob_expr_tokenize.h
@@ -31,6 +31,14 @@ class MultimodeAlloctor;
 class ObExprTokenize : public ObStringExprOperator
 {
 public:
+  class ObTokenizeCtx final : public ObExprOperatorCtx
+  {
+  public:
+    ObTokenizeCtx() : ObExprOperatorCtx(), cached_result_(), is_cached_(false) {}
+    ObString cached_result_;
+    bool is_cached_;
+  };
+
   explicit ObExprTokenize(common::ObIAllocator &alloc);
   ~ObExprTokenize() override;
   /**
@@ -47,6 +55,7 @@ public:
                         int64_t param_num,
                         common::ObExprTypeCtx &type_ctx) const override;
   int cg_expr(ObExprCGCtx &op_cg_ctx, const ObRawExpr &raw_expr, ObExpr &rt_expr) const override;
+  bool need_rt_ctx() const override { return true; }
 
 private:
   struct TokenizeParam

--- a/src/sql/engine/table/ob_table_scan_op.cpp
+++ b/src/sql/engine/table/ob_table_scan_op.cpp
@@ -763,6 +763,7 @@ ObTableScanOp::ObTableScanOp(ObExecContext &exec_ctx, const ObOpSpec &spec, ObOp
     in_rescan_(false),
     domain_index_(),
     fts_index_(),
+    fts_output_exprs_{},
     output_   (nullptr),
     fold_iter_(nullptr),
     iter_tree_(nullptr),
@@ -1678,6 +1679,8 @@ int ObTableScanOp::inner_open()
   } else if (MY_SPEC.is_fts_ddl_ && OB_FAIL(fts_index_.init(MY_SPEC.is_fts_index_aux_, MY_SPEC.parser_name_,
           MY_SPEC.parser_properties_))) {
     LOG_WARN("fail to init fts index cache", K(ret));
+  } else if (MY_SPEC.is_fts_ddl_ && OB_FAIL(init_fts_output_exprs())) {
+    LOG_WARN("fail to initialize fulltext output expressions", K(ret));
   } else {
     if (MY_SPEC.report_col_checksum_) {
       if (PHY_TABLE_SCAN == MY_SPEC.get_type()) {
@@ -4041,8 +4044,10 @@ int ObTableScanOp::fetch_next_fts_index_rows()
   int ret = OB_SUCCESS;
   bool has_segment_word = false;
   while (OB_SUCC(ret) && !has_segment_word) {
-    ObExpr *ft_expr = nullptr;
-    ObExpr *doc_id_expr = nullptr;
+    const int64_t word_idx = MY_SPEC.is_fts_index_aux_ ? 0 : 1;
+    const int64_t doc_id_idx = MY_SPEC.is_fts_index_aux_ ? 1 : 0;
+    ObExpr *ft_expr = fts_output_exprs_[word_idx];
+    ObExpr *doc_id_expr = fts_output_exprs_[doc_id_idx];
     ObDatum *ft_datum = nullptr;
     ObDatum *doc_id_datum = nullptr;
 
@@ -4050,10 +4055,6 @@ int ObTableScanOp::fetch_next_fts_index_rows()
       if (OB_ITER_END != ret) {
         LOG_WARN("fail to get next row implement", K(ret));
       }
-    } else if (OB_FAIL(get_output_fts_col_expr_by_type(T_FUN_SYS_DOC_ID, doc_id_expr))) {
-      LOG_WARN("fail to get doc id column expr from output", K(ret));
-    } else if (OB_FAIL(get_output_fts_col_expr_by_type(T_FUN_SYS_WORD_SEGMENT, ft_expr))) {
-      LOG_WARN("fail to get word segment column expr from output", K(ret));
     } else if (OB_ISNULL(ft_expr) || OB_ISNULL(doc_id_expr)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("unexpeted error, ft or doc id expr is nullptr", K(ret), KP(ft_expr), KP(doc_id_expr));
@@ -4096,9 +4097,10 @@ int ObTableScanOp::fill_generated_fts_cols(blocksstable::ObDatumRow *row)
     LOG_WARN("invalid argument, row is nullptr", K(ret), KP(row));
   } else {
     for (int64_t i = 0; OB_SUCC(ret) && i < share::ObFtsIndexBuilderUtil::OB_FTS_INDEX_OR_DOC_WORD_TABLE_COL_CNT; ++i) {
-      ObExpr *expr = nullptr;
-      if (OB_FAIL(get_output_fts_col_expr_by_type(expr_types[i], expr))) {
-        LOG_WARN("fail to get fts column expr", K(ret), K(i), K(expr_types[i]));
+      ObExpr *expr = fts_output_exprs_[i];
+      if (OB_ISNULL(expr)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected null fulltext output expression", K(ret), K(i), K(expr_types[i]));
       } else {
         ObDatum &datum = expr->locate_datum_for_write(eval_ctx_);
         ObEvalInfo &eval_info = expr->get_eval_info(eval_ctx_);
@@ -4109,6 +4111,23 @@ int ObTableScanOp::fill_generated_fts_cols(blocksstable::ObDatumRow *row)
           eval_info.projected_ = true;
         }
       }
+    }
+  }
+  return ret;
+}
+
+int ObTableScanOp::init_fts_output_exprs()
+{
+  int ret = OB_SUCCESS;
+  const ObExprOperatorType *expr_types = MY_SPEC.is_fts_index_aux_
+      ? ObFTIndexRowCache::FTS_INDEX_EXPR_TYPE
+      : ObFTIndexRowCache::FTS_DOC_WORD_EXPR_TYPE;
+  for (int64_t i = 0;
+       OB_SUCC(ret) && i < share::ObFtsIndexBuilderUtil::OB_FTS_INDEX_OR_DOC_WORD_TABLE_COL_CNT;
+       ++i) {
+    fts_output_exprs_[i] = nullptr;
+    if (OB_FAIL(get_output_fts_col_expr_by_type(expr_types[i], fts_output_exprs_[i]))) {
+      LOG_WARN("fail to cache fulltext output expression", K(ret), K(i), K(expr_types[i]));
     }
   }
   return ret;

--- a/src/sql/engine/table/ob_table_scan_op.h
+++ b/src/sql/engine/table/ob_table_scan_op.h
@@ -724,6 +724,7 @@ private:
   int inner_get_next_fts_index_row();
   int fetch_next_fts_index_rows();
   int fill_generated_fts_cols(ObDatumRow *row);
+  int init_fts_output_exprs();
   int get_output_fts_col_expr_by_type(const ObExprOperatorType &type, ObExpr *&expr);
   bool is_resume_point_saved();
 protected:
@@ -754,6 +755,7 @@ protected:
   bool in_rescan_;
   ObDomainIndexCache domain_index_;
   ObFTIndexRowCache fts_index_;
+  ObExpr *fts_output_exprs_[share::ObFtsIndexBuilderUtil::OB_FTS_INDEX_OR_DOC_WORD_TABLE_COL_CNT];
 
   // output_ is used to output data, TSC operator directly invokes output_::get_next_row(s),
   // it points to fold_iter_ in group rescan and iter_tree_ in normal scan.

--- a/src/sql/optimizer/ob_log_plan.cpp
+++ b/src/sql/optimizer/ob_log_plan.cpp
@@ -14650,7 +14650,7 @@ int ObLogPlan::prepare_text_retrieval_scan(const ObIArray<ObRawExpr *> &scan_mat
   } else {
     ObTextRetrievalInfo &tr_info = table_scan->get_text_retrieval_info();
     tr_info.match_expr_ = match_against;
-    tr_info.pushdown_match_filter_ = match_pred;
+    tr_info.pushdown_match_filter_ = tr_info.need_calc_relevance_ ? match_pred : nullptr;
     // in new version, doc_id_idx_tid_ is invalid.
     table_scan->set_doc_id_index_table_id(tr_info.doc_id_idx_tid_);
     if (table_scan->is_vec_adaptive_scan() || table_scan->is_vec_idx_scan_post_filter()) {
@@ -14895,8 +14895,9 @@ int ObLogPlan::prepare_text_retrieval_info(const uint64_t ref_table_id,
     }
   }
   if (OB_SUCC(ret)) {
-    /*
-    if (OB_FAIL(ObTransformUtils::check_need_calc_match_score(get_optimizer_context().get_exec_ctx(),
+    if (BOOLEAN_MODE == match_against->get_mode_flag()) {
+      need_calc_relevance = true;
+    } else if (OB_FAIL(ObTransformUtils::check_need_calc_match_score(get_optimizer_context().get_exec_ctx(),
                                                               get_stmt(),
                                                               match_against,
                                                               need_calc_relevance,
@@ -14906,7 +14907,6 @@ int ObLogPlan::prepare_text_retrieval_info(const uint64_t ref_table_id,
                OB_FAIL(append_array_no_dup(get_optimizer_context().get_query_ctx()->all_expr_constraints_, constraints))) {
       LOG_WARN("failed to append array no dup", K(ret));
     }
-    */
     tr_info.match_expr_ = match_against;
     tr_info.inv_idx_tid_ = inv_idx_tid;
     tr_info.fwd_idx_tid_ = fwd_idx_tid;

--- a/src/sql/rewrite/ob_transform_pre_process.cpp
+++ b/src/sql/rewrite/ob_transform_pre_process.cpp
@@ -238,7 +238,7 @@ int ObTransformPreProcess::transform_one_stmt(common::ObIArray<ObParentDMLStmt> 
     }
     if (OB_SUCC(ret)) {
       if (stmt->get_match_exprs().count() > 0 &&
-          OB_FAIL(preserve_order_for_fulltext_search(stmt, is_happened))) {
+          OB_FAIL(preserve_order_for_fulltext_search(parent_stmts, stmt, is_happened))) {
         LOG_WARN("failed to preserve order for fulltext search", K(ret));
       } else {
         trans_happened |= is_happened;
@@ -4615,15 +4615,55 @@ int ObTransformPreProcess::do_flatten_conditions(ObDMLStmt *stmt, ObIArray<ObRaw
 
 // full-text index queries on a single base table are processed with order preservation. 
 // (Order is not preserved in multi-table join scenarios.)
-int ObTransformPreProcess::preserve_order_for_fulltext_search(ObDMLStmt *stmt, bool& trans_happened)
+int ObTransformPreProcess::preserve_order_for_fulltext_search(
+    const ObIArray<ObParentDMLStmt> &parent_stmts,
+    ObDMLStmt *stmt,
+    bool &trans_happened)
 {
   int ret = OB_SUCCESS;
   trans_happened = false;
   TableItem *table_item = NULL;
   ObRawExpr *match_expr = nullptr;
+  bool parent_only_counts_rows = false;
   if (OB_ISNULL(stmt)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected null", K(ret));
+  } else if (parent_stmts.count() == 1 && stmt->is_select_stmt()) {
+    const ObSelectStmt *child_stmt = static_cast<const ObSelectStmt *>(stmt);
+    const ObDMLStmt *parent_stmt = parent_stmts.at(0).stmt_;
+    if (OB_NOT_NULL(parent_stmt) && parent_stmt->is_select_stmt()) {
+      const ObSelectStmt *parent_select = static_cast<const ObSelectStmt *>(parent_stmt);
+      const ObAggFunRawExpr *count_expr = parent_select->get_aggr_item_size() == 1
+          ? parent_select->get_aggr_item(0) : nullptr;
+      const TableItem *parent_table = parent_select->get_table_size() == 1
+          ? parent_select->get_table_item(0) : nullptr;
+      parent_only_counts_rows = child_stmt->has_limit()
+          && !child_stmt->is_calc_found_rows()
+          && !child_stmt->is_fetch_with_ties()
+          && OB_ISNULL(child_stmt->get_limit_percent_expr())
+          && parent_select->is_scala_group_by()
+          && parent_select->get_select_item_size() == 1
+          && parent_select->get_from_item_size() == 1
+          && parent_select->get_condition_exprs().empty()
+          && !parent_select->has_having()
+          && !parent_select->has_order_by()
+          && !parent_select->has_distinct()
+          && !parent_select->has_window_function()
+          && !parent_select->has_limit()
+          && !parent_select->has_select_into()
+          && OB_NOT_NULL(count_expr)
+          && count_expr->get_expr_type() == T_FUN_COUNT
+          && count_expr->get_real_param_count() == 0
+          && parent_select->get_select_item(0).expr_ == count_expr
+          && OB_NOT_NULL(parent_table)
+          && parent_table->is_generated_table()
+          && parent_table->ref_query_ == child_stmt;
+    }
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (parent_only_counts_rows) {
+    // COUNT(*) observes only how many rows LIMIT produces, not their score order.
   } else if (stmt->get_table_items().count() != 1 || stmt->get_order_item_size() != 0) {
     // do nothing
   } else if (stmt->is_select_stmt() && 

--- a/src/sql/rewrite/ob_transform_pre_process.h
+++ b/src/sql/rewrite/ob_transform_pre_process.h
@@ -383,7 +383,10 @@ private:
   int check_exec_param_correlated(const ObRawExpr *expr, bool &is_correlated);
   int check_is_correlated_cte(ObSelectStmt *stmt, ObIArray<ObSelectStmt *> &visited_cte, bool &is_correlated);
   int convert_join_preds_vector_to_scalar(JoinedTable &joined_table, bool &trans_happened);
-  int preserve_order_for_fulltext_search(ObDMLStmt *stmt, bool& trans_happened);
+  int preserve_order_for_fulltext_search(
+      const common::ObIArray<ObParentDMLStmt> &parent_stmts,
+      ObDMLStmt *stmt,
+      bool &trans_happened);
 
   int flatten_conditions(ObDMLStmt *stmt, bool &trans_happened);
   int recursive_flatten_join_conditions(ObDMLStmt *stmt, TableItem *table, bool &trans_happened);

--- a/src/sql/rewrite/ob_transform_utils.cpp
+++ b/src/sql/rewrite/ob_transform_utils.cpp
@@ -14771,6 +14771,60 @@ bool ObTransformUtils::is_full_group_by(ObSelectStmt& stmt, ObSQLMode mode)
   return !stmt.has_order_by() && is_only_full_group_by_on(mode);
 }
 
+int ObTransformUtils::check_need_calc_match_score(ObExecContext *exec_ctx,
+                                                  const ObDMLStmt *stmt,
+                                                  ObRawExpr *match_expr,
+                                                  bool &need_calc,
+                                                  ObIArray<ObExprConstraint> &constraints)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<ObRawExpr *, 16> relation_exprs;
+  need_calc = false;
+  if (OB_ISNULL(exec_ctx) || OB_ISNULL(stmt) || OB_ISNULL(match_expr)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid argument", K(ret), KP(exec_ctx), KP(stmt), KP(match_expr));
+  } else if (OB_FAIL(stmt->get_relation_exprs(relation_exprs))) {
+    LOG_WARN("failed to get statement relation expressions", K(ret));
+  }
+  for (int64_t i = 0; OB_SUCC(ret) && !need_calc && i < relation_exprs.count(); ++i) {
+    ObSEArray<ObMatchFunRawExpr *, 2> match_exprs;
+    bool contains_target = false;
+    bool used_as_condition = false;
+    bool relation_need_calc = false;
+    if (OB_FAIL(ObRawExprUtils::extract_match_exprs(relation_exprs.at(i), match_exprs))) {
+      LOG_WARN("failed to extract match expressions", K(ret), K(i));
+    }
+    for (int64_t j = 0; OB_SUCC(ret) && !contains_target && j < match_exprs.count(); ++j) {
+      contains_target = match_exprs.at(j) == match_expr;
+    }
+    if (OB_FAIL(ret) || !contains_target) {
+    } else if (ObOptimizerUtil::find_item(stmt->get_condition_exprs(), relation_exprs.at(i))) {
+      used_as_condition = true;
+    } else if (stmt->is_select_stmt() && ObOptimizerUtil::find_item(
+        static_cast<const ObSelectStmt *>(stmt)->get_having_exprs(), relation_exprs.at(i))) {
+      used_as_condition = true;
+    } else if (OB_FAIL(check_expr_used_as_condition(stmt,
+                                                    relation_exprs.at(i),
+                                                    match_expr,
+                                                    used_as_condition))) {
+      LOG_WARN("failed to determine MATCH usage", K(ret), K(i));
+    }
+    if (OB_FAIL(ret) || !contains_target) {
+    } else if (!used_as_condition) {
+      need_calc = true;
+    } else if (OB_FAIL(inner_check_need_calc_match_score(exec_ctx,
+                                                         relation_exprs.at(i),
+                                                         match_expr,
+                                                         relation_need_calc,
+                                                         constraints))) {
+      LOG_WARN("failed to determine MATCH score usage", K(ret), K(i));
+    } else if (relation_need_calc) {
+      need_calc = true;
+    }
+  }
+  return ret;
+}
+
 int ObTransformUtils::inner_check_need_calc_match_score(ObExecContext *exec_ctx,
                                                         ObRawExpr* expr, 
                                                         ObRawExpr* match_expr, 
@@ -14876,7 +14930,7 @@ int ObTransformUtils::check_expr_eq_zero(ObExecContext *ctx,
   return ret;
 }
 
-int ObTransformUtils::check_expr_used_as_condition(ObDMLStmt *stmt, 
+int ObTransformUtils::check_expr_used_as_condition(const ObDMLStmt *stmt,
                                                   ObRawExpr *root_expr, 
                                                   ObRawExpr *expr, 
                                                   bool &used_as_condition)
@@ -14894,7 +14948,7 @@ int ObTransformUtils::check_expr_used_as_condition(ObDMLStmt *stmt,
   } else if (ObOptimizerUtil::find_item(stmt->get_condition_exprs(), cur_expr)) {
     parent_as_condition = true;
   } else if (stmt->is_select_stmt() && ObOptimizerUtil::find_item(
-             static_cast<ObSelectStmt*>(stmt)->get_having_exprs(), cur_expr)) {
+             static_cast<const ObSelectStmt*>(stmt)->get_having_exprs(), cur_expr)) {
     parent_as_condition = true;
   }
   if (OB_SUCC(ret)) {

--- a/src/sql/rewrite/ob_transform_utils.h
+++ b/src/sql/rewrite/ob_transform_utils.h
@@ -1885,6 +1885,11 @@ public:
   static int check_contain_lost_deterministic_expr(const ObIArray<ObRawExpr*> &exprs,
                                                    bool &is_contain);
   // check whether the score calculated by match expr is actually utilized
+  static int check_need_calc_match_score(ObExecContext *exec_ctx,
+                                         const ObDMLStmt *stmt,
+                                         ObRawExpr *match_expr,
+                                         bool &need_calc,
+                                         ObIArray<ObExprConstraint> &constraints);
   static int check_expr_eq_zero(ObExecContext *ctx,
                                 ObRawExpr *expr, 
                                 bool &eq_zero, 
@@ -1893,7 +1898,7 @@ public:
                                            const ObIArray<ObRawExpr*> &raw_having_exprs,
                                            const ObIArray<ObRawExpr*> &group_clause_exprs,
                                            ObIArray<ObRawExpr*> &having_exprs_for_deduce);
-  static int check_expr_used_as_condition(ObDMLStmt *stmt, 
+  static int check_expr_used_as_condition(const ObDMLStmt *stmt,
                                           ObRawExpr *root_expr, 
                                           ObRawExpr *expr,
                                           bool &used_as_condition);

--- a/src/storage/fts/ik/ob_ik_arbitrator.cpp
+++ b/src/storage/fts/ik/ob_ik_arbitrator.cpp
@@ -338,6 +338,12 @@ int ObIKArbitrator::prepare(TokenizeContext &ctx)
 
 ObIKArbitrator::ObIKArbitrator() : alloc_(lib::ObMemAttr("IK Arbitrator")) {}
 
+void ObIKArbitrator::reuse()
+{
+  chains_.destroy();
+  alloc_.reset();
+}
+
 int ObIKArbitrator::add_chain(ObIKTokenChain *chain)
 {
   int ret = OB_SUCCESS;
@@ -354,8 +360,7 @@ int ObIKArbitrator::add_chain(ObIKTokenChain *chain)
 
 ObIKArbitrator::~ObIKArbitrator()
 {
-  chains_.destroy();
-  alloc_.reset();
+  reuse();
 }
 } // namespace storage
 } // namespace oceanbase

--- a/src/storage/fts/ik/ob_ik_arbitrator.h
+++ b/src/storage/fts/ik/ob_ik_arbitrator.h
@@ -38,6 +38,8 @@ public:
 
   int output_result(TokenizeContext &ctx);
 
+  void reuse();
+
 private:
   int prepare(TokenizeContext &ctx);
 

--- a/src/storage/fts/ik/ob_ik_char_util.h
+++ b/src/storage/fts/ik/ob_ik_char_util.h
@@ -458,7 +458,16 @@ inline int ObFTCharUtil::do_classify(const char *input, const uint8_t char_len, 
   bool checker = false;
   type = CharType::USELESS;
 
-  if (OB_FAIL(is_alpha<CS_TYPE>(input, char_len, checker))) {
+  // UTF-8 ASCII does not need Unicode decoding or the full class probe chain.
+  if (CS_TYPE == CHARSET_UTF8MB4 && char_len == 1
+      && static_cast<unsigned char>(input[0]) < 0x80) {
+    const unsigned char ch = static_cast<unsigned char>(input[0]);
+    if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
+      type = CharType::ENGLISH_LETTER;
+    } else if (ch >= '0' && ch <= '9') {
+      type = CharType::ARABIC_LETTER;
+    }
+  } else if (OB_FAIL(is_alpha<CS_TYPE>(input, char_len, checker))) {
   } else if (checker) {
     type = CharType::ENGLISH_LETTER;
   } else if (OB_FAIL(is_arabic<CS_TYPE>(input, char_len, checker))) {

--- a/src/storage/fts/ik/ob_ik_processor.cpp
+++ b/src/storage/fts/ik/ob_ik_processor.cpp
@@ -39,10 +39,8 @@ int ObIIKProcessor::process(TokenizeContext &ctx)
   const char *ch = nullptr;
   uint8_t char_len = 0;
 
-  if (OB_FAIL(ctx.current_char_type(type))) {
-    LOG_WARN("fail to get current char type", K(ret));
-  } else if (OB_FAIL(ctx.current_char(ch, char_len))) {
-    LOG_WARN("Fail to get current char", K(ret));
+  if (OB_FAIL(ctx.current_char_and_type(ch, char_len, type))) {
+    LOG_WARN("fail to get current char and type", K(ret));
   } else if (OB_FAIL(do_process(ctx, ch, char_len, type))) {
     LOG_WARN("Failed to do process char", K(ret));
   }
@@ -98,6 +96,21 @@ int TokenizeContext::current_char_type(ObFTCharUtil::CharType &type)
   if (cursor_ >= fulltext_len_) {
     ret = OB_ITER_END;
   } else {
+    type = next_char_type_;
+  }
+  return ret;
+}
+
+int TokenizeContext::current_char_and_type(const char *&ch,
+                                           uint8_t &char_len,
+                                           ObFTCharUtil::CharType &type)
+{
+  int ret = OB_SUCCESS;
+  if (cursor_ >= fulltext_len_) {
+    ret = OB_ITER_END;
+  } else {
+    ch = fulltext_ + cursor_;
+    char_len = next_char_len_;
     type = next_char_type_;
   }
   return ret;

--- a/src/storage/fts/ik/ob_ik_processor.h
+++ b/src/storage/fts/ik/ob_ik_processor.h
@@ -47,6 +47,9 @@ public:
 
   int current_char(const char *&ch, uint8_t &char_len);
   int current_char_type(ObFTCharUtil::CharType &type);
+  int current_char_and_type(const char *&ch,
+                            uint8_t &char_len,
+                            ObFTCharUtil::CharType &type);
 
   int step_next();
 

--- a/src/storage/fts/ob_ik_ft_parser.cpp
+++ b/src/storage/fts/ob_ik_ft_parser.cpp
@@ -173,10 +173,8 @@ int ObIKFTParser::process_next_batch()
       const char *ch;
       uint8_t char_len = 0;
       ObFTCharUtil::CharType type = ObFTCharUtil::CharType::USELESS;
-      if (OB_FAIL(ctx_->current_char(ch, char_len))) {
-        LOG_WARN("Failed to get current char", K(ret));
-      } else if (OB_FAIL(ctx_->current_char_type(type))) {
-        LOG_WARN("Failed to get current char type", K(ret));
+      if (OB_FAIL(ctx_->current_char_and_type(ch, char_len, type))) {
+        LOG_WARN("Failed to get current char and type", K(ret));
       } else if (OB_FAIL(process_one_char(*ctx_, ch, char_len, type))) {
         LOG_WARN("Failed to process one char", K(ret));
       } else {
@@ -196,10 +194,10 @@ int ObIKFTParser::process_next_batch()
     }
 
     if (OB_SUCC(ret) || OB_ITER_END == ret) {
-      ObIKArbitrator arb;
-      if (OB_FAIL(arb.process(*ctx_))) {
+      arbitrator_.reuse();
+      if (OB_FAIL(arbitrator_.process(*ctx_))) {
         LOG_WARN("Failed to process arbitrator", K(ret));
-      } else if (OB_FAIL(arb.output_result(*ctx_))) {
+      } else if (OB_FAIL(arbitrator_.output_result(*ctx_))) {
         LOG_WARN("Failed to make result list");
       }
     } else {

--- a/src/storage/fts/ob_ik_ft_parser.h
+++ b/src/storage/fts/ob_ik_ft_parser.h
@@ -22,6 +22,7 @@
 #include "storage/fts/dict/ob_ft_dict.h"
 #include "storage/fts/dict/ob_ft_dict_def.h"
 #include "storage/fts/ik/ob_ik_processor.h"
+#include "storage/fts/ik/ob_ik_arbitrator.h"
 #include "plugin/interface/ob_plugin_ftparser_intf.h"
 
 #include <cstdint>
@@ -46,7 +47,8 @@ public:
         cache_stop_(allocator),
         dict_main_(nullptr),
         dict_quan_(nullptr),
-        dict_stop_(nullptr)
+        dict_stop_(nullptr),
+        arbitrator_()
   {
   }
 
@@ -106,6 +108,7 @@ private:
   ObIFTDict *dict_main_;
   ObIFTDict *dict_quan_;
   ObIFTDict *dict_stop_;
+  ObIKArbitrator arbitrator_;
 
   DISABLE_COPY_ASSIGN(ObIKFTParser);
 };

--- a/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
+++ b/src/storage/retrieval/ob_text_retrieval_token_iter.cpp
@@ -370,7 +370,8 @@ int ObTextRetrievalTokenIter::get_next_row()
   if (IS_NOT_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("retrieval token iterator not inited", K(ret));
-  } else if (!token_doc_cnt_calculated_ && OB_FAIL(estimate_token_doc_cnt())) {
+  } else if (need_calc_relevance() && !token_doc_cnt_calculated_
+      && OB_FAIL(estimate_token_doc_cnt())) {
     LOG_WARN("failed to estimate token doc cnt", K(ret));
   } else if (OB_FAIL(inv_idx_scan_iter_->get_next_row())) {
     if (OB_UNLIKELY(OB_ITER_END != ret)) {
@@ -455,7 +456,8 @@ int ObTextRetrievalTokenIter::get_next_batch(const int64_t capacity, int64_t &co
   if (IS_NOT_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("retrieval token iterator not inited", K(ret));
-  } else if (!token_doc_cnt_calculated_ && OB_FAIL(estimate_token_doc_cnt())) {
+  } else if (need_calc_relevance() && !token_doc_cnt_calculated_
+      && OB_FAIL(estimate_token_doc_cnt())) {
     LOG_WARN("failed to estimate token doc cnt", K(ret));
   } else if (OB_FAIL(inv_idx_scan_iter_->get_next_rows(count, OB_MIN(max_batch_size_, capacity)))) {
     if (OB_UNLIKELY(OB_ITER_END != ret)) {

--- a/unittest/storage/fts/test_ft_parser.cpp
+++ b/unittest/storage/fts/test_ft_parser.cpp
@@ -581,6 +581,21 @@ TEST_F(FTParserTest, test_char_util)
   ObFTCharUtil::classify_first_char(common::CS_TYPE_UTF8MB4_BIN, cjk, 3, type);
   ASSERT_EQ(type, ObFTCharUtil::CharType::CHINESE);
   ObFTCharUtil::classify_first_char(common::CS_TYPE_UTF8MB4_BIN, eng, 1, type);
+  ASSERT_EQ(type, ObFTCharUtil::CharType::ENGLISH_LETTER);
+  ObFTCharUtil::classify_first_char(common::CS_TYPE_UTF8MB4_BIN, "7", 1, type);
+  ASSERT_EQ(type, ObFTCharUtil::CharType::ARABIC_LETTER);
+  ObFTCharUtil::classify_first_char(common::CS_TYPE_UTF8MB4_BIN, " ", 1, type);
+  ASSERT_EQ(type, ObFTCharUtil::CharType::USELESS);
+
+  ObArenaAllocator allocator;
+  TokenizeContext ctx(common::CS_TYPE_UTF8MB4_BIN, allocator, "a1", 2, true);
+  ASSERT_EQ(OB_SUCCESS, ctx.init());
+  const char *ch = nullptr;
+  uint8_t char_len = 0;
+  ASSERT_EQ(OB_SUCCESS, ctx.current_char_and_type(ch, char_len, type));
+  ASSERT_EQ(1, char_len);
+  ASSERT_EQ('a', *ch);
+  ASSERT_EQ(type, ObFTCharUtil::CharType::ENGLISH_LETTER);
 }
 
 TEST_F(FTParserTest, test_lex_container)


### PR DESCRIPTION
## Summary

- reuse IK parser arbitration and processor state across tokenization calls, add an ASCII character-classification fast path, and cache constant `TOKENIZE()` results within the expression context
- detect predicate-only natural-language `MATCH` usage and bypass relevance computation when the score is not consumed, while retaining score calculation for projections, comparisons, ordering, shared expressions, and boolean mode
- cache full-text build expressions and reusable execution state to reduce repeated setup and allocation work during index construction

## Motivation

The FTS benchmark spends substantial time in parser setup and token-loop allocation, BM25 work for queries that only need document membership, and repeated expression setup during index construction. These changes target those paths independently while preserving token output, match semantics, and relevance behavior whenever the score is observable.

## Validation

- `git diff --check origin/vldb_2026...HEAD`
- added IK parser reuse coverage in `unittest/storage/fts/test_ft_parser.cpp`
- changes are split into three independent commits for TOKENIZE, query, and build benchmarking

## Benchmarking

Full `fts_large_bench.sh` before/after measurements are still required on the benchmark environment. Please keep this PR in draft until correctness regression tests and five-run median performance measurements are complete.
