### PR TITLE
feat: add LOAD_FILE and AI_SPLIT_DOCUMENT functions

### DIFF
--- a/deps/oblib/src/lib/ob_name_def.h
+++ b/deps/oblib/src/lib/ob_name_def.h
@@ -1258,5 +1258,7 @@
 #define N_AI_EMBED                          "ai_embed"
 #define N_AI_RERANK                         "ai_rerank"
 #define N_AI_PROMPT                         "ai_prompt"
+#define N_AI_SPLIT_DOCUMENT                 "ai_split_document"
+#define N_LOAD_FILE                         "load_file"
 #define N_CHECK_LOCATION_ACCESS "check_location_access"
 #endif //OCEANBASE_LIB_OB_NAME_DEF_H_

--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -977,6 +977,8 @@ typedef enum ObItemType
   T_FUN_SYS_EMBEDDED_VEC = 1928,
   T_FUN_SYS_AI_PROMPT = 1929,
   T_FUN_SYS_VEC_VISIBLE = 1930, // vector index table 5
+  T_FUN_SYS_LOAD_FILE = 1931,
+  T_FUN_SYS_AI_SPLIT_DOCUMENT = 1932,
 
   ///< @note add new sys function type before this line
   T_FUN_SYS_END = 2000,

--- a/src/sql/CMakeLists.txt
+++ b/src/sql/CMakeLists.txt
@@ -641,6 +641,7 @@ ob_set_subtarget(ob_sql engine_expr
   engine/expr/ob_expr_least.cpp
   engine/expr/ob_expr_left.cpp
   engine/expr/ob_expr_length.cpp
+  engine/expr/ob_expr_load_file.cpp
   engine/expr/ob_expr_less_equal.cpp
   engine/expr/ob_expr_less_than.cpp
   engine/expr/ob_expr_like.cpp
@@ -960,6 +961,7 @@ ob_set_subtarget(ob_sql engine_expr
   engine/expr/ob_expr_ai/ob_expr_ai_embed.cpp
   engine/expr/ob_expr_ai/ob_expr_ai_rerank.cpp
   engine/expr/ob_expr_ai/ob_expr_ai_prompt.cpp
+  engine/expr/ob_expr_ai/ob_expr_ai_split_document.cpp
 )
 
 ob_set_subtarget(ob_sql_extra ALONE

--- a/src/sql/engine/basic/ob_function_table_op.cpp
+++ b/src/sql/engine/basic/ob_function_table_op.cpp
@@ -19,6 +19,8 @@
 #include "sql/engine/basic/ob_function_table_op.h"
 #include "sql/engine/ob_exec_context.h"
 #include "sql/engine/expr/ob_expr_lob_utils.h"
+#include "common/json_type/ob_json_base.h"
+#include "common/json_type/ob_json_tree.h"
 
 
 namespace oceanbase
@@ -29,6 +31,76 @@ namespace sql
 
 OB_SERIALIZE_MEMBER((ObFunctionTableSpec, ObOpSpec), value_expr_, column_exprs_, has_correlated_expr_);
 
+namespace
+{
+static const int64_t AI_SPLIT_DOCUMENT_COLUMN_COUNT = 4;
+static const int64_t AI_SPLIT_DOCUMENT_MAX_INPUT_LENGTH = common::OB_MAX_LONGTEXT_LENGTH;
+
+bool ai_split_document_equal_string(const ObString &left, const char *right)
+{
+  return 0 == left.case_compare(right);
+}
+
+int ai_split_document_invalid_argument(const char *message)
+{
+  int ret = OB_INVALID_ARGUMENT;
+  LOG_WARN("invalid AI_SPLIT_DOCUMENT argument", K(ret), K(message));
+  LOG_USER_ERROR(OB_INVALID_ARGUMENT, message);
+  return ret;
+}
+
+int get_ai_split_document_json_string(ObJsonObject &json_obj,
+                                      const char *field_name,
+                                      ObString &value)
+{
+  int ret = OB_SUCCESS;
+  ObJsonNode *node = json_obj.get_value(ObString::make_string(field_name));
+  if (OB_ISNULL(node)) {
+    // use default
+  } else if (ObJsonNodeType::J_STRING != node->json_type()) {
+    ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT string parameter type");
+    LOG_WARN("AI_SPLIT_DOCUMENT json string field has unexpected type",
+             K(ret), K(field_name), K(node->json_type()));
+  } else {
+    value = static_cast<ObJsonString *>(node)->get_str();
+  }
+  return ret;
+}
+
+int get_ai_split_document_json_int(ObJsonObject &json_obj,
+                                   const char *field_name,
+                                   int64_t &value)
+{
+  int ret = OB_SUCCESS;
+  ObJsonNode *node = json_obj.get_value(ObString::make_string(field_name));
+  if (OB_ISNULL(node)) {
+    // use default
+  } else if (ObJsonNodeType::J_INT == node->json_type()) {
+    value = static_cast<ObJsonInt *>(node)->value();
+  } else if (ObJsonNodeType::J_UINT == node->json_type()) {
+    const uint64_t uint_value = static_cast<ObJsonUint *>(node)->value();
+    if (OB_UNLIKELY(uint_value > static_cast<uint64_t>(INT64_MAX))) {
+      ret = OB_SIZE_OVERFLOW;
+      LOG_WARN("AI_SPLIT_DOCUMENT integer parameter is too large",
+               K(ret), K(field_name), K(uint_value));
+    } else {
+      value = static_cast<int64_t>(uint_value);
+    }
+  } else {
+    ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT integer parameter type");
+    LOG_WARN("AI_SPLIT_DOCUMENT json integer field has unexpected type",
+             K(ret), K(field_name), K(node->json_type()));
+  }
+  return ret;
+}
+}
+
+bool ObFunctionTableOp::is_ai_split_document() const
+{
+  return OB_NOT_NULL(MY_SPEC.value_expr_)
+      && T_FUN_SYS_AI_SPLIT_DOCUMENT == MY_SPEC.value_expr_->type_;
+}
+
 int ObFunctionTableOp::inner_open()
 {
   int ret = OB_SUCCESS;
@@ -37,6 +109,8 @@ int ObFunctionTableOp::inner_open()
   if (OB_ISNULL(MY_SPEC.value_expr_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("value expr is not init", K(ret));
+  } else if (is_ai_split_document()) {
+    next_row_func_ = &ObFunctionTableOp::inner_get_next_row_ai_split_document;
   } else if (ObExtendType == MY_SPEC.value_expr_->datum_meta_.type_) {
     next_row_func_ = &ObFunctionTableOp::inner_get_next_row_udf;
   } else {
@@ -52,7 +126,9 @@ int ObFunctionTableOp::inner_rescan()
     LOG_WARN("failed to inner rescan", K(ret));
   } else {
     node_idx_ = 0;
-    if (MY_SPEC.has_correlated_expr_) {
+    if (is_ai_split_document()) {
+      reset_ai_split_document_state();
+    } else if (MY_SPEC.has_correlated_expr_) {
       row_count_ = 0;
       col_count_ = 0;
       value_table_ = NULL;
@@ -69,6 +145,7 @@ int ObFunctionTableOp::inner_close()
   row_count_ = 0;
   col_count_ = 0;
   value_table_ = NULL;
+  reset_ai_split_document_state();
   return ret;
 }
 
@@ -92,6 +169,7 @@ int ObFunctionTableOp::switch_iterator()
 
 void ObFunctionTableOp::destroy()
 {
+  reset_ai_split_document_state();
   ObOperator::destroy();
 }
 
@@ -244,6 +322,614 @@ int ObFunctionTableOp::inner_get_next_row_sys_func()
   } else {
     MY_SPEC.column_exprs_.at(0)->locate_datum_for_write(eval_ctx_).set_datum(*value);
     MY_SPEC.column_exprs_.at(0)->set_evaluated_projected(eval_ctx_);
+  }
+  return ret;
+}
+
+void ObFunctionTableOp::reset_ai_split_document_state()
+{
+  ai_split_chunks_.reset();
+  ai_split_alloc_.reuse();
+  ai_split_content_.reset();
+  ai_split_next_idx_ = 0;
+  ai_split_inited_ = false;
+}
+
+int ObFunctionTableOp::parse_ai_split_document_params(ObIAllocator &allocator,
+                                                      const ObExpr &expr,
+                                                      AISplitParams &params)
+{
+  int ret = OB_SUCCESS;
+  ObDatum *params_datum = NULL;
+  ObString params_str;
+  ObIJsonBase *json_base = NULL;
+  ObJsonObject *json_obj = NULL;
+  if (OB_UNLIKELY(expr.arg_cnt_ < 1 || expr.arg_cnt_ > 2)) {
+    ret = OB_ERR_PARAM_SIZE;
+    LOG_WARN("AI_SPLIT_DOCUMENT expects one or two arguments", K(ret), K(expr.arg_cnt_));
+  } else if (1 == expr.arg_cnt_) {
+    // use default parameters
+  } else if (OB_ISNULL(expr.args_) || OB_ISNULL(expr.args_[1])) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("AI_SPLIT_DOCUMENT parameter expr is null", K(ret), KP(expr.args_));
+  } else if (OB_FAIL(expr.args_[1]->eval(eval_ctx_, params_datum))) {
+    LOG_WARN("failed to eval AI_SPLIT_DOCUMENT parameters", K(ret));
+  } else if (OB_ISNULL(params_datum)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("AI_SPLIT_DOCUMENT parameter datum is null", K(ret));
+  } else if (params_datum->is_null()) {
+    // use default parameters
+  } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(allocator,
+                                                               *params_datum,
+                                                               expr.args_[1]->datum_meta_,
+                                                               expr.args_[1]->obj_meta_.has_lob_header(),
+                                                               params_str,
+                                                               &get_exec_ctx()))) {
+    LOG_WARN("failed to read AI_SPLIT_DOCUMENT parameter string", K(ret));
+  } else if (params_str.empty()) {
+    ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT parameters must be a JSON object");
+  } else if (OB_FAIL(ObJsonBaseFactory::get_json_base(&allocator,
+                                                      params_str,
+                                                      ObJsonInType::JSON_TREE,
+                                                      ObJsonInType::JSON_TREE,
+                                                      json_base))) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("failed to parse AI_SPLIT_DOCUMENT parameters json", K(ret));
+    LOG_USER_ERROR(OB_INVALID_ARGUMENT, "AI_SPLIT_DOCUMENT parameters must be a JSON object");
+  } else if (OB_ISNULL(json_base) || ObJsonNodeType::J_OBJECT != json_base->json_type()) {
+    ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT parameters must be a JSON object");
+    LOG_WARN("AI_SPLIT_DOCUMENT parameters json is not object", K(ret), KP(json_base));
+  } else if (FALSE_IT(json_obj = static_cast<ObJsonObject *>(json_base))) {
+  } else if (OB_FAIL(get_ai_split_document_json_string(*json_obj, "type", params.type_))) {
+    LOG_WARN("failed to get AI_SPLIT_DOCUMENT type parameter", K(ret));
+  } else if (OB_FAIL(get_ai_split_document_json_string(*json_obj, "by", params.by_))) {
+    LOG_WARN("failed to get AI_SPLIT_DOCUMENT by parameter", K(ret));
+  } else if (OB_FAIL(get_ai_split_document_json_int(*json_obj, "max", params.max_))) {
+    LOG_WARN("failed to get AI_SPLIT_DOCUMENT max parameter", K(ret));
+  } else if (OB_FAIL(get_ai_split_document_json_int(*json_obj, "overlap", params.overlap_))) {
+    LOG_WARN("failed to get AI_SPLIT_DOCUMENT overlap parameter", K(ret));
+  }
+
+  if (OB_SUCC(ret)) {
+    if (OB_UNLIKELY(params.max_ <= 0)) {
+      ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT max must be greater than 0");
+    } else if (OB_UNLIKELY(params.max_ > AI_SPLIT_DOCUMENT_MAX_INPUT_LENGTH)) {
+      ret = OB_SIZE_OVERFLOW;
+      LOG_WARN("AI_SPLIT_DOCUMENT max is too large",
+               K(ret), K(params.max_), K(AI_SPLIT_DOCUMENT_MAX_INPUT_LENGTH));
+    } else if (OB_UNLIKELY(params.overlap_ < 0)) {
+      ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT overlap must be greater than or equal to 0");
+    } else if (OB_UNLIKELY(params.overlap_ >= params.max_)) {
+      ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT overlap must be less than max");
+    } else if (!ai_split_document_equal_string(params.type_, "text")
+               && !ai_split_document_equal_string(params.type_, "markdown")) {
+      ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT type must be text or markdown");
+    } else if (!ai_split_document_equal_string(params.by_, "word")
+               && !ai_split_document_equal_string(params.by_, "sentence")) {
+      ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT by must be word or sentence");
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::init_ai_split_document()
+{
+  int ret = OB_SUCCESS;
+  ObDatum *content_datum = NULL;
+  ObString content;
+  AISplitParams params;
+  ObEvalCtx::TempAllocGuard tmp_alloc_guard(eval_ctx_);
+  ObIAllocator &tmp_allocator = tmp_alloc_guard.get_allocator();
+
+  reset_ai_split_document_state();
+  if (OB_ISNULL(MY_SPEC.value_expr_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("AI_SPLIT_DOCUMENT value expr is null", K(ret));
+  } else if (OB_UNLIKELY(MY_SPEC.value_expr_->arg_cnt_ < 1 || MY_SPEC.value_expr_->arg_cnt_ > 2)) {
+    ret = OB_ERR_PARAM_SIZE;
+    LOG_WARN("AI_SPLIT_DOCUMENT expects one or two arguments",
+             K(ret), K(MY_SPEC.value_expr_->arg_cnt_));
+  } else if (OB_ISNULL(MY_SPEC.value_expr_->args_) || OB_ISNULL(MY_SPEC.value_expr_->args_[0])) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("AI_SPLIT_DOCUMENT content expr is null", K(ret), KP(MY_SPEC.value_expr_->args_));
+  } else if (OB_FAIL(MY_SPEC.value_expr_->args_[0]->eval(eval_ctx_, content_datum))) {
+    LOG_WARN("failed to eval AI_SPLIT_DOCUMENT content", K(ret));
+  } else if (OB_ISNULL(content_datum)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("AI_SPLIT_DOCUMENT content datum is null", K(ret));
+  } else if (content_datum->is_null()) {
+    ai_split_inited_ = true;
+  } else if (OB_FAIL(ObTextStringHelper::read_real_string_data(tmp_allocator,
+                                                               *content_datum,
+                                                               MY_SPEC.value_expr_->args_[0]->datum_meta_,
+                                                               MY_SPEC.value_expr_->args_[0]->obj_meta_.has_lob_header(),
+                                                               content,
+                                                               &get_exec_ctx()))) {
+    LOG_WARN("failed to read AI_SPLIT_DOCUMENT content string", K(ret));
+  } else if (OB_UNLIKELY(content.length() > AI_SPLIT_DOCUMENT_MAX_INPUT_LENGTH)) {
+    ret = OB_SIZE_OVERFLOW;
+    LOG_WARN("AI_SPLIT_DOCUMENT content is too large",
+             K(ret), K(content.length()), K(AI_SPLIT_DOCUMENT_MAX_INPUT_LENGTH));
+  } else if (0 == content.length()) {
+    ai_split_inited_ = true;
+  } else if (OB_FAIL(parse_ai_split_document_params(tmp_allocator, *MY_SPEC.value_expr_, params))) {
+    LOG_WARN("failed to parse AI_SPLIT_DOCUMENT parameters", K(ret));
+  } else {
+    char *content_buf = static_cast<char *>(ai_split_alloc_.alloc(content.length()));
+    if (OB_ISNULL(content_buf)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate AI_SPLIT_DOCUMENT content buffer", K(ret), K(content.length()));
+    } else {
+      MEMCPY(content_buf, content.ptr(), content.length());
+      ai_split_content_.assign_ptr(content_buf, content.length());
+      if (OB_FAIL(build_ai_split_document_chunks(params))) {
+        LOG_WARN("failed to build AI_SPLIT_DOCUMENT chunks", K(ret));
+      } else {
+        ai_split_inited_ = true;
+      }
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::build_ai_split_document_chunks(const AISplitParams &params)
+{
+  int ret = OB_SUCCESS;
+  if (ai_split_document_equal_string(params.type_, "markdown")) {
+    if (OB_FAIL(build_ai_split_document_markdown_chunks(params))) {
+      LOG_WARN("failed to build markdown chunks for AI_SPLIT_DOCUMENT", K(ret));
+    }
+  } else if (ai_split_document_equal_string(params.by_, "word")) {
+    if (OB_FAIL(build_ai_split_document_word_chunks(params))) {
+      LOG_WARN("failed to build word chunks for AI_SPLIT_DOCUMENT", K(ret));
+    }
+  } else if (ai_split_document_equal_string(params.by_, "sentence")) {
+    if (OB_FAIL(build_ai_split_document_sentence_chunks(params))) {
+      LOG_WARN("failed to build sentence chunks for AI_SPLIT_DOCUMENT", K(ret));
+    }
+  } else {
+    ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT by must be word or sentence");
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::build_ai_split_document_word_chunks(const AISplitParams &params)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<AISplitRange, 128> words;
+  const char *data = ai_split_content_.ptr();
+  const int64_t len = ai_split_content_.length();
+  int64_t pos = 0;
+  while (OB_SUCC(ret) && pos < len) {
+    while (pos < len && is_ai_split_ascii_space(data[pos])) {
+      ++pos;
+    }
+    if (pos < len) {
+      const int64_t word_start = pos;
+      while (pos < len && !is_ai_split_ascii_space(data[pos])) {
+        ++pos;
+      }
+      const int64_t word_end = pos;
+      if (OB_FAIL(words.push_back(AISplitRange(word_start, word_end)))) {
+        LOG_WARN("failed to append AI_SPLIT_DOCUMENT word range", K(ret));
+      }
+    }
+  }
+  if (OB_SUCC(ret)) {
+    const int64_t step = params.max_ - params.overlap_;
+    for (int64_t word_idx = 0; OB_SUCC(ret) && word_idx < words.count(); word_idx += step) {
+      const int64_t last_word_idx = MIN(word_idx + params.max_, words.count()) - 1;
+      if (OB_FAIL(add_ai_split_document_chunk(words.at(word_idx).start_,
+                                              words.at(last_word_idx).end_))) {
+        LOG_WARN("failed to add AI_SPLIT_DOCUMENT word chunk", K(ret), K(word_idx), K(last_word_idx));
+      }
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::build_ai_split_document_sentence_chunks(const AISplitParams &params)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<AISplitRange, 64> sentences;
+  const char *data = ai_split_content_.ptr();
+  const int64_t len = ai_split_content_.length();
+  int64_t pos = 0;
+  while (OB_SUCC(ret) && pos < len) {
+    while (pos < len && is_ai_split_ascii_space(data[pos])) {
+      ++pos;
+    }
+    if (pos < len) {
+      const int64_t sentence_start = pos;
+      int64_t sentence_end = len;
+      bool found_terminator = false;
+      while (pos < len && !found_terminator) {
+        const int64_t char_len = get_ai_split_utf8_char_len(data + pos, len - pos);
+        if (is_ai_split_sentence_terminator(data + pos, char_len)) {
+          pos += char_len;
+          sentence_end = pos;
+          found_terminator = true;
+        } else {
+          pos += char_len;
+        }
+      }
+      if (!found_terminator) {
+        sentence_end = pos;
+        while (sentence_end > sentence_start && is_ai_split_ascii_space(data[sentence_end - 1])) {
+          --sentence_end;
+        }
+      }
+      if (sentence_end > sentence_start
+          && OB_FAIL(sentences.push_back(AISplitRange(sentence_start, sentence_end)))) {
+        LOG_WARN("failed to append AI_SPLIT_DOCUMENT sentence range", K(ret));
+      }
+    }
+  }
+  if (OB_SUCC(ret)) {
+    const int64_t step = params.max_ - params.overlap_;
+    for (int64_t sentence_idx = 0; OB_SUCC(ret) && sentence_idx < sentences.count(); sentence_idx += step) {
+      const int64_t last_sentence_idx = MIN(sentence_idx + params.max_, sentences.count()) - 1;
+      if (OB_FAIL(add_ai_split_document_chunk(sentences.at(sentence_idx).start_,
+                                              sentences.at(last_sentence_idx).end_))) {
+        LOG_WARN("failed to add AI_SPLIT_DOCUMENT sentence chunk",
+                 K(ret), K(sentence_idx), K(last_sentence_idx));
+      }
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::build_ai_split_document_markdown_chunks(const AISplitParams &params)
+{
+  int ret = OB_SUCCESS;
+  const char *data = ai_split_content_.ptr();
+  const int64_t len = ai_split_content_.length();
+  ObString current_heading;
+  int64_t section_body_start = 0;
+  int64_t pos = 0;
+  while (OB_SUCC(ret) && pos < len) {
+    const int64_t line_start = pos;
+    while (pos < len && '\n' != data[pos] && '\r' != data[pos]) {
+      ++pos;
+    }
+    const int64_t line_end = pos;
+    int64_t next_line = pos;
+    if (next_line < len && '\r' == data[next_line]) {
+      ++next_line;
+      if (next_line < len && '\n' == data[next_line]) {
+        ++next_line;
+      }
+    } else if (next_line < len && '\n' == data[next_line]) {
+      ++next_line;
+    }
+
+    ObString heading;
+    if (is_ai_split_markdown_heading(data + line_start, line_end - line_start, heading)) {
+      if (ai_split_document_equal_string(params.by_, "word")) {
+        if (OB_FAIL(build_ai_split_document_markdown_word_chunks(params,
+                                                                 current_heading,
+                                                                 section_body_start,
+                                                                 line_start))) {
+          LOG_WARN("failed to build AI_SPLIT_DOCUMENT markdown word section",
+                   K(ret), K(section_body_start), K(line_start));
+        }
+      } else if (ai_split_document_equal_string(params.by_, "sentence")) {
+        if (OB_FAIL(build_ai_split_document_markdown_sentence_chunks(params,
+                                                                     current_heading,
+                                                                     section_body_start,
+                                                                     line_start))) {
+          LOG_WARN("failed to build AI_SPLIT_DOCUMENT markdown sentence section",
+                   K(ret), K(section_body_start), K(line_start));
+        }
+      } else {
+        ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT by must be word or sentence");
+      }
+      current_heading = heading;
+      section_body_start = next_line;
+    }
+    pos = next_line;
+  }
+  if (OB_SUCC(ret)) {
+    if (ai_split_document_equal_string(params.by_, "word")) {
+      if (OB_FAIL(build_ai_split_document_markdown_word_chunks(params,
+                                                               current_heading,
+                                                               section_body_start,
+                                                               len))) {
+        LOG_WARN("failed to build final AI_SPLIT_DOCUMENT markdown word section",
+                 K(ret), K(section_body_start), K(len));
+      }
+    } else if (ai_split_document_equal_string(params.by_, "sentence")) {
+      if (OB_FAIL(build_ai_split_document_markdown_sentence_chunks(params,
+                                                                   current_heading,
+                                                                   section_body_start,
+                                                                   len))) {
+        LOG_WARN("failed to build final AI_SPLIT_DOCUMENT markdown sentence section",
+                 K(ret), K(section_body_start), K(len));
+      }
+    } else {
+      ret = ai_split_document_invalid_argument("AI_SPLIT_DOCUMENT by must be word or sentence");
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::build_ai_split_document_markdown_word_chunks(const AISplitParams &params,
+                                                                    const ObString &heading,
+                                                                    const int64_t body_start,
+                                                                    const int64_t body_end)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<AISplitRange, 128> words;
+  const char *data = ai_split_content_.ptr();
+  int64_t pos = body_start;
+  if (body_start < 0 || body_end < body_start || body_end > ai_split_content_.length()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid AI_SPLIT_DOCUMENT markdown body range",
+             K(ret), K(body_start), K(body_end), K(ai_split_content_.length()));
+  }
+  while (OB_SUCC(ret) && pos < body_end) {
+    while (pos < body_end && is_ai_split_ascii_space(data[pos])) {
+      ++pos;
+    }
+    if (pos < body_end) {
+      const int64_t word_start = pos;
+      while (pos < body_end && !is_ai_split_ascii_space(data[pos])) {
+        ++pos;
+      }
+      const int64_t word_end = pos;
+      if (OB_FAIL(words.push_back(AISplitRange(word_start, word_end)))) {
+        LOG_WARN("failed to append AI_SPLIT_DOCUMENT markdown word range", K(ret));
+      }
+    }
+  }
+  if (OB_SUCC(ret)) {
+    const int64_t step = params.max_ - params.overlap_;
+    for (int64_t word_idx = 0; OB_SUCC(ret) && word_idx < words.count(); word_idx += step) {
+      const int64_t last_word_idx = MIN(word_idx + params.max_, words.count()) - 1;
+      if (OB_FAIL(add_ai_split_document_markdown_chunk(heading,
+                                                       words.at(word_idx).start_,
+                                                       words.at(last_word_idx).end_))) {
+        LOG_WARN("failed to add AI_SPLIT_DOCUMENT markdown word chunk",
+                 K(ret), K(word_idx), K(last_word_idx));
+      }
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::build_ai_split_document_markdown_sentence_chunks(const AISplitParams &params,
+                                                                        const ObString &heading,
+                                                                        const int64_t body_start,
+                                                                        const int64_t body_end)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<AISplitRange, 64> sentences;
+  const char *data = ai_split_content_.ptr();
+  int64_t pos = body_start;
+  if (body_start < 0 || body_end < body_start || body_end > ai_split_content_.length()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid AI_SPLIT_DOCUMENT markdown body range",
+             K(ret), K(body_start), K(body_end), K(ai_split_content_.length()));
+  }
+  while (OB_SUCC(ret) && pos < body_end) {
+    while (pos < body_end && is_ai_split_ascii_space(data[pos])) {
+      ++pos;
+    }
+    if (pos < body_end) {
+      const int64_t sentence_start = pos;
+      int64_t sentence_end = body_end;
+      bool found_terminator = false;
+      while (pos < body_end && !found_terminator) {
+        const int64_t char_len = get_ai_split_utf8_char_len(data + pos, body_end - pos);
+        if (is_ai_split_sentence_terminator(data + pos, char_len)) {
+          pos += char_len;
+          sentence_end = pos;
+          found_terminator = true;
+        } else {
+          pos += char_len;
+        }
+      }
+      if (!found_terminator) {
+        sentence_end = pos;
+        while (sentence_end > sentence_start && is_ai_split_ascii_space(data[sentence_end - 1])) {
+          --sentence_end;
+        }
+      }
+      if (sentence_end > sentence_start
+          && OB_FAIL(sentences.push_back(AISplitRange(sentence_start, sentence_end)))) {
+        LOG_WARN("failed to append AI_SPLIT_DOCUMENT markdown sentence range", K(ret));
+      }
+    }
+  }
+  if (OB_SUCC(ret)) {
+    const int64_t step = params.max_ - params.overlap_;
+    for (int64_t sentence_idx = 0; OB_SUCC(ret) && sentence_idx < sentences.count(); sentence_idx += step) {
+      const int64_t last_sentence_idx = MIN(sentence_idx + params.max_, sentences.count()) - 1;
+      if (OB_FAIL(add_ai_split_document_markdown_chunk(heading,
+                                                       sentences.at(sentence_idx).start_,
+                                                       sentences.at(last_sentence_idx).end_))) {
+        LOG_WARN("failed to add AI_SPLIT_DOCUMENT markdown sentence chunk",
+                 K(ret), K(sentence_idx), K(last_sentence_idx));
+      }
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::add_ai_split_document_chunk(const int64_t start, const int64_t end)
+{
+  int ret = OB_SUCCESS;
+  ObString chunk_text;
+  if (OB_UNLIKELY(start < 0 || end < start || end > ai_split_content_.length())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid AI_SPLIT_DOCUMENT chunk range",
+             K(ret), K(start), K(end), K(ai_split_content_.length()));
+  } else {
+    chunk_text.assign_ptr(ai_split_content_.ptr() + start, end - start);
+    if (OB_FAIL(add_ai_split_document_chunk(start, end, chunk_text))) {
+      LOG_WARN("failed to add AI_SPLIT_DOCUMENT chunk", K(ret), K(start), K(end));
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::add_ai_split_document_chunk(const int64_t start,
+                                                   const int64_t end,
+                                                   const ObString &chunk_text)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(start < 0 || end < start || end > ai_split_content_.length())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid AI_SPLIT_DOCUMENT chunk range",
+             K(ret), K(start), K(end), K(ai_split_content_.length()));
+  } else {
+    AISplitChunk chunk;
+    chunk.chunk_id_ = ai_split_chunks_.count();
+    chunk.chunk_offset_ = start;
+    chunk.chunk_length_ = end - start;
+    chunk.chunk_text_ = chunk_text;
+    if (OB_FAIL(ai_split_chunks_.push_back(chunk))) {
+      LOG_WARN("failed to append AI_SPLIT_DOCUMENT chunk", K(ret));
+    }
+  }
+  return ret;
+}
+
+int ObFunctionTableOp::add_ai_split_document_markdown_chunk(const ObString &heading,
+                                                            const int64_t start,
+                                                            const int64_t end)
+{
+  int ret = OB_SUCCESS;
+  ObString chunk_text;
+  const int64_t body_len = end - start;
+  if (OB_UNLIKELY(start < 0 || end < start || end > ai_split_content_.length())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid AI_SPLIT_DOCUMENT markdown chunk range",
+             K(ret), K(start), K(end), K(ai_split_content_.length()));
+  } else if (0 == body_len) {
+    // no row for an empty body chunk
+  } else if (heading.empty()) {
+    chunk_text.assign_ptr(ai_split_content_.ptr() + start, body_len);
+    if (OB_FAIL(add_ai_split_document_chunk(start, end, chunk_text))) {
+      LOG_WARN("failed to add AI_SPLIT_DOCUMENT markdown chunk without heading", K(ret), K(start), K(end));
+    }
+  } else if (OB_UNLIKELY(heading.length() > AI_SPLIT_DOCUMENT_MAX_INPUT_LENGTH - body_len - 1)) {
+    ret = OB_SIZE_OVERFLOW;
+    LOG_WARN("AI_SPLIT_DOCUMENT markdown chunk is too large",
+             K(ret), K(heading.length()), K(body_len));
+  } else {
+    const int64_t chunk_text_len = heading.length() + 1 + body_len;
+    char *buf = static_cast<char *>(ai_split_alloc_.alloc(chunk_text_len));
+    if (OB_ISNULL(buf)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to allocate AI_SPLIT_DOCUMENT markdown chunk buffer",
+               K(ret), K(chunk_text_len));
+    } else {
+      MEMCPY(buf, heading.ptr(), heading.length());
+      buf[heading.length()] = '\n';
+      MEMCPY(buf + heading.length() + 1, ai_split_content_.ptr() + start, body_len);
+      chunk_text.assign_ptr(buf, chunk_text_len);
+      if (OB_FAIL(add_ai_split_document_chunk(start, end, chunk_text))) {
+        LOG_WARN("failed to add AI_SPLIT_DOCUMENT markdown chunk with heading", K(ret), K(start), K(end));
+      }
+    }
+  }
+  return ret;
+}
+
+bool ObFunctionTableOp::is_ai_split_ascii_space(const char c)
+{
+  return ' ' == c || '\t' == c || '\n' == c || '\r' == c || '\f' == c || '\v' == c;
+}
+
+bool ObFunctionTableOp::is_ai_split_markdown_heading(const char *line,
+                                                     const int64_t len,
+                                                     ObString &heading)
+{
+  bool is_heading = false;
+  int64_t sharp_count = 0;
+  heading.reset();
+  if (OB_ISNULL(line) || len <= 0) {
+    is_heading = false;
+  } else {
+    while (sharp_count < len && sharp_count < 6 && '#' == line[sharp_count]) {
+      ++sharp_count;
+    }
+    if (sharp_count > 0 && sharp_count < len && ' ' == line[sharp_count]) {
+      heading.assign_ptr(line, len);
+      is_heading = true;
+    }
+  }
+  return is_heading;
+}
+
+bool ObFunctionTableOp::is_ai_split_sentence_terminator(const char *ptr, const int64_t len)
+{
+  bool is_terminator = false;
+  if (OB_ISNULL(ptr) || len <= 0) {
+    is_terminator = false;
+  } else if (1 == len) {
+    is_terminator = '.' == ptr[0] || '!' == ptr[0] || '?' == ptr[0];
+  } else if (3 == len) {
+    const unsigned char *u8 = reinterpret_cast<const unsigned char *>(ptr);
+    is_terminator =
+        (0xE3 == u8[0] && 0x80 == u8[1] && 0x82 == u8[2])
+        || (0xEF == u8[0] && 0xBC == u8[1] && 0x81 == u8[2])
+        || (0xEF == u8[0] && 0xBC == u8[1] && 0x9F == u8[2]);
+  }
+  return is_terminator;
+}
+
+int64_t ObFunctionTableOp::get_ai_split_utf8_char_len(const char *ptr, const int64_t remain)
+{
+  int64_t char_len = 1;
+  if (OB_ISNULL(ptr) || remain <= 0) {
+    char_len = 0;
+  } else {
+    const unsigned char first = static_cast<unsigned char>(ptr[0]);
+    if (first < 0x80) {
+      char_len = 1;
+    } else if ((first & 0xE0) == 0xC0 && remain >= 2) {
+      char_len = 2;
+    } else if ((first & 0xF0) == 0xE0 && remain >= 3) {
+      char_len = 3;
+    } else if ((first & 0xF8) == 0xF0 && remain >= 4) {
+      char_len = 4;
+    } else {
+      char_len = 1;
+    }
+  }
+  return char_len;
+}
+
+int ObFunctionTableOp::inner_get_next_row_ai_split_document()
+{
+  int ret = OB_SUCCESS;
+  ObPhysicalPlanCtx *plan_ctx = nullptr;
+  clear_evaluated_flag();
+  if (OB_ISNULL(plan_ctx = ctx_.get_physical_plan_ctx())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("failed to get plan ctx", K(ret), K(plan_ctx));
+  } else if (OB_FAIL(ctx_.check_status())) {
+    LOG_WARN("failed to check status", K(ret));
+  } else if (OB_UNLIKELY(MY_SPEC.column_exprs_.count() < AI_SPLIT_DOCUMENT_COLUMN_COUNT)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("AI_SPLIT_DOCUMENT output column exprs are invalid",
+             K(ret), K(MY_SPEC.column_exprs_.count()));
+  } else if (!ai_split_inited_ && OB_FAIL(init_ai_split_document())) {
+    LOG_WARN("failed to init AI_SPLIT_DOCUMENT", K(ret));
+  } else if (ai_split_next_idx_ >= ai_split_chunks_.count()) {
+    ret = OB_ITER_END;
+  } else {
+    const AISplitChunk &chunk = ai_split_chunks_.at(ai_split_next_idx_);
+    MY_SPEC.column_exprs_.at(0)->locate_datum_for_write(eval_ctx_).set_int(chunk.chunk_id_);
+    MY_SPEC.column_exprs_.at(1)->locate_datum_for_write(eval_ctx_).set_int(chunk.chunk_offset_);
+    MY_SPEC.column_exprs_.at(2)->locate_datum_for_write(eval_ctx_).set_int(chunk.chunk_length_);
+    MY_SPEC.column_exprs_.at(3)->locate_datum_for_write(eval_ctx_).set_string(chunk.chunk_text_);
+    for (int64_t i = 0; i < AI_SPLIT_DOCUMENT_COLUMN_COUNT; ++i) {
+      MY_SPEC.column_exprs_.at(i)->set_evaluated_projected(eval_ctx_);
+    }
+    ++ai_split_next_idx_;
   }
   return ret;
 }

--- a/src/sql/engine/basic/ob_function_table_op.h
+++ b/src/sql/engine/basic/ob_function_table_op.h
@@ -70,6 +70,7 @@ private:
   {
     AISplitRange() : start_(0), end_(0) {}
     AISplitRange(int64_t start, int64_t end) : start_(start), end_(end) {}
+    TO_STRING_KV(K_(start), K_(end));
     int64_t start_;
     int64_t end_;
   };
@@ -77,6 +78,7 @@ private:
   struct AISplitChunk
   {
     AISplitChunk() : chunk_id_(0), chunk_offset_(0), chunk_length_(0), chunk_text_() {}
+    TO_STRING_KV(K_(chunk_id), K_(chunk_offset), K_(chunk_length), K_(chunk_text));
     int64_t chunk_id_;
     int64_t chunk_offset_;
     int64_t chunk_length_;

--- a/src/sql/engine/basic/ob_function_table_op.h
+++ b/src/sql/engine/basic/ob_function_table_op.h
@@ -20,6 +20,7 @@
 #include "sql/engine/ob_operator.h"
 #include "sql/engine/basic/ob_chunk_datum_store.h"
 #include "lib/charset/ob_charset.h"
+#include "lib/container/ob_se_array.h"
 
 namespace oceanbase
 {
@@ -48,7 +49,13 @@ public:
     already_calc_(false),
     row_count_(0),
     col_count_(0),
-    value_table_(NULL) 
+    value_table_(NULL),
+    next_row_func_(nullptr),
+    ai_split_alloc_("AISplitDocument"),
+    ai_split_chunks_(),
+    ai_split_content_(),
+    ai_split_next_idx_(0),
+    ai_split_inited_(false)
   {}
 
   virtual int inner_open() override;
@@ -59,9 +66,72 @@ public:
   virtual int inner_close() override;
   virtual void destroy() override;
 private:
+  struct AISplitRange
+  {
+    AISplitRange() : start_(0), end_(0) {}
+    AISplitRange(int64_t start, int64_t end) : start_(start), end_(end) {}
+    int64_t start_;
+    int64_t end_;
+  };
+
+  struct AISplitChunk
+  {
+    AISplitChunk() : chunk_id_(0), chunk_offset_(0), chunk_length_(0), chunk_text_() {}
+    int64_t chunk_id_;
+    int64_t chunk_offset_;
+    int64_t chunk_length_;
+    common::ObString chunk_text_;
+  };
+
+  struct AISplitParams
+  {
+    AISplitParams()
+      : type_(common::ObString::make_string("markdown")),
+        by_(common::ObString::make_string("word")),
+        max_(256),
+        overlap_(0)
+    {}
+    common::ObString type_;
+    common::ObString by_;
+    int64_t max_;
+    int64_t overlap_;
+  };
+
   int inner_get_next_row_udf();
   int inner_get_next_row_sys_func();
+  int inner_get_next_row_ai_split_document();
   int get_current_result(common::ObObj &result);
+  bool is_ai_split_document() const;
+  void reset_ai_split_document_state();
+  int init_ai_split_document();
+  int parse_ai_split_document_params(common::ObIAllocator &allocator,
+                                     const ObExpr &expr,
+                                     AISplitParams &params);
+  int build_ai_split_document_chunks(const AISplitParams &params);
+  int build_ai_split_document_word_chunks(const AISplitParams &params);
+  int build_ai_split_document_sentence_chunks(const AISplitParams &params);
+  int build_ai_split_document_markdown_chunks(const AISplitParams &params);
+  int build_ai_split_document_markdown_word_chunks(const AISplitParams &params,
+                                                   const common::ObString &heading,
+                                                   const int64_t body_start,
+                                                   const int64_t body_end);
+  int build_ai_split_document_markdown_sentence_chunks(const AISplitParams &params,
+                                                       const common::ObString &heading,
+                                                       const int64_t body_start,
+                                                       const int64_t body_end);
+  int add_ai_split_document_chunk(const int64_t start, const int64_t end);
+  int add_ai_split_document_chunk(const int64_t start,
+                                  const int64_t end,
+                                  const common::ObString &chunk_text);
+  int add_ai_split_document_markdown_chunk(const common::ObString &heading,
+                                           const int64_t start,
+                                           const int64_t end);
+  static bool is_ai_split_ascii_space(const char c);
+  static bool is_ai_split_markdown_heading(const char *line,
+                                           const int64_t len,
+                                           common::ObString &heading);
+  static bool is_ai_split_sentence_terminator(const char *ptr, const int64_t len);
+  static int64_t get_ai_split_utf8_char_len(const char *ptr, const int64_t remain);
   int64_t node_idx_;
   bool already_calc_;
   int64_t row_count_;
@@ -69,6 +139,11 @@ private:
   common::ObObj value_;
   pl::ObPLCollection *value_table_;
   int (ObFunctionTableOp::*next_row_func_)();
+  common::ObArenaAllocator ai_split_alloc_;
+  common::ObSEArray<AISplitChunk, 16> ai_split_chunks_;
+  common::ObString ai_split_content_;
+  int64_t ai_split_next_idx_;
+  bool ai_split_inited_;
 };
 
 } // end namespace sql

--- a/src/sql/engine/expr/ob_expr_ai/ob_expr_ai_split_document.cpp
+++ b/src/sql/engine/expr/ob_expr_ai/ob_expr_ai_split_document.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+
+#include "sql/engine/expr/ob_expr_ai/ob_expr_ai_split_document.h"
+
+using namespace oceanbase::common;
+using namespace oceanbase::sql;
+
+namespace oceanbase
+{
+namespace sql
+{
+
+ObExprAISplitDocument::ObExprAISplitDocument(ObIAllocator &alloc)
+    : ObFuncExprOperator(alloc,
+                         T_FUN_SYS_AI_SPLIT_DOCUMENT,
+                         N_AI_SPLIT_DOCUMENT,
+                         ONE_OR_TWO,
+                         NOT_VALID_FOR_GENERATED_COL,
+                         NOT_ROW_DIMENSION)
+{
+}
+
+ObExprAISplitDocument::~ObExprAISplitDocument()
+{
+}
+
+int ObExprAISplitDocument::calc_result_typeN(ObExprResType &type,
+                                             ObExprResType *types_array,
+                                             int64_t param_num,
+                                             ObExprTypeCtx &type_ctx) const
+{
+  int ret = OB_SUCCESS;
+  UNUSED(type_ctx);
+  if (OB_UNLIKELY(param_num < 1 || param_num > 2)) {
+    ObString func_name(get_name());
+    ret = OB_ERR_PARAM_SIZE;
+    LOG_WARN("AI_SPLIT_DOCUMENT expects one or two arguments", K(ret), K(param_num));
+    LOG_USER_ERROR(OB_ERR_PARAM_SIZE, func_name.length(), func_name.ptr());
+  } else {
+    type.set_type(ObLongTextType);
+    type.set_accuracy(ObAccuracy::DDL_DEFAULT_ACCURACY[ObLongTextType]);
+    type.set_collation_type(CS_TYPE_UTF8MB4_BIN);
+    type.set_collation_level(CS_LEVEL_IMPLICIT);
+
+    types_array[0].set_calc_type(ObLongTextType);
+    types_array[0].set_calc_collation_type(CS_TYPE_UTF8MB4_BIN);
+    if (2 == param_num) {
+      types_array[1].set_calc_type(ObLongTextType);
+      types_array[1].set_calc_collation_type(CS_TYPE_UTF8MB4_BIN);
+    }
+  }
+  return ret;
+}
+
+int ObExprAISplitDocument::cg_expr(ObExprCGCtx &expr_cg_ctx,
+                                   const ObRawExpr &raw_expr,
+                                   ObExpr &rt_expr) const
+{
+  int ret = OB_SUCCESS;
+  UNUSED(expr_cg_ctx);
+  UNUSED(raw_expr);
+  if (OB_UNLIKELY(rt_expr.arg_cnt_ < 1 || rt_expr.arg_cnt_ > 2)) {
+    ret = OB_ERR_PARAM_SIZE;
+    LOG_WARN("AI_SPLIT_DOCUMENT expects one or two arguments", K(ret), K(rt_expr.arg_cnt_));
+  } else {
+    rt_expr.eval_func_ = ObExprAISplitDocument::eval_ai_split_document;
+  }
+  return ret;
+}
+
+int ObExprAISplitDocument::eval_ai_split_document(const ObExpr &expr,
+                                                  ObEvalCtx &ctx,
+                                                  ObDatum &res)
+{
+  int ret = OB_NOT_SUPPORTED;
+  UNUSED(expr);
+  UNUSED(ctx);
+  UNUSED(res);
+  LOG_WARN("AI_SPLIT_DOCUMENT scalar evaluation is not supported", K(ret));
+  LOG_USER_ERROR(OB_NOT_SUPPORTED, "AI_SPLIT_DOCUMENT scalar evaluation");
+  return ret;
+}
+
+} // namespace sql
+} // namespace oceanbase

--- a/src/sql/engine/expr/ob_expr_ai/ob_expr_ai_split_document.h
+++ b/src/sql/engine/expr/ob_expr_ai/ob_expr_ai_split_document.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_AI_SPLIT_DOCUMENT_H_
+#define OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_AI_SPLIT_DOCUMENT_H_
+
+#include "sql/engine/expr/ob_expr_operator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+
+class ObExprAISplitDocument : public ObFuncExprOperator
+{
+public:
+  explicit ObExprAISplitDocument(common::ObIAllocator &alloc);
+  virtual ~ObExprAISplitDocument();
+  virtual int calc_result_typeN(ObExprResType &type,
+                                ObExprResType *types_array,
+                                int64_t param_num,
+                                common::ObExprTypeCtx &type_ctx) const override;
+  virtual int cg_expr(ObExprCGCtx &expr_cg_ctx,
+                      const ObRawExpr &raw_expr,
+                      ObExpr &rt_expr) const override;
+  static int eval_ai_split_document(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &res);
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObExprAISplitDocument);
+};
+
+} // namespace sql
+} // namespace oceanbase
+
+#endif // OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_AI_SPLIT_DOCUMENT_H_

--- a/src/sql/engine/expr/ob_expr_eval_functions.cpp
+++ b/src/sql/engine/expr/ob_expr_eval_functions.cpp
@@ -386,8 +386,10 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_embed.h"
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_rerank.h"
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
+#include "sql/engine/expr/ob_expr_ai/ob_expr_ai_split_document.h"
 #include "ob_expr_vector_similarity.h"
 #include "ob_expr_check_location_access.h"
+#include "ob_expr_load_file.h"
 
 namespace oceanbase
 {
@@ -1341,6 +1343,8 @@ static ObExpr::EvalFunc g_expr_eval_functions[] = {
   ObExprVectorCosineSimilarity::calc_cosine_similarity,                /* 872 */
   ObExprVectorIPSimilarity::calc_ip_similarity,                        /* 873 */
   ObExprVectorSimilarity::calc_similarity,                             /* 874 */
+  ObExprLoadFile::eval_load_file,                                      /* 875 */
+  ObExprAISplitDocument::eval_ai_split_document,                       /* 876 */
 };
 
 static ObExpr::EvalBatchFunc g_expr_eval_batch_functions[] = {

--- a/src/sql/engine/expr/ob_expr_load_file.cpp
+++ b/src/sql/engine/expr/ob_expr_load_file.cpp
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define USING_LOG_PREFIX SQL_ENG
+
+#include "sql/engine/expr/ob_expr_load_file.h"
+#include "lib/string/ob_sql_string.h"
+#include "share/io/ob_backup_io_adapter.h"
+#include "share/io/ob_backup_storage_info.h"
+#include "share/schema/ob_location_schema_struct.h"
+#include "share/schema/ob_schema_getter_guard.h"
+#include "sql/engine/ob_exec_context.h"
+#include "sql/engine/expr/ob_expr_lob_utils.h"
+#include "sql/session/ob_sql_session_info.h"
+
+using namespace oceanbase::common;
+using namespace oceanbase::sql;
+
+namespace oceanbase
+{
+namespace sql
+{
+namespace
+{
+static const char *LOAD_FILE_SAFE_PATH_ERROR =
+    "LOAD_FILE file_name should be a non-empty safe relative path";
+
+bool is_ascii_alpha(const char c)
+{
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+bool is_uri_scheme_char(const char c)
+{
+  return is_ascii_alpha(c) || (c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.';
+}
+
+int hex_to_int(const char c)
+{
+  return (c >= '0' && c <= '9') ? c - '0'
+      : (c >= 'a' && c <= 'f') ? c - 'a' + 10
+      : (c >= 'A' && c <= 'F') ? c - 'A' + 10
+      : -1;
+}
+
+bool has_uri_scheme(const ObString &path)
+{
+  bool has_scheme = false;
+  const char *ptr = path.ptr();
+  const int64_t len = path.length();
+  if (len > 1 && OB_NOT_NULL(ptr) && is_ascii_alpha(ptr[0])) {
+    bool scheme_candidate = true;
+    for (int64_t i = 1; !has_scheme && scheme_candidate && i < len; ++i) {
+      if (':' == ptr[i]) {
+        has_scheme = true;
+      } else if ('/' == ptr[i]) {
+        scheme_candidate = false;
+      } else if (!is_uri_scheme_char(ptr[i])) {
+        scheme_candidate = false;
+      }
+    }
+  }
+  return has_scheme;
+}
+
+int set_load_file_path_error(const ObString &path, const char *path_state, const char *reason)
+{
+  const int ret = OB_INVALID_ARGUMENT;
+  LOG_WARN("invalid LOAD_FILE file_name", K(ret), K(path), K(path_state), K(reason));
+  LOG_USER_ERROR(OB_INVALID_ARGUMENT, LOAD_FILE_SAFE_PATH_ERROR);
+  return ret;
+}
+
+int check_load_file_path_segments(const ObString &path, const char *path_state)
+{
+  int ret = OB_SUCCESS;
+  const char *ptr = path.ptr();
+  const int64_t len = path.length();
+  int64_t segment_start = 0;
+  for (int64_t i = 0; OB_SUCC(ret) && i <= len; ++i) {
+    if (i == len || '/' == ptr[i]) {
+      const int64_t segment_len = i - segment_start;
+      if (1 == segment_len && '.' == ptr[segment_start]) {
+        ret = set_load_file_path_error(path, path_state, "dot path segment");
+      } else if (2 == segment_len && '.' == ptr[segment_start] && '.' == ptr[segment_start + 1]) {
+        ret = set_load_file_path_error(path, path_state, "dot-dot path segment");
+      } else {
+        segment_start = i + 1;
+      }
+    }
+  }
+  return ret;
+}
+
+int check_load_file_relative_path_once(const ObString &path, const char *path_state)
+{
+  int ret = OB_SUCCESS;
+  const char *ptr = path.ptr();
+  const int64_t len = path.length();
+  if (OB_ISNULL(ptr) || len <= 0) {
+    ret = set_load_file_path_error(path, path_state, "empty path");
+  } else if ('/' == ptr[0]) {
+    ret = set_load_file_path_error(path, path_state, "absolute unix path");
+  } else if (is_ascii_alpha(ptr[0]) && len >= 2 && ':' == ptr[1]) {
+    ret = set_load_file_path_error(path, path_state, "windows drive path");
+  } else if (has_uri_scheme(path)) {
+    ret = set_load_file_path_error(path, path_state, "uri scheme");
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < len; ++i) {
+      if ('\0' == ptr[i]) {
+        ret = set_load_file_path_error(path, path_state, "nul byte");
+      } else if ('\\' == ptr[i]) {
+        ret = set_load_file_path_error(path, path_state, "backslash");
+      }
+    }
+    if (OB_SUCC(ret) && OB_FAIL(check_load_file_path_segments(path, path_state))) {
+      LOG_WARN("failed to check LOAD_FILE path segments", K(ret), K(path), K(path_state));
+    }
+  }
+  return ret;
+}
+
+int percent_decode_for_validation(const ObString &path,
+                                  ObIAllocator &allocator,
+                                  ObString &decoded_path,
+                                  bool &has_decoded)
+{
+  int ret = OB_SUCCESS;
+  const char *ptr = path.ptr();
+  const int64_t len = path.length();
+  char *buf = NULL;
+  has_decoded = false;
+  decoded_path.reset();
+  for (int64_t i = 0; !has_decoded && i + 2 < len; ++i) {
+    if ('%' == ptr[i] && hex_to_int(ptr[i + 1]) >= 0 && hex_to_int(ptr[i + 2]) >= 0) {
+      has_decoded = true;
+    }
+  }
+  if (!has_decoded) {
+    decoded_path = path;
+  } else if (OB_ISNULL(buf = static_cast<char *>(allocator.alloc(len)))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("failed to allocate LOAD_FILE decoded path buffer", K(ret), K(len));
+  } else {
+    int64_t pos = 0;
+    for (int64_t i = 0; i < len; ++i) {
+      const int high = (i + 2 < len && '%' == ptr[i]) ? hex_to_int(ptr[i + 1]) : -1;
+      const int low = high >= 0 ? hex_to_int(ptr[i + 2]) : -1;
+      if (high >= 0 && low >= 0) {
+        buf[pos++] = static_cast<char>((high << 4) + low);
+        i += 2;
+      } else {
+        buf[pos++] = ptr[i];
+      }
+    }
+    decoded_path.assign_ptr(buf, static_cast<int32_t>(pos));
+  }
+  return ret;
+}
+
+int check_load_file_relative_path(const ObString &path, ObIAllocator &allocator)
+{
+  int ret = OB_SUCCESS;
+  ObString decoded_path;
+  bool has_decoded = false;
+  if (OB_FAIL(check_load_file_relative_path_once(path, "raw"))) {
+    LOG_WARN("LOAD_FILE raw path is not safe", K(ret), K(path));
+  } else if (OB_FAIL(percent_decode_for_validation(path, allocator, decoded_path, has_decoded))) {
+    LOG_WARN("failed to percent-decode LOAD_FILE path for validation", K(ret), K(path));
+  } else if (has_decoded && OB_FAIL(check_load_file_relative_path_once(decoded_path, "percent decoded"))) {
+    LOG_WARN("LOAD_FILE percent decoded path is not safe", K(ret), K(path), K(decoded_path));
+  }
+  return ret;
+}
+
+} // namespace
+
+ObExprLoadFile::ObExprLoadFile(ObIAllocator &alloc)
+    : ObFuncExprOperator(alloc, T_FUN_SYS_LOAD_FILE, N_LOAD_FILE, 2,
+                         NOT_VALID_FOR_GENERATED_COL, NOT_ROW_DIMENSION)
+{
+}
+
+ObExprLoadFile::~ObExprLoadFile()
+{
+}
+
+int ObExprLoadFile::calc_result_type2(ObExprResType &type,
+                                      ObExprResType &type1,
+                                      ObExprResType &type2,
+                                      ObExprTypeCtx &type_ctx) const
+{
+  int ret = OB_SUCCESS;
+  UNUSED(type_ctx);
+
+  type.set_type(ObLongTextType);
+  type.set_accuracy(ObAccuracy::DDL_DEFAULT_ACCURACY[ObLongTextType]);
+  type.set_length(OB_MAX_LONGTEXT_LENGTH);
+  type.set_collation_level(CS_LEVEL_COERCIBLE);
+  type.set_collation_type(CS_TYPE_BINARY);
+
+  type1.set_calc_type(ObVarcharType);
+  type1.set_calc_collation_type(ObCharset::get_system_collation());
+  type2.set_calc_type(ObVarcharType);
+  type2.set_calc_collation_type(ObCharset::get_system_collation());
+  return ret;
+}
+
+int ObExprLoadFile::cg_expr(ObExprCGCtx &op_cg_ctx,
+                            const ObRawExpr &raw_expr,
+                            ObExpr &rt_expr) const
+{
+  int ret = OB_SUCCESS;
+  UNUSED(op_cg_ctx);
+  UNUSED(raw_expr);
+  if (OB_UNLIKELY(2 != rt_expr.arg_cnt_)) {
+    ret = OB_ERR_PARAM_SIZE;
+    LOG_WARN("LOAD_FILE expects two arguments", K(ret), K(rt_expr.arg_cnt_));
+  } else {
+    rt_expr.eval_func_ = ObExprLoadFile::eval_load_file;
+  }
+  return ret;
+}
+
+int ObExprLoadFile::eval_load_file(const ObExpr &expr,
+                                   ObEvalCtx &ctx,
+                                   ObDatum &expr_datum)
+{
+  int ret = OB_SUCCESS;
+  ObDatum *location_datum = NULL;
+  ObDatum *file_datum = NULL;
+  const ObSQLSessionInfo *session_info = NULL;
+  share::schema::ObSessionPrivInfo session_priv;
+  share::schema::ObSchemaGetterGuard schema_guard;
+  const share::schema::ObLocationSchema *location_schema = NULL;
+  ObString location_name;
+  ObString file_name;
+
+  if (OB_UNLIKELY(2 != expr.arg_cnt_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("LOAD_FILE expects two arguments", K(ret), K(expr.arg_cnt_));
+  } else if (OB_ISNULL(session_info = ctx.exec_ctx_.get_my_session()) || OB_ISNULL(GCTX.schema_service_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("get unexpected null", K(ret), KP(session_info), KP(GCTX.schema_service_));
+  } else if (OB_FAIL(expr.eval_param_value(ctx, location_datum, file_datum))) {
+    LOG_WARN("evaluate LOAD_FILE parameters failed", K(ret));
+  } else if (location_datum->is_null() || file_datum->is_null()) {
+    expr_datum.set_null();
+  } else if (FALSE_IT(location_name = location_datum->get_string())) {
+  } else if (FALSE_IT(file_name = file_datum->get_string())) {
+  } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+    LOG_WARN("failed to get tenant schema guard", K(ret));
+  } else if (OB_FAIL(session_info->get_session_priv_info(session_priv))) {
+    LOG_WARN("failed to get session priv info", K(ret));
+  } else if (OB_FAIL(schema_guard.get_location_schema_by_name(location_name, location_schema))) {
+    LOG_WARN("failed to get location schema by name", K(ret), K(location_name));
+  } else if (OB_ISNULL(location_schema)) {
+    ret = OB_LOCATION_OBJ_NOT_EXIST;
+    LOG_WARN("location object does not exist", K(ret), K(location_name));
+    LOG_USER_ERROR(OB_LOCATION_OBJ_NOT_EXIST,
+                   static_cast<int>(location_name.length()),
+                   location_name.ptr());
+  } else if (OB_FAIL(schema_guard.check_location_access(session_priv,
+                                                        session_info->get_enable_role_array(),
+                                                        location_name,
+                                                        false))) {
+    LOG_WARN("failed to check location read access", K(ret), K(location_name));
+  } else {
+    const ObString &location_url = location_schema->get_location_url_str();
+    const ObString &location_access_info = location_schema->get_location_access_info_str();
+    const int64_t location_url_len = location_url.length();
+    const int64_t location_access_info_len = location_access_info.length();
+    share::ObBackupStorageInfo storage_info;
+    ObSqlString file_uri_buf;
+    ObEvalCtx::TempAllocGuard tmp_alloc_guard(ctx);
+    int64_t file_length = -1;
+    int64_t read_size = 0;
+    const int64_t lob_max_load_file_length =
+        OB_MAX_LONGTEXT_LENGTH - ObTextStringResult::MAX_TMP_LOB_HEADER_LEN;
+    const int64_t expr_max_length = expr.max_length_ > 0
+        ? static_cast<int64_t>(expr.max_length_)
+        : lob_max_load_file_length;
+    const int64_t max_load_file_length = MIN(lob_max_load_file_length, expr_max_length);
+    const bool need_path_sep =
+        location_url.length() > 0 && file_name.length() > 0
+        && '/' != location_url.ptr()[location_url.length() - 1]
+        && '/' != file_name.ptr()[0];
+
+    if (OB_FAIL(check_load_file_relative_path(file_name, tmp_alloc_guard.get_allocator()))) {
+      LOG_WARN("failed to check LOAD_FILE safe relative path", K(ret), K(location_name), K(file_name));
+    } else if (OB_FAIL(storage_info.set(location_schema->get_location_url(),
+                                        location_schema->get_location_access_info()))) {
+      LOG_WARN("failed to set LOAD_FILE storage info",
+               K(ret), K(location_name), K(location_url_len), K(location_access_info_len));
+    } else if (OB_FAIL(file_uri_buf.append(location_url))) {
+      LOG_WARN("failed to append LOAD_FILE location url", K(ret), K(location_name), K(location_url_len));
+    } else if (need_path_sep && OB_FAIL(file_uri_buf.append("/"))) {
+      LOG_WARN("failed to append LOAD_FILE path separator", K(ret), K(location_name), K(location_url_len), K(file_name));
+    } else if (OB_FAIL(file_uri_buf.append(file_name))) {
+      LOG_WARN("failed to append LOAD_FILE file name", K(ret), K(location_name), K(file_name));
+    } else {
+      const ObString file_uri = file_uri_buf.string();
+      if (OB_FAIL(ObBackupIoAdapter::get_file_length(file_uri, &storage_info, file_length))) {
+        LOG_WARN("failed to get LOAD_FILE file length", K(ret), K(location_name), K(file_name));
+      } else if (OB_UNLIKELY(file_length < 0)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("LOAD_FILE file length is invalid", K(ret), K(location_name), K(file_name), K(file_length));
+      } else if (OB_UNLIKELY(file_length > max_load_file_length)) {
+        ret = OB_SIZE_OVERFLOW;
+        LOG_WARN("LOAD_FILE file is too large",
+                 K(ret), K(location_name), K(file_name), K(file_length), K(max_load_file_length));
+      } else if (0 == file_length) {
+        expr_datum.set_string(NULL, 0);
+      } else {
+        char *read_buf = static_cast<char *>(tmp_alloc_guard.get_allocator().alloc(file_length));
+        if (OB_ISNULL(read_buf)) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+          LOG_WARN("failed to allocate LOAD_FILE read buffer", K(ret), K(location_name), K(file_name), K(file_length));
+        } else if (OB_FAIL(ObBackupIoAdapter::read_single_file(file_uri,
+                                                               &storage_info,
+                                                               read_buf,
+                                                               file_length,
+                                                               read_size,
+                                                               ObStorageIdMod::get_default_id_mod()))) {
+          LOG_WARN("failed to read LOAD_FILE file",
+                   K(ret), K(location_name), K(file_name), K(file_length), K(read_size));
+        } else if (OB_UNLIKELY(read_size != file_length)) {
+          ret = OB_BUF_NOT_ENOUGH;
+          LOG_WARN("LOAD_FILE read size does not match file length",
+                   K(ret), K(location_name), K(file_name), K(file_length), K(read_size));
+        } else {
+          ObTextStringDatumResult result(expr.datum_meta_.type_, &expr, &ctx, &expr_datum);
+          if (OB_FAIL(result.init(file_length))) {
+            LOG_WARN("failed to init LOAD_FILE result", K(ret), K(location_name), K(file_name), K(file_length));
+          } else if (OB_FAIL(result.append(read_buf, read_size))) {
+            LOG_WARN("failed to append LOAD_FILE result", K(ret), K(location_name), K(file_name), K(read_size));
+          } else {
+            result.set_result();
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+}
+}

--- a/src/sql/engine/expr/ob_expr_load_file.h
+++ b/src/sql/engine/expr/ob_expr_load_file.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_
+#define OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_
+
+#include "sql/engine/expr/ob_expr_operator.h"
+
+namespace oceanbase
+{
+namespace sql
+{
+class ObExprLoadFile : public ObFuncExprOperator
+{
+public:
+  explicit ObExprLoadFile(common::ObIAllocator &alloc);
+  virtual ~ObExprLoadFile();
+  virtual int calc_result_type2(ObExprResType &type,
+                                ObExprResType &type1,
+                                ObExprResType &type2,
+                                common::ObExprTypeCtx &type_ctx) const override;
+  virtual int cg_expr(ObExprCGCtx &op_cg_ctx,
+                      const ObRawExpr &raw_expr,
+                      ObExpr &rt_expr) const override;
+  static int eval_load_file(const ObExpr &expr, ObEvalCtx &ctx, ObDatum &expr_datum);
+
+private:
+  DISALLOW_COPY_AND_ASSIGN(ObExprLoadFile);
+};
+}
+}
+
+#endif // OCEANBASE_SQL_ENGINE_EXPR_OB_EXPR_LOAD_FILE_

--- a/src/sql/engine/expr/ob_expr_operator_factory.cpp
+++ b/src/sql/engine/expr/ob_expr_operator_factory.cpp
@@ -440,8 +440,10 @@
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_embed.h"
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_rerank.h"
 #include "sql/engine/expr/ob_expr_ai/ob_expr_ai_prompt.h"
+#include "sql/engine/expr/ob_expr_ai/ob_expr_ai_split_document.h"
 #include "sql/engine/expr/ob_expr_vector_similarity.h"
 #include "sql/engine/expr/ob_expr_check_location_access.h"
+#include "sql/engine/expr/ob_expr_load_file.h"
 
 
 #include "sql/engine/expr/ob_expr_lock_func.h"
@@ -1147,7 +1149,9 @@ void ObExprOperatorFactory::register_expr_operators()
     REG_OP(ObExprAIEmbed);
     REG_OP(ObExprAIRerank);
     REG_OP(ObExprAIPrompt);
+    REG_OP(ObExprAISplitDocument);
     REG_OP(ObExprCheckLocationAccess);
+    REG_OP(ObExprLoadFile);
   }();
 }
 
@@ -1332,4 +1336,3 @@ void ObExprOperatorFactory::get_function_alias_name(const ObString &origin_name,
 
 } //end sql
 } //end oceanbase
-

--- a/src/sql/parser/non_reserved_keywords_mysql_mode.c
+++ b/src/sql/parser/non_reserved_keywords_mysql_mode.c
@@ -31,6 +31,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"accessible", ACCESSIBLE},
   {"access_info", ACCESS_INFO},
   {"ai", AI},
+  {"ai_split_document", AI_SPLIT_DOCUMENT},
   {"account", ACCOUNT},
   {"action", ACTION},
   {"activate", ACTIVATE},

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -977,6 +977,8 @@ typedef enum ObItemType
   T_FUN_SYS_EMBEDDED_VEC = 1928,
   T_FUN_SYS_AI_PROMPT = 1929,
   T_FUN_SYS_VEC_VISIBLE = 1930, // vector index table 5
+  T_FUN_SYS_LOAD_FILE = 1931,
+  T_FUN_SYS_AI_SPLIT_DOCUMENT = 1932,
 
   ///< @note add new sys function type before this line
   T_FUN_SYS_END = 2000,

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -274,7 +274,7 @@ END_P SET_VAR DELIMITER
 //-----------------------------reserved keyword end-------------------------------------------------
 %token <non_reserved_keyword>
 //-----------------------------non_reserved keyword begin-------------------------------------------
-        ACCESS ACCESS_INFO ACCESSID ACCESSKEY ACCESSTYPE ACCOUNT ACTION ACTIVE ADDDATE AFTER AGAINST AGGREGATE AI ALGORITHM ALL_META ALL_USER ALWAYS ALLOW ANALYSE ANY
+        ACCESS ACCESS_INFO ACCESSID ACCESSKEY ACCESSTYPE ACCOUNT ACTION ACTIVE ADDDATE AFTER AGAINST AGGREGATE AI AI_SPLIT_DOCUMENT ALGORITHM ALL_META ALL_USER ALWAYS ALLOW ANALYSE ANY
         APPID APPROX_COUNT_DISTINCT APPROX_COUNT_DISTINCT_SYNOPSIS APPROX_COUNT_DISTINCT_SYNOPSIS_MERGE
         ARRAY ASCII ASIS AT ATTRIBUTE AUTHORS AUTO AUTOEXTEND_SIZE AUTO_INCREMENT AUTO_INCREMENT_MODE AUTO_INCREMENT_CACHE_SIZE
         AVG AVG_ROW_LENGTH ACTIVATE AVAILABILITY ARCHIVELOG ASYNCHRONOUS AUDIT ADMIN AUTO_REFRESH API_MODE APPROX APPROXIMATE ARRAY_AGG ARRAY_FILTER ARRAY_FIRST ARRAY_MAP ARRAY_SORTBY 
@@ -537,7 +537,7 @@ END_P SET_VAR DELIMITER
 %type <node> skip_index_type opt_skip_index_type_list
 %type <node> opt_rebuild_column_store
 %type <node> vec_index_params vec_index_param vec_index_param_value opt_with_vector_index_parameters
-%type <node> json_table_expr rb_iterate_expr unnest_expr mock_jt_on_error_on_empty jt_column_list json_table_column_def 
+%type <node> json_table_expr rb_iterate_expr unnest_expr ai_split_document_expr ai_split_document_function mock_jt_on_error_on_empty jt_column_list json_table_column_def
 %type <node> json_table_ordinality_column_def json_table_exists_column_def json_table_value_column_def json_table_nested_column_def
 %type <node> opt_value_on_empty_or_error_or_mismatch opt_on_mismatch
 %type <node> table_values_clause table_values_clause_with_order_by_and_limit values_row_list row_value
@@ -12991,6 +12991,10 @@ tbl_name
 {
   $$ = $1;
 }
+| ai_split_document_expr
+{
+  $$ = $1;
+}
 ;
 
 tbl_name:
@@ -21872,6 +21876,42 @@ literal
 }
 ;
 
+ai_split_document_expr:
+ai_split_document_function %prec LOWER_PARENS
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, $1, NULL);
+}
+| ai_split_document_function relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, $1, $2);
+}
+| ai_split_document_function AS relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_COLLECTION_EXPRESSION, 2, $1, $3);
+}
+;
+
+ai_split_document_function:
+AI_SPLIT_DOCUMENT '(' simple_expr ')'
+{
+  ParseNode *name_node = NULL;
+  ParseNode *params_node = NULL;
+  make_name_node(name_node, result->malloc_pool_, "ai_split_document");
+  name_node->sql_str_off_ = @1.first_column;
+  malloc_non_terminal_node(params_node, result->malloc_pool_, T_EXPR_LIST, 1, $3);
+  malloc_non_terminal_node($$, result->malloc_pool_, T_FUN_SYS, 2, name_node, params_node);
+}
+| AI_SPLIT_DOCUMENT '(' simple_expr ',' simple_expr ')'
+{
+  ParseNode *name_node = NULL;
+  ParseNode *params_node = NULL;
+  make_name_node(name_node, result->malloc_pool_, "ai_split_document");
+  name_node->sql_str_off_ = @1.first_column;
+  malloc_non_terminal_node(params_node, result->malloc_pool_, T_EXPR_LIST, 2, $3, $5);
+  malloc_non_terminal_node($$, result->malloc_pool_, T_FUN_SYS, 2, name_node, params_node);
+}
+;
+
 create_ccl_rule_stmt:
 CREATE CONCURRENT_LIMITING_RULE opt_if_not_exists relation_name 
 ON ccl_database_table_optition
@@ -22004,6 +22044,7 @@ ACCESS_INFO
 |       ADMIN
 |       AFTER
 |       AI
+|       AI_SPLIT_DOCUMENT
 |       AGAINST
 |       AGGREGATE
 |       ALGORITHM

--- a/src/sql/resolver/dml/ob_dml_resolver.cpp
+++ b/src/sql/resolver/dml/ob_dml_resolver.cpp
@@ -9071,6 +9071,50 @@ int ObDMLResolver::resolve_function_table_column_item(const TableItem &table_ite
   return ret;
 }
 
+int ObDMLResolver::resolve_ai_split_document_column_items(const TableItem &table_item,
+                                                          ObIArray<ColumnItem> &col_items)
+{
+  int ret = OB_SUCCESS;
+  ObDMLStmt *stmt = get_stmt();
+  ColumnItem *col_item = NULL;
+  common::ObObjMeta int_meta;
+  common::ObObjMeta text_meta;
+  const ObAccuracy int_accuracy = ObAccuracy::DDL_DEFAULT_ACCURACY[ObIntType];
+  const ObAccuracy text_accuracy = ObAccuracy::DDL_DEFAULT_ACCURACY[ObLongTextType];
+  const ObString column_names[] = {
+      ObString("CHUNK_ID"),
+      ObString("CHUNK_OFFSET"),
+      ObString("CHUNK_LENGTH"),
+      ObString("CHUNK_TEXT")
+  };
+  int_meta.set_int();
+  text_meta.set_clob();
+  text_meta.set_collation_type(CS_TYPE_UTF8MB4_BIN);
+
+  CK (OB_NOT_NULL(stmt));
+  CK (OB_LIKELY(table_item.is_function_table()));
+  for (int64_t i = 0; OB_SUCC(ret) && i < ARRAYSIZEOF(column_names); ++i) {
+    const bool is_text_column = (3 == i);
+    const common::ObObjMeta &meta = is_text_column ? text_meta : int_meta;
+    const ObAccuracy &accuracy = is_text_column ? text_accuracy : int_accuracy;
+    OX (col_item = NULL);
+    if (OB_FAIL(ret)) {
+    } else if (NULL != (col_item = stmt->get_column_item(table_item.table_id_, column_names[i]))) {
+      // exist, ignore resolve...
+    } else {
+      OZ (resolve_function_table_column_item(table_item,
+                                             meta,
+                                             accuracy,
+                                             column_names[i],
+                                             OB_APP_MIN_COLUMN_ID + i,
+                                             col_item));
+    }
+    CK (OB_NOT_NULL(col_item));
+    OZ (col_items.push_back(*col_item));
+  }
+  return ret;
+}
+
 int ObDMLResolver::resolve_function_table_column_item_udf(const TableItem &table_item,
                                                           ObIArray<ColumnItem> &col_items)
 {
@@ -9236,6 +9280,8 @@ int ObDMLResolver::resolve_function_table_column_item_sys_func(const TableItem &
   } else if (!ObResolverUtils::is_expr_can_be_used_in_table_function(*table_expr)) {
     ret = OB_NOT_SUPPORTED;
     LOG_USER_ERROR(OB_NOT_SUPPORTED, "access rows from a non-nested table item");
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == table_expr->get_expr_type()) {
+    OZ (resolve_ai_split_document_column_items(table_item, col_items));
   } else if (NULL != (col_item = stmt->get_column_item(table_item.table_id_, ObString("COLUMN_VALUE")))) {
     //exist, ignore resolve...
   } else {

--- a/src/sql/resolver/dml/ob_dml_resolver.h
+++ b/src/sql/resolver/dml/ob_dml_resolver.h
@@ -665,6 +665,8 @@ protected:
                                          const ObString &column_name,
                                          uint64_t column_id,
                                          ColumnItem *&col_item);
+  int resolve_ai_split_document_column_items(const TableItem &table_item,
+                                             ObIArray<ColumnItem> &col_items);
   int resolve_generated_table_column_item(const TableItem &table_item,
                                           const common::ObString &column_name,
                                           ColumnItem *&col_item,

--- a/src/sql/resolver/ob_resolver_utils.cpp
+++ b/src/sql/resolver/ob_resolver_utils.cpp
@@ -89,73 +89,83 @@ int ObResolverUtils::get_all_function_table_column_names(const TableItem &table_
   ObRawExpr *table_expr = NULL;
   ObPLPackageGuard *package_guard = nullptr;
   const ObUserDefinedType *user_type = NULL;
-  ObExecContext *exec_ctx = params.session_info_->get_cur_exec_ctx();
-  CK (OB_NOT_NULL(exec_ctx));
-  OZ (exec_ctx->get_package_guard(package_guard));
-  CK (OB_NOT_NULL(package_guard));
+  ObExecContext *exec_ctx = NULL;
   CK (OB_LIKELY(table_item.is_function_table()));
   CK (OB_NOT_NULL(table_expr = table_item.function_table_expr_));
-  CK (table_expr->get_udt_id() != OB_INVALID_ID);
+  if (OB_FAIL(ret)) {
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == table_expr->get_expr_type()) {
+    OZ (column_names.push_back(ObString("CHUNK_ID")));
+    OZ (column_names.push_back(ObString("CHUNK_OFFSET")));
+    OZ (column_names.push_back(ObString("CHUNK_LENGTH")));
+    OZ (column_names.push_back(ObString("CHUNK_TEXT")));
+  } else {
+    CK (OB_NOT_NULL(params.session_info_));
+    OX (exec_ctx = params.session_info_->get_cur_exec_ctx());
+    CK (OB_NOT_NULL(exec_ctx));
+    OZ (exec_ctx->get_package_guard(package_guard));
+    CK (OB_NOT_NULL(package_guard));
+    CK (table_expr->get_udt_id() != OB_INVALID_ID);
 
-  CK (OB_NOT_NULL(params.schema_checker_));
-  OZ (ObResolverUtils::get_user_type(
-    params.allocator_, params.session_info_, params.sql_proxy_,
-    params.schema_checker_->get_schema_guard(),
-    *package_guard,
-    table_expr->get_udt_id(), user_type));
-  CK (OB_NOT_NULL(user_type));
-  if (OB_SUCC(ret) && !user_type->is_collection_type()) {
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("function table get udf with return type not table type",
-             K(ret), K(user_type->is_collection_type()));
-    LOG_USER_ERROR(OB_NOT_SUPPORTED, "user define type is not collation type in function table");
-  }
-  const ObCollectionType *coll_type = NULL;
-  CK (OB_NOT_NULL(coll_type = static_cast<const ObCollectionType*>(user_type)));
-  if (OB_SUCC(ret)
-      && !coll_type->get_element_type().is_obj_type()
-      && !coll_type->get_element_type().is_record_type()
-      && !coll_type->get_element_type().is_collection_type()
-      && !(coll_type->get_element_type().is_opaque_type()
-            && coll_type->get_element_type().get_user_type_id() == T_OBJ_XML)) {
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("not suppoert type in table function", K(ret), KPC(coll_type));
-    ObString err;
-    err.write(coll_type->get_name().ptr(), coll_type->get_name().length());
-    err.write(" collation type in table function\0", sizeof(" collation type in table function\0"));
-    LOG_USER_ERROR(OB_NOT_SUPPORTED, err.ptr());
-  }
-  if (OB_SUCC(ret) && (coll_type->get_element_type().is_obj_type()
-                      || coll_type->get_element_type().is_opaque_type()
-                      || coll_type->get_element_type().is_collection_type())) {
-    OZ (column_names.push_back(ObString("COLUMN_VALUE")));
-  }
-  if (OB_SUCC(ret) && coll_type->get_element_type().is_record_type()) {
-    const ObRecordType *record_type = NULL;
-    const ObUserDefinedType *user_type = NULL;
     CK (OB_NOT_NULL(params.schema_checker_));
     OZ (ObResolverUtils::get_user_type(
       params.allocator_, params.session_info_, params.sql_proxy_,
       params.schema_checker_->get_schema_guard(),
       *package_guard,
-      coll_type->get_element_type().get_user_type_id(), user_type));
+      table_expr->get_udt_id(), user_type));
     CK (OB_NOT_NULL(user_type));
-    CK (user_type->is_record_type());
-    CK (OB_NOT_NULL(record_type = static_cast<const ObRecordType *>(user_type)));
-    for (int64_t i = 0; OB_SUCC(ret) && i < record_type->get_member_count(); ++i) {
-      ObString name;
-      const ObString *member_name = record_type->get_record_member_name(i);
-      CK (OB_NOT_NULL(member_name));
+    if (OB_SUCC(ret) && !user_type->is_collection_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_WARN("function table get udf with return type not table type",
+               K(ret), K(user_type->is_collection_type()));
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "user define type is not collation type in function table");
+    }
+    const ObCollectionType *coll_type = NULL;
+    CK (OB_NOT_NULL(coll_type = static_cast<const ObCollectionType*>(user_type)));
+    if (OB_SUCC(ret)
+        && !coll_type->get_element_type().is_obj_type()
+        && !coll_type->get_element_type().is_record_type()
+        && !coll_type->get_element_type().is_collection_type()
+        && !(coll_type->get_element_type().is_opaque_type()
+              && coll_type->get_element_type().get_user_type_id() == T_OBJ_XML)) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_WARN("not suppoert type in table function", K(ret), KPC(coll_type));
+      ObString err;
+      err.write(coll_type->get_name().ptr(), coll_type->get_name().length());
+      err.write(" collation type in table function\0", sizeof(" collation type in table function\0"));
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, err.ptr());
+    }
+    if (OB_SUCC(ret) && (coll_type->get_element_type().is_obj_type()
+                        || coll_type->get_element_type().is_opaque_type()
+                        || coll_type->get_element_type().is_collection_type())) {
+      OZ (column_names.push_back(ObString("COLUMN_VALUE")));
+    }
+    if (OB_SUCC(ret) && coll_type->get_element_type().is_record_type()) {
+      const ObRecordType *record_type = NULL;
+      const ObUserDefinedType *user_type = NULL;
+      CK (OB_NOT_NULL(params.schema_checker_));
+      OZ (ObResolverUtils::get_user_type(
+        params.allocator_, params.session_info_, params.sql_proxy_,
+        params.schema_checker_->get_schema_guard(),
+        *package_guard,
+        coll_type->get_element_type().get_user_type_id(), user_type));
+      CK (OB_NOT_NULL(user_type));
+      CK (user_type->is_record_type());
+      CK (OB_NOT_NULL(record_type = static_cast<const ObRecordType *>(user_type)));
+      for (int64_t i = 0; OB_SUCC(ret) && i < record_type->get_member_count(); ++i) {
+        ObString name;
+        const ObString *member_name = record_type->get_record_member_name(i);
+        CK (OB_NOT_NULL(member_name));
 
-      if (OB_FAIL(ret)) {
-        // do nothing
-      } else if (PL_TYPE_PACKAGE == user_type->get_type_from()) {
-        OZ (ob_write_string(*params.allocator_, *member_name, name));
-      } else {
-        name = *member_name;
+        if (OB_FAIL(ret)) {
+          // do nothing
+        } else if (PL_TYPE_PACKAGE == user_type->get_type_from()) {
+          OZ (ob_write_string(*params.allocator_, *member_name, name));
+        } else {
+          name = *member_name;
+        }
+
+        OZ (column_names.push_back(name));
       }
-
-      OZ (column_names.push_back(name));
     }
   }
   return ret;
@@ -2981,6 +2991,9 @@ bool ObResolverUtils::is_expr_can_be_used_in_table_function(const ObRawExpr &exp
     bret = true;
   } else if (T_FUN_SYS_GENERATOR == expr.get_expr_type()) {
     // for generator(N) stream function
+    bret = true;
+  } else if (T_FUN_SYS_AI_SPLIT_DOCUMENT == expr.get_expr_type()) {
+    // AI_SPLIT_DOCUMENT is resolved as a function table source.
     bret = true;
   }
   return bret;


### PR DESCRIPTION
## Task Description

Implement Document AI Functions for seekdb:

- `LOAD_FILE(location_name, file_name)`
- `AI_SPLIT_DOCUMENT(content, parameters)`

## Solution Description

### LOAD_FILE

- Adds `LOAD_FILE` as a built-in scalar function.
- Resolves registered `LOCATION` objects at runtime.
- Checks LOCATION read permission.
- Reads raw file bytes through the existing storage I/O layer.
- Returns file content as a BLOB.
- Restricts file names to safe relative paths.

### AI_SPLIT_DOCUMENT

- Supports direct `FROM AI_SPLIT_DOCUMENT(...)` syntax.
- Reuses the existing function-table execution pipeline.
- Returns `CHUNK_ID`, `CHUNK_OFFSET`, `CHUNK_LENGTH`, and `CHUNK_TEXT`.
- Supports text and Markdown inputs.
- Supports word- and sentence-based splitting.
- Supports configurable maximum chunk size and overlap.

## Test

- `git diff --check`: passed.
- Full build and mysqltest were not run locally because the development environment is Windows.
- Validation is delegated to VLDB CI.