### PR TITLE
feat: support custom dictionaries for IK parser

### DIFF
--- a/.github/workflows/vldb-benchmark-comment.yml
+++ b/.github/workflows/vldb-benchmark-comment.yml
@@ -33,21 +33,33 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.VLDB_PR_COMMENT_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
+          PR_NUMBER_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+          WORKFLOW_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           ARTIFACT_DIR: ${{ runner.temp }}/vldb-fts-large-benchmark
         run: |
           set -euo pipefail
 
           REPORT_PATH="$ARTIFACT_DIR/report.txt"
-          PR_NUMBER_PATH="$ARTIFACT_DIR/pr_number"
-          if [[ ! -f "$REPORT_PATH" || ! -f "$PR_NUMBER_PATH" ]]; then
+          SCORE_PATH="$ARTIFACT_DIR/score.txt"
+          if [[ ! -f "$REPORT_PATH" ]]; then
             echo "benchmark comment artifact not found, skip PR comment"
             exit 0
           fi
 
-          PR_NUMBER="$(tr -d '[:space:]' < "$PR_NUMBER_PATH")"
+          PR_NUMBER="$PR_NUMBER_FROM_EVENT"
           if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "invalid PR number in artifact: $PR_NUMBER"
+            PR_NUMBER_PATH="$ARTIFACT_DIR/pr_number"
+            if [[ ! -f "$PR_NUMBER_PATH" ]]; then
+              echo "::warning::PR number missing from workflow_run event and artifact, skip PR comment"
+              exit 0
+            fi
+            PR_NUMBER="$(tr -d '[:space:]' < "$PR_NUMBER_PATH")"
+            echo "workflow_run event did not include PR number, using artifact PR number: $PR_NUMBER"
+          fi
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "invalid PR number: $PR_NUMBER"
             exit 1
           fi
 
@@ -56,18 +68,65 @@ jobs:
           COMMENT_BODY="$RUNNER_TEMP/vldb_fts_benchmark_comment.json"
           COMMENTS_JSON="$RUNNER_TEMP/vldb_fts_benchmark_comments.json"
           RESPONSE_JSON="$RUNNER_TEMP/vldb_fts_benchmark_response.json"
+          PR_JSON="$RUNNER_TEMP/vldb_fts_benchmark_pr.json"
 
-          python3 - "$REPORT_PATH" "$RUN_URL" "$MARKER" > "$COMMENT_BODY" <<'PY'
-          import html
+          http_code="$(curl -sS -L -w '%{http_code}' -o "$PR_JSON" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" || true)"
+          if [[ "$http_code" == "401" || "$http_code" == "403" ]]; then
+            echo "::warning::skip PR comment: token cannot read pull request"
+            cat "$PR_JSON" 2>/dev/null || true
+            exit 0
+          fi
+          if [[ ! "$http_code" =~ ^2 ]]; then
+            echo "::warning::skip PR comment: failed to read pull request, HTTP $http_code"
+            cat "$PR_JSON" 2>/dev/null || true
+            exit 0
+          fi
+
+          python3 - "$PR_JSON" "$WORKFLOW_HEAD_REPO" "$WORKFLOW_HEAD_SHA" <<'PY'
           import json
           import sys
 
-          report_path, run_url, marker = sys.argv[1:4]
-          with open(report_path, encoding="utf-8") as f:
-              report = f.read().strip()
+          pr_path, workflow_head_repo, workflow_head_sha = sys.argv[1:4]
+          with open(pr_path, encoding="utf-8") as f:
+              pr = json.load(f)
 
-          body = "\n".join([
+          pr_head_repo = (pr.get("head", {}).get("repo") or {}).get("full_name") or ""
+          pr_head_sha = pr.get("head", {}).get("sha") or ""
+          if workflow_head_repo and pr_head_repo and workflow_head_repo != pr_head_repo:
+              raise SystemExit(
+                  f"PR head repo mismatch: workflow_run={workflow_head_repo}, pr={pr_head_repo}"
+              )
+          if workflow_head_sha and pr_head_sha and workflow_head_sha != pr_head_sha:
+              print(
+                  f"::warning::PR head sha differs from workflow_run head_sha: "
+                  f"workflow_run={workflow_head_sha}, pr={pr_head_sha}"
+              )
+          PY
+
+          python3 - "$REPORT_PATH" "$SCORE_PATH" "$RUN_URL" "$MARKER" > "$COMMENT_BODY" <<'PY'
+          import html
+          import json
+          from pathlib import Path
+          import sys
+
+          report_path, score_path, run_url, marker = sys.argv[1:5]
+          report = Path(report_path).read_text(encoding="utf-8").strip()
+          score = ""
+          if score_path and Path(score_path).is_file():
+              score = Path(score_path).read_text(encoding="utf-8").strip()
+
+          parts = [
               marker,
+              "### FTS Large Benchmark Score",
+              "",
+              "<pre>",
+              html.escape(score or "score output not found"),
+              "</pre>",
+              "",
               "### FTS Large Benchmark Report",
               "",
               "<pre>",
@@ -75,7 +134,8 @@ jobs:
               "</pre>",
               "",
               f"[Workflow run]({run_url})",
-          ])
+          ]
+          body = "\n".join(parts)
           print(json.dumps({"body": body}, ensure_ascii=False))
           PY
 

--- a/.github/workflows/vldb-benchmark-comment.yml
+++ b/.github/workflows/vldb-benchmark-comment.yml
@@ -1,0 +1,138 @@
+name: VLDB Benchmark Comment
+
+on:
+  workflow_run:
+    workflows: [VLDB CI]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  comment:
+    name: comment-fts-benchmark
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download FTS benchmark artifact
+        id: download
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: vldb-fts-large-benchmark
+          path: ${{ runner.temp }}/vldb-fts-large-benchmark
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment FTS benchmark report on PR
+        if: ${{ always() }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.VLDB_PR_COMMENT_TOKEN || github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          ARTIFACT_DIR: ${{ runner.temp }}/vldb-fts-large-benchmark
+        run: |
+          set -euo pipefail
+
+          REPORT_PATH="$ARTIFACT_DIR/report.txt"
+          PR_NUMBER_PATH="$ARTIFACT_DIR/pr_number"
+          if [[ ! -f "$REPORT_PATH" || ! -f "$PR_NUMBER_PATH" ]]; then
+            echo "benchmark comment artifact not found, skip PR comment"
+            exit 0
+          fi
+
+          PR_NUMBER="$(tr -d '[:space:]' < "$PR_NUMBER_PATH")"
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "invalid PR number in artifact: $PR_NUMBER"
+            exit 1
+          fi
+
+          MARKER="<!-- seekdb-vldb-fts-large-benchmark -->"
+          COMMENTS_API="https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}/comments"
+          COMMENT_BODY="$RUNNER_TEMP/vldb_fts_benchmark_comment.json"
+          COMMENTS_JSON="$RUNNER_TEMP/vldb_fts_benchmark_comments.json"
+          RESPONSE_JSON="$RUNNER_TEMP/vldb_fts_benchmark_response.json"
+
+          python3 - "$REPORT_PATH" "$RUN_URL" "$MARKER" > "$COMMENT_BODY" <<'PY'
+          import html
+          import json
+          import sys
+
+          report_path, run_url, marker = sys.argv[1:4]
+          with open(report_path, encoding="utf-8") as f:
+              report = f.read().strip()
+
+          body = "\n".join([
+              marker,
+              "### FTS Large Benchmark Report",
+              "",
+              "<pre>",
+              html.escape(report),
+              "</pre>",
+              "",
+              f"[Workflow run]({run_url})",
+          ])
+          print(json.dumps({"body": body}, ensure_ascii=False))
+          PY
+
+          http_code="$(curl -sS -L -w '%{http_code}' -o "$COMMENTS_JSON" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$COMMENTS_API" || true)"
+          if [[ "$http_code" == "401" || "$http_code" == "403" ]]; then
+            echo "::warning::skip PR comment: token cannot read comments"
+            cat "$COMMENTS_JSON" 2>/dev/null || true
+            exit 0
+          fi
+          if [[ ! "$http_code" =~ ^2 ]]; then
+            echo "::warning::skip PR comment: failed to list comments, HTTP $http_code"
+            cat "$COMMENTS_JSON" 2>/dev/null || true
+            exit 0
+          fi
+
+          comment_id="$(python3 - "$COMMENTS_JSON" "$MARKER" <<'PY'
+          import json
+          import sys
+
+          comments_path, marker = sys.argv[1:3]
+          with open(comments_path, encoding="utf-8") as f:
+              comments = json.load(f)
+          for comment in comments:
+              if marker in (comment.get("body") or ""):
+                  print(comment["id"])
+                  break
+          PY
+          )"
+
+          if [[ -n "$comment_id" ]]; then
+            METHOD="PATCH"
+            COMMENT_API="https://api.github.com/repos/${GH_REPO}/issues/comments/${comment_id}"
+          else
+            METHOD="POST"
+            COMMENT_API="$COMMENTS_API"
+          fi
+
+          http_code="$(curl -sS -L -w '%{http_code}' -o "$RESPONSE_JSON" \
+            -X "$METHOD" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data-binary @"$COMMENT_BODY" \
+            "$COMMENT_API" || true)"
+          if [[ "$http_code" == "401" || "$http_code" == "403" ]]; then
+            echo "::warning::skip PR comment: token cannot write comments"
+            cat "$RESPONSE_JSON" 2>/dev/null || true
+            exit 0
+          fi
+          if [[ ! "$http_code" =~ ^2 ]]; then
+            echo "::warning::skip PR comment: failed to write comment, HTTP $http_code"
+            cat "$RESPONSE_JSON" 2>/dev/null || true
+            exit 0
+          fi
+
+          echo "FTS benchmark PR comment posted"

--- a/.github/workflows/vldb-benchmark-comment.yml
+++ b/.github/workflows/vldb-benchmark-comment.yml
@@ -43,8 +43,9 @@ jobs:
 
           REPORT_PATH="$ARTIFACT_DIR/report.txt"
           SCORE_PATH="$ARTIFACT_DIR/score.txt"
-          if [[ ! -f "$REPORT_PATH" ]]; then
-            echo "benchmark comment artifact not found, skip PR comment"
+          AI_FUNCS_SCORE_PATH="$ARTIFACT_DIR/ai_funcs_score.txt"
+          if [[ ! -f "$REPORT_PATH" && ! -f "$AI_FUNCS_SCORE_PATH" ]]; then
+            echo "comment artifact has neither benchmark report nor ai_funcs score, skip PR comment"
             exit 0
           fi
 
@@ -107,34 +108,49 @@ jobs:
               )
           PY
 
-          python3 - "$REPORT_PATH" "$SCORE_PATH" "$RUN_URL" "$MARKER" > "$COMMENT_BODY" <<'PY'
+          python3 - "$REPORT_PATH" "$SCORE_PATH" "$AI_FUNCS_SCORE_PATH" "$RUN_URL" "$MARKER" > "$COMMENT_BODY" <<'PY'
           import html
           import json
           from pathlib import Path
           import sys
 
-          report_path, score_path, run_url, marker = sys.argv[1:5]
-          report = Path(report_path).read_text(encoding="utf-8").strip()
-          score = ""
-          if score_path and Path(score_path).is_file():
-              score = Path(score_path).read_text(encoding="utf-8").strip()
+          report_path, score_path, ai_funcs_score_path, run_url, marker = sys.argv[1:6]
 
-          parts = [
-              marker,
-              "### FTS Large Benchmark Score",
-              "",
-              "<pre>",
-              html.escape(score or "score output not found"),
-              "</pre>",
-              "",
-              "### FTS Large Benchmark Report",
-              "",
-              "<pre>",
-              html.escape(report),
-              "</pre>",
-              "",
-              f"[Workflow run]({run_url})",
-          ]
+          def read_optional(path):
+              if path and Path(path).is_file():
+                  return Path(path).read_text(encoding="utf-8").strip()
+              return ""
+
+          report = read_optional(report_path)
+          score = read_optional(score_path)
+          ai_funcs_score = read_optional(ai_funcs_score_path)
+
+          parts = [marker]
+          if ai_funcs_score:
+              parts += [
+                  "### Document AI & IK Custom Dictionary Score",
+                  "",
+                  "<pre>",
+                  html.escape(ai_funcs_score),
+                  "</pre>",
+                  "",
+              ]
+          if report:
+              parts += [
+                  "### FTS Large Benchmark Score",
+                  "",
+                  "<pre>",
+                  html.escape(score or "score output not found"),
+                  "</pre>",
+                  "",
+                  "### FTS Large Benchmark Report",
+                  "",
+                  "<pre>",
+                  html.escape(report),
+                  "</pre>",
+                  "",
+              ]
+          parts.append(f"[Workflow run]({run_url})")
           body = "\n".join(parts)
           print(json.dumps({"body": body}, ensure_ascii=False))
           PY

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -243,17 +243,27 @@ jobs:
           fi
           echo "mysql-compatible client: $CLIENT"
 
-          chmod +x "$WORKSPACE/tools/benchmark/fts_large_bench.sh" "$WORKSPACE/tools/benchmark/fts_large_bench_gen.py"
+          chmod +x \
+            "$WORKSPACE/tools/benchmark/fts_large_bench.sh" \
+            "$WORKSPACE/tools/benchmark/fts_large_bench_gen.py" \
+            "$WORKSPACE/tools/benchmark/fts_large_bench_score.py"
           BENCH_OUTPUT="$VLDB_WORK_DIR/fts_large_bench_report.txt"
+          SCORE_OUTPUT="$VLDB_WORK_DIR/fts_large_bench_score.txt"
           export MYSQL="$CLIENT -h127.0.0.1 -P2881 -uroot -N -s -A --default-character-set=utf8mb4"
           export MYSQL_VERBOSE="$CLIENT -h127.0.0.1 -P2881 -uroot -A --default-character-set=utf8mb4"
           export LABEL="vldb-ci-${{ github.run_id }}-${{ github.run_attempt }}"
           export OUTPUT="$BENCH_OUTPUT"
 
           "$WORKSPACE/tools/benchmark/fts_large_bench.sh" | tee "$VLDB_WORK_DIR/fts_large_bench.log"
+          "$WORKSPACE/tools/benchmark/fts_large_bench_score.py" "$BENCH_OUTPUT" | tee "$SCORE_OUTPUT"
 
           if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
             {
+              echo "### FTS Large Benchmark Score"
+              echo '```'
+              cat "$SCORE_OUTPUT"
+              echo '```'
+              echo
               echo "### FTS Large Benchmark Report"
               echo '```'
               cat "$BENCH_OUTPUT"
@@ -267,6 +277,7 @@ jobs:
         run: |
           set -euo pipefail
           BENCH_OUTPUT="$VLDB_WORK_DIR/fts_large_bench_report.txt"
+          SCORE_OUTPUT="$VLDB_WORK_DIR/fts_large_bench_score.txt"
           ARTIFACT_DIR="$VLDB_WORK_DIR/fts_large_bench_comment"
           if [[ ! -f "$BENCH_OUTPUT" ]]; then
             echo "benchmark report not found, skip comment artifact: $BENCH_OUTPUT"
@@ -274,6 +285,9 @@ jobs:
           fi
           mkdir -p "$ARTIFACT_DIR"
           cp -f "$BENCH_OUTPUT" "$ARTIFACT_DIR/report.txt"
+          if [[ -f "$SCORE_OUTPUT" ]]; then
+            cp -f "$SCORE_OUTPUT" "$ARTIFACT_DIR/score.txt"
+          fi
           echo "${{ github.event.pull_request.number }}" > "$ARTIFACT_DIR/pr_number"
           echo "${{ github.run_id }}" > "$ARTIFACT_DIR/source_run_id"
           echo "${{ github.run_attempt }}" > "$ARTIFACT_DIR/source_run_attempt"

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -187,10 +187,6 @@ jobs:
 
       - name: Run mysqltest (Document AI functions + custom IK parser)
         shell: bash
-        env:
-          API_KEY: "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"
-          MODEL_NAME: "gpt-4o-mini"
-          API_ENDPOINT: "https://api.openai.com/v1/chat/completions"
         run: |
           set -euo pipefail
           WS="${{ github.workspace }}"
@@ -228,15 +224,13 @@ jobs:
           MTR_TMP="$VLDB_WORK_DIR/mtr_tmp"; mkdir -p "$MTR_TMP"
           cd "$WORKSPACE/tools/deploy"
           export MYSQL_TMP_DIR="$MTR_TMP" OBMYSQL_MS0=127.0.0.1 OBMYSQL_PORT=2881 OBMYSQL_PWD=
-          export AI_FIXTURE_DIR="$WORKSPACE/tools/deploy/mysql_test/test_suite/ai_funcs"
 
-          # ai_funcs suite: load_file, ai_split_document, ai_parse_doc (Document AI) + ik_custom_dict (custom IK parser).
-          # ai_parse_doc's live parse runs when the API_KEY hardcoded in this step's env is set; otherwise it is skipped and the
-          # deterministic error cases keep the run green.
+          # ai_funcs suite (ai_parse_doc excluded -- it needs a live vision endpoint):
+          # load_file, ai_split_document (Document AI) + ik_custom_dict (custom IK parser).
           suite=mysql_test/test_suite/ai_funcs
           fail=0
-          for tf in "$suite"/t/*.test; do
-            t="$(basename "$tf" .test)"
+          for t in load_file ai_split_document ik_custom_dict; do
+            tf="$suite/t/$t.test"
             echo "===================== ai_funcs/$t ====================="
             if "$MT" --host=127.0.0.1 --port=2881 --user=root --database=test \
                  --test-file="$tf" --result-file="$suite/r/$t.result"; then

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -1,0 +1,195 @@
+name: VLDB CI
+
+on:
+  pull_request:
+    branches: [vldb_2026]
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+
+env:
+  cache-name: cache-deps
+  VLDB_WORK_DIR: ${{ github.workspace }}/vldb_smoke
+  SEEKDB_TASK_DIR: ${{ github.workspace }}/seekdb_build/${{ github.run_id }}
+
+jobs:
+  build-and-smoke:
+    name: build-observer-and-smoke
+    if: ${{ github.repository_owner == 'oceanbase' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
+    runs-on: arc-runner-k8s-ci-org
+    container:
+      image: harbor.oceanbase-dev.com/obrde-test/ob-actions-runner-worker:0.0.2
+    steps:
+      - name: Checkout with retry
+        shell: bash
+        env:
+          CHECKOUT_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          CHECKOUT_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          CHECKOUT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git init
+          git remote remove origin 2>/dev/null || true
+          git remote add origin "https://github.com/${CHECKOUT_REPOSITORY}.git"
+          for i in $(seq 1 10); do
+            if git fetch --no-tags --depth=1 origin "+refs/heads/${CHECKOUT_REF}:refs/remotes/origin/${CHECKOUT_REF}"; then
+              if git checkout --force "$CHECKOUT_SHA" || { git fetch --no-tags --depth=1 origin "$CHECKOUT_SHA" && git checkout --force FETCH_HEAD; }; then
+                git clean -ffdx
+                git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                exit 0
+              fi
+            fi
+            echo "checkout failed, retry ${i}/10"
+            sleep $((i * 10))
+          done
+          exit 1
+
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-el9.x86_64-${{ hashFiles('deps/init/oceanbase.el9.x86_64.deps') }}
+          path: deps/3rd
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2.11
+        with:
+          max-size: 800M
+          save: false
+          key: vldb
+
+      - name: Compile observer
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x .github/script/seekdb/compile.sh
+          export GITHUB_RUN_ID="${{ github.run_id }}"
+          WS="${{ github.workspace }}"
+          if [[ ! -f "$WS/build.sh" ]] && [[ -f "$(pwd)/build.sh" ]]; then
+            export GITHUB_WORKSPACE="$(pwd)"
+          else
+            export GITHUB_WORKSPACE="$WS"
+          fi
+          export SEEKDB_TASK_DIR="${{ env.SEEKDB_TASK_DIR }}"
+          export RELEASE_MODE="${{ vars.RELEASE_MODE || '' }}"
+          export FORWARDING_HOST="${{ vars.FORWARDING_HOST || '' }}"
+          export PATH="$GITHUB_WORKSPACE/deps/3rd/usr/local/oceanbase/devtools/bin:$PATH"
+          .github/script/seekdb/compile.sh
+
+      - name: Prepare observer
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$VLDB_WORK_DIR"
+          if [[ ! -x observer ]]; then
+            for base in build_debug build_release build; do
+              for cand in "$base/observer" "$base/src/observer/observer"; do
+                if [[ -f "$cand" ]] && [[ -x "$cand" ]]; then
+                  cp -f "$cand" observer && chmod +x observer
+                  echo "observer copied from $cand"
+                  break 2
+                fi
+              done
+            done
+          fi
+          if [[ ! -x observer ]]; then echo "observer missing or not executable"; exit 1; fi
+          cp -f observer "$VLDB_WORK_DIR/observer"
+          chmod +x "$VLDB_WORK_DIR/observer"
+          echo "observer size: $(stat -c%s "$VLDB_WORK_DIR/observer" 2>/dev/null || stat -f%z "$VLDB_WORK_DIR/observer" 2>/dev/null) bytes"
+          "$VLDB_WORK_DIR/observer" -V
+
+      - name: Start observer
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$VLDB_WORK_DIR"
+          ./observer
+          for i in $(seq 1 60); do
+            [[ -f run/seekdb.pid ]] && break
+            sleep 1
+          done
+          [[ -f run/seekdb.pid ]] || { echo "observer pid file not found"; tail -n 200 log/seekdb.log 2>/dev/null || true; exit 1; }
+          echo "observer pid: $(cat run/seekdb.pid)"
+
+      - name: Run smoke SQL
+        shell: bash
+        run: |
+          set -euo pipefail
+          WS="${{ github.workspace }}"
+          if [[ ! -f "$WS/build.sh" ]] && [[ -f "$(pwd)/build.sh" ]]; then
+            WORKSPACE="$(pwd)"
+          else
+            WORKSPACE="$WS"
+          fi
+          if grep -q 'dep_create.sh' "$WORKSPACE/build.sh" 2>/dev/null; then
+            DEP_PATH="$WORKSPACE/deps/3rd"
+          else
+            DEP_PATH="$WORKSPACE/rpm/.dep_create/var"
+          fi
+          export LD_LIBRARY_PATH="$DEP_PATH/u01/obclient/lib:${LD_LIBRARY_PATH:-}"
+
+          CLIENT=""
+          for cand in \
+            "$DEP_PATH/u01/obclient/bin/obclient" \
+            "$WORKSPACE/deps/3rd/u01/obclient/bin/obclient" \
+            "$WORKSPACE/rpm/.dep_create/var/u01/obclient/bin/obclient" \
+            "$WORKSPACE/tools/deploy/obclient"; do
+            if [[ -x "$cand" ]]; then
+              CLIENT="$cand"
+              break
+            fi
+          done
+          if [[ -z "$CLIENT" ]]; then
+            for root in "$WORKSPACE/deps/3rd" "$WORKSPACE/rpm/.dep_create/var"; do
+              [[ -d "$root" ]] || continue
+              cand="$(find "$root" -maxdepth 8 -path '*/bin/obclient' -type f -print -quit 2>/dev/null || true)"
+              if [[ -n "$cand" ]]; then
+                chmod +x "$cand" 2>/dev/null || true
+                if [[ -x "$cand" ]]; then
+                  CLIENT="$cand"
+                  break
+                fi
+              fi
+            done
+          fi
+          if [[ -z "$CLIENT" ]] && command -v obclient >/dev/null 2>&1; then
+            CLIENT="$(command -v obclient)"
+          elif [[ -z "$CLIENT" ]] && command -v mysql >/dev/null 2>&1; then
+            CLIENT="$(command -v mysql)"
+          fi
+          if [[ -z "$CLIENT" ]]; then
+            echo "no mysql-compatible client found"
+            echo "WORKSPACE=$WORKSPACE"
+            echo "DEP_PATH=$DEP_PATH"
+            for root in "$WORKSPACE/deps/3rd" "$WORKSPACE/rpm/.dep_create/var"; do
+              [[ -d "$root" ]] || continue
+              find "$root" -maxdepth 6 -path '*/bin/obclient' -type f -print 2>/dev/null || true
+            done
+            exit 1
+          fi
+          echo "mysql-compatible client: $CLIENT"
+
+          for i in $(seq 1 90); do
+            if "$CLIENT" -h127.0.0.1 -P2881 -uroot -A -e "select 1;" > "$VLDB_WORK_DIR/sql.out" 2>&1; then
+              cat "$VLDB_WORK_DIR/sql.out"
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "failed to run smoke SQL"
+          cat "$VLDB_WORK_DIR/sql.out" 2>/dev/null || true
+          tail -n 200 "$VLDB_WORK_DIR/log/seekdb.log" 2>/dev/null || true
+          exit 1
+
+      - name: Stop observer
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if [[ -f "$VLDB_WORK_DIR/run/seekdb.pid" ]]; then
+            PID="$(cat "$VLDB_WORK_DIR/run/seekdb.pid")"
+            kill "$PID"
+            sleep 5
+            kill -9 "$PID" 2>/dev/null || true
+          fi

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -185,6 +185,73 @@ jobs:
           tail -n 200 "$VLDB_WORK_DIR/log/seekdb.log" 2>/dev/null || true
           exit 1
 
+      - name: Run mysqltest (Document AI functions + custom IK parser)
+        shell: bash
+        env:
+          API_KEY: "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"
+          MODEL_NAME: "gpt-4o-mini"
+          API_ENDPOINT: "https://api.openai.com/v1/chat/completions"
+        run: |
+          set -euo pipefail
+          WS="${{ github.workspace }}"
+          if [[ ! -f "$WS/build.sh" ]] && [[ -f "$(pwd)/build.sh" ]]; then
+            WORKSPACE="$(pwd)"
+          else
+            WORKSPACE="$WS"
+          fi
+          if grep -q 'dep_create.sh' "$WORKSPACE/build.sh" 2>/dev/null; then
+            DEP_PATH="$WORKSPACE/deps/3rd"
+          else
+            DEP_PATH="$WORKSPACE/rpm/.dep_create/var"
+          fi
+          export LD_LIBRARY_PATH="$DEP_PATH/u01/obclient/lib:${LD_LIBRARY_PATH:-}"
+
+          # mysqltest ships next to obclient in the obclient toolchain
+          MT=""
+          for cand in \
+            "$DEP_PATH/u01/obclient/bin/mysqltest" \
+            "$WORKSPACE/deps/3rd/u01/obclient/bin/mysqltest" \
+            "$WORKSPACE/rpm/.dep_create/var/u01/obclient/bin/mysqltest"; do
+            if [[ -x "$cand" ]]; then MT="$cand"; break; fi
+          done
+          if [[ -z "$MT" ]]; then
+            cand="$(find "$DEP_PATH" -maxdepth 8 -path '*/bin/mysqltest' -type f -print -quit 2>/dev/null || true)"
+            if [[ -n "$cand" ]]; then chmod +x "$cand" 2>/dev/null || true; MT="$cand"; fi
+          fi
+          if [[ -z "$MT" || ! -x "$MT" ]]; then echo "mysqltest not found under $DEP_PATH"; exit 1; fi
+          OBC="$(dirname "$MT")/obclient"
+          echo "mysqltest: $MT"
+
+          # mysqltest's default connection needs the 'test' database to exist
+          "$OBC" -h127.0.0.1 -P2881 -uroot -A -e "CREATE DATABASE IF NOT EXISTS test;"
+
+          MTR_TMP="$VLDB_WORK_DIR/mtr_tmp"; mkdir -p "$MTR_TMP"
+          cd "$WORKSPACE/tools/deploy"
+          export MYSQL_TMP_DIR="$MTR_TMP" OBMYSQL_MS0=127.0.0.1 OBMYSQL_PORT=2881 OBMYSQL_PWD=
+          export AI_FIXTURE_DIR="$WORKSPACE/tools/deploy/mysql_test/test_suite/ai_funcs"
+
+          # ai_funcs suite: load_file, ai_split_document, ai_parse_doc (Document AI) + ik_custom_dict (custom IK parser).
+          # ai_parse_doc's live parse runs when the API_KEY hardcoded in this step's env is set; otherwise it is skipped and the
+          # deterministic error cases keep the run green.
+          suite=mysql_test/test_suite/ai_funcs
+          fail=0
+          for tf in "$suite"/t/*.test; do
+            t="$(basename "$tf" .test)"
+            echo "===================== ai_funcs/$t ====================="
+            if "$MT" --host=127.0.0.1 --port=2881 --user=root --database=test \
+                 --test-file="$tf" --result-file="$suite/r/$t.result"; then
+              echo ">>> $t: PASS"
+            else
+              echo ">>> $t: FAIL"
+              fail=1
+            fi
+          done
+          if [[ "$fail" -ne 0 ]]; then
+            echo "----- observer log tail -----"
+            tail -n 200 "$VLDB_WORK_DIR/log/seekdb.log" 2>/dev/null || true
+          fi
+          exit "$fail"
+
       - name: Run FTS large benchmark
         shell: bash
         run: |

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -182,6 +182,82 @@ jobs:
           tail -n 200 "$VLDB_WORK_DIR/log/seekdb.log" 2>/dev/null || true
           exit 1
 
+      - name: Run FTS large benchmark
+        shell: bash
+        run: |
+          set -euo pipefail
+          WS="${{ github.workspace }}"
+          if [[ ! -f "$WS/build.sh" ]] && [[ -f "$(pwd)/build.sh" ]]; then
+            WORKSPACE="$(pwd)"
+          else
+            WORKSPACE="$WS"
+          fi
+          if grep -q 'dep_create.sh' "$WORKSPACE/build.sh" 2>/dev/null; then
+            DEP_PATH="$WORKSPACE/deps/3rd"
+          else
+            DEP_PATH="$WORKSPACE/rpm/.dep_create/var"
+          fi
+          export LD_LIBRARY_PATH="$DEP_PATH/u01/obclient/lib:${LD_LIBRARY_PATH:-}"
+
+          CLIENT=""
+          for cand in \
+            "$DEP_PATH/u01/obclient/bin/obclient" \
+            "$WORKSPACE/deps/3rd/u01/obclient/bin/obclient" \
+            "$WORKSPACE/rpm/.dep_create/var/u01/obclient/bin/obclient" \
+            "$WORKSPACE/tools/deploy/obclient"; do
+            if [[ -x "$cand" ]]; then
+              CLIENT="$cand"
+              break
+            fi
+          done
+          if [[ -z "$CLIENT" ]]; then
+            for root in "$WORKSPACE/deps/3rd" "$WORKSPACE/rpm/.dep_create/var"; do
+              [[ -d "$root" ]] || continue
+              cand="$(find "$root" -maxdepth 8 -path '*/bin/obclient' -type f -print -quit 2>/dev/null || true)"
+              if [[ -n "$cand" ]]; then
+                chmod +x "$cand" 2>/dev/null || true
+                if [[ -x "$cand" ]]; then
+                  CLIENT="$cand"
+                  break
+                fi
+              fi
+            done
+          fi
+          if [[ -z "$CLIENT" ]] && command -v obclient >/dev/null 2>&1; then
+            CLIENT="$(command -v obclient)"
+          elif [[ -z "$CLIENT" ]] && command -v mysql >/dev/null 2>&1; then
+            CLIENT="$(command -v mysql)"
+          fi
+          if [[ -z "$CLIENT" ]]; then
+            echo "no mysql-compatible client found"
+            echo "WORKSPACE=$WORKSPACE"
+            echo "DEP_PATH=$DEP_PATH"
+            for root in "$WORKSPACE/deps/3rd" "$WORKSPACE/rpm/.dep_create/var"; do
+              [[ -d "$root" ]] || continue
+              find "$root" -maxdepth 6 -path '*/bin/obclient' -type f -print 2>/dev/null || true
+            done
+            exit 1
+          fi
+          echo "mysql-compatible client: $CLIENT"
+
+          chmod +x "$WORKSPACE/tools/benchmark/fts_large_bench.sh" "$WORKSPACE/tools/benchmark/fts_large_bench_gen.py"
+          BENCH_OUTPUT="$VLDB_WORK_DIR/fts_large_bench_report.txt"
+          export MYSQL="$CLIENT -h127.0.0.1 -P2881 -uroot -N -s -A --default-character-set=utf8mb4"
+          export MYSQL_VERBOSE="$CLIENT -h127.0.0.1 -P2881 -uroot -A --default-character-set=utf8mb4"
+          export LABEL="vldb-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+          export OUTPUT="$BENCH_OUTPUT"
+
+          "$WORKSPACE/tools/benchmark/fts_large_bench.sh" | tee "$VLDB_WORK_DIR/fts_large_bench.log"
+
+          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+            {
+              echo "### FTS Large Benchmark Report"
+              echo '```'
+              cat "$BENCH_OUTPUT"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Stop observer
         if: always()
         shell: bash

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 env:
   cache-name: cache-deps
@@ -263,71 +261,32 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Comment FTS benchmark report on PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+      - name: Prepare FTS benchmark comment artifact
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BENCH_OUTPUT="$VLDB_WORK_DIR/fts_large_bench_report.txt"
+          ARTIFACT_DIR="$VLDB_WORK_DIR/fts_large_bench_comment"
+          if [[ ! -f "$BENCH_OUTPUT" ]]; then
+            echo "benchmark report not found, skip comment artifact: $BENCH_OUTPUT"
+            exit 0
+          fi
+          mkdir -p "$ARTIFACT_DIR"
+          cp -f "$BENCH_OUTPUT" "$ARTIFACT_DIR/report.txt"
+          echo "${{ github.event.pull_request.number }}" > "$ARTIFACT_DIR/pr_number"
+          echo "${{ github.run_id }}" > "$ARTIFACT_DIR/source_run_id"
+          echo "${{ github.run_attempt }}" > "$ARTIFACT_DIR/source_run_attempt"
+
+      - name: Upload FTS benchmark comment artifact
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v7
         continue-on-error: true
-        env:
-          BENCH_OUTPUT: ${{ env.VLDB_WORK_DIR }}/fts_large_bench_report.txt
         with:
-          github-token: ${{ secrets.VLDB_PR_COMMENT_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- seekdb-vldb-fts-large-benchmark -->';
-            const reportPath = process.env.BENCH_OUTPUT;
-            if (!fs.existsSync(reportPath)) {
-              core.warning(`benchmark report not found: ${reportPath}`);
-              return;
-            }
-
-            const report = fs.readFileSync(reportPath, 'utf8').trim();
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = [
-              marker,
-              '### FTS Large Benchmark Report',
-              '',
-              '```',
-              report,
-              '```',
-              '',
-              `[Workflow run](${runUrl})`,
-            ].join('\n');
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            try {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number,
-                per_page: 100,
-              });
-              const previous = comments.find((comment) =>
-                comment.body && comment.body.includes(marker)
-              );
-
-              if (previous) {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: previous.id,
-                  body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number,
-                  body,
-                });
-              }
-            } catch (error) {
-              if (error.status === 401 || error.status === 403) {
-                core.warning('skip PR comment: VLDB_PR_COMMENT_TOKEN cannot write comments for this pull_request run');
-                return;
-              }
-              throw error;
-            }
+          name: vldb-fts-large-benchmark
+          path: ${{ env.VLDB_WORK_DIR }}/fts_large_bench_comment/
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Stop observer
         if: always()

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -253,18 +253,20 @@ jobs:
           done
           DOC_AI_SCORE=$((LOAD_FILE_PTS + SPLIT_DOC_PTS))
 
-          echo "Document AI Functions Score"
-          echo "==========================="
-          printf "score: %.2f / 100\n" "$DOC_AI_SCORE"
-          echo "load_file: $LOAD_FILE_PTS / 50"
-          echo "ai_split_document: $SPLIT_DOC_PTS / 50"
-          echo
-          echo "IK Custom Dictionary Score"
-          echo "=========================="
-          printf "score: %.2f / 100\n" "$IK_SCORE"
-          echo "ik_custom_dict: $IK_SCORE / 100"
-
-          exit "$fail"
+          # Write the score report for the comment-artifact step to pick up.
+          # It is deliberately not printed here.
+          {
+            echo "Document AI Functions Score"
+            echo "==========================="
+            printf "score: %.2f / 100\n" "$DOC_AI_SCORE"
+            echo "load_file: $LOAD_FILE_PTS / 50"
+            echo "ai_split_document: $SPLIT_DOC_PTS / 50"
+            echo
+            echo "IK Custom Dictionary Score"
+            echo "=========================="
+            printf "score: %.2f / 100\n" "$IK_SCORE"
+            echo "ik_custom_dict: $IK_SCORE / 100"
+          } > "$VLDB_WORK_DIR/ai_funcs_score.txt"
 
       - name: Run FTS large benchmark
         shell: bash
@@ -352,34 +354,52 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Prepare FTS benchmark comment artifact
+      - name: Prepare benchmark comment artifact
         if: ${{ always() && github.event_name == 'pull_request' }}
         shell: bash
         run: |
           set -euo pipefail
-          BENCH_OUTPUT="$VLDB_WORK_DIR/fts_large_bench_report.txt"
-          SCORE_OUTPUT="$VLDB_WORK_DIR/fts_large_bench_score.txt"
-          ARTIFACT_DIR="$VLDB_WORK_DIR/fts_large_bench_comment"
-          if [[ ! -f "$BENCH_OUTPUT" ]]; then
-            echo "benchmark report not found, skip comment artifact: $BENCH_OUTPUT"
+          FTS_REPORT="$VLDB_WORK_DIR/fts_large_bench_report.txt"
+          FTS_SCORE="$VLDB_WORK_DIR/fts_large_bench_score.txt"
+          AI_FUNCS_SCORE="$VLDB_WORK_DIR/ai_funcs_score.txt"
+          ARTIFACT_DIR="$VLDB_WORK_DIR/vldb_comment"
+
+          # ai_funcs score, written by the mysqltest step
+          if [[ -f "$AI_FUNCS_SCORE" ]]; then
+            cat "$AI_FUNCS_SCORE"
+            echo
+          fi
+
+          if [[ ! -f "$FTS_REPORT" && ! -f "$AI_FUNCS_SCORE" ]]; then
+            echo "neither benchmark report nor ai_funcs score found, skip comment artifact"
             exit 0
           fi
           mkdir -p "$ARTIFACT_DIR"
-          cp -f "$BENCH_OUTPUT" "$ARTIFACT_DIR/report.txt"
-          if [[ -f "$SCORE_OUTPUT" ]]; then
-            cp -f "$SCORE_OUTPUT" "$ARTIFACT_DIR/score.txt"
+          # The file names below are a contract with vldb-benchmark-comment.yml, which
+          # runs from the default branch. Renaming one side alone silently drops the
+          # PR comment, so change both together.
+          if [[ -f "$FTS_REPORT" ]]; then
+            cp -f "$FTS_REPORT" "$ARTIFACT_DIR/report.txt"
+          fi
+          if [[ -f "$FTS_SCORE" ]]; then
+            cp -f "$FTS_SCORE" "$ARTIFACT_DIR/score.txt"
+          fi
+          if [[ -f "$AI_FUNCS_SCORE" ]]; then
+            cp -f "$AI_FUNCS_SCORE" "$ARTIFACT_DIR/ai_funcs_score.txt"
           fi
           echo "${{ github.event.pull_request.number }}" > "$ARTIFACT_DIR/pr_number"
           echo "${{ github.run_id }}" > "$ARTIFACT_DIR/source_run_id"
           echo "${{ github.run_attempt }}" > "$ARTIFACT_DIR/source_run_attempt"
 
-      - name: Upload FTS benchmark comment artifact
+      - name: Upload benchmark comment artifact
         if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
+          # Artifact name is a contract with vldb-benchmark-comment.yml on the default
+          # branch; renaming it here alone silently disables the PR comment.
           name: vldb-fts-large-benchmark
-          path: ${{ env.VLDB_WORK_DIR }}/fts_large_bench_comment/
+          path: ${{ env.VLDB_WORK_DIR }}/vldb_comment/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -229,21 +229,41 @@ jobs:
           # load_file, ai_split_document (Document AI) + ik_custom_dict (custom IK parser).
           suite=mysql_test/test_suite/ai_funcs
           fail=0
+          # A passing case earns its full points; a failing one earns zero.
+          # Document AI Functions = load_file (50) + ai_split_document (50).
+          # IK Custom Dictionary  = ik_custom_dict (100).
+          LOAD_FILE_PTS=0
+          SPLIT_DOC_PTS=0
+          IK_SCORE=0
           for t in load_file ai_split_document ik_custom_dict; do
             tf="$suite/t/$t.test"
             echo "===================== ai_funcs/$t ====================="
             if "$MT" --host=127.0.0.1 --port=2881 --user=root --database=test \
                  --test-file="$tf" --result-file="$suite/r/$t.result"; then
               echo ">>> $t: PASS"
+              case "$t" in
+                load_file)         LOAD_FILE_PTS=50 ;;
+                ai_split_document) SPLIT_DOC_PTS=50 ;;
+                ik_custom_dict)    IK_SCORE=100 ;;
+              esac
             else
               echo ">>> $t: FAIL"
               fail=1
             fi
           done
-          if [[ "$fail" -ne 0 ]]; then
-            echo "----- observer log tail -----"
-            tail -n 200 "$VLDB_WORK_DIR/log/seekdb.log" 2>/dev/null || true
-          fi
+          DOC_AI_SCORE=$((LOAD_FILE_PTS + SPLIT_DOC_PTS))
+
+          echo "Document AI Functions Score"
+          echo "==========================="
+          printf "score: %.2f / 100\n" "$DOC_AI_SCORE"
+          echo "load_file: $LOAD_FILE_PTS / 50"
+          echo "ai_split_document: $SPLIT_DOC_PTS / 50"
+          echo
+          echo "IK Custom Dictionary Score"
+          echo "=========================="
+          printf "score: %.2f / 100\n" "$IK_SCORE"
+          echo "ik_custom_dict: $IK_SCORE / 100"
+
           exit "$fail"
 
       - name: Run FTS large benchmark

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -270,6 +270,7 @@ jobs:
         env:
           BENCH_OUTPUT: ${{ env.VLDB_WORK_DIR }}/fts_large_bench_report.txt
         with:
+          github-token: ${{ secrets.VLDB_PR_COMMENT_TOKEN }}
           script: |
             const fs = require('fs');
             const marker = '<!-- seekdb-vldb-fts-large-benchmark -->';
@@ -294,30 +295,38 @@ jobs:
 
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const previous = comments.find((comment) =>
-              comment.user.type === 'Bot' && comment.body && comment.body.includes(marker)
-            );
-
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: previous.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
                 issue_number,
-                body,
+                per_page: 100,
               });
+              const previous = comments.find((comment) =>
+                comment.body && comment.body.includes(marker)
+              );
+
+              if (previous) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: previous.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body,
+                });
+              }
+            } catch (error) {
+              if (error.status === 401 || error.status === 403) {
+                core.warning('skip PR comment: VLDB_PR_COMMENT_TOKEN cannot write comments for this pull_request run');
+                return;
+              }
+              throw error;
             }
 
       - name: Stop observer

--- a/.github/workflows/vldb.yml
+++ b/.github/workflows/vldb.yml
@@ -6,6 +6,11 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 env:
   cache-name: cache-deps
   VLDB_WORK_DIR: ${{ github.workspace }}/vldb_smoke
@@ -257,6 +262,63 @@ jobs:
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Comment FTS benchmark report on PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        continue-on-error: true
+        env:
+          BENCH_OUTPUT: ${{ env.VLDB_WORK_DIR }}/fts_large_bench_report.txt
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- seekdb-vldb-fts-large-benchmark -->';
+            const reportPath = process.env.BENCH_OUTPUT;
+            if (!fs.existsSync(reportPath)) {
+              core.warning(`benchmark report not found: ${reportPath}`);
+              return;
+            }
+
+            const report = fs.readFileSync(reportPath, 'utf8').trim();
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              '### FTS Large Benchmark Report',
+              '',
+              '```',
+              report,
+              '```',
+              '',
+              `[Workflow run](${runUrl})`,
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previous = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body && comment.body.includes(marker)
+            );
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
 
       - name: Stop observer
         if: always()

--- a/deps/oblib/src/CMakeLists.txt
+++ b/deps/oblib/src/CMakeLists.txt
@@ -271,7 +271,7 @@ if(OB_AIO AND OB_AIO STREQUAL "libaio1t64" AND NOT APPLE)
     list(APPEND AIO_SEARCH_PATHS /usr/lib/aarch64-linux-gnu)
   endif()
   list(APPEND AIO_SEARCH_PATHS /usr/lib)
-  find_library(AIO_LIBRARY
+  find_file(AIO_LIBRARY
     NAMES libaio.so.1t64
     PATHS ${AIO_SEARCH_PATHS}
     NO_DEFAULT_PATH

--- a/src/objit/include/objit/common/ob_item_type.h
+++ b/src/objit/include/objit/common/ob_item_type.h
@@ -2882,6 +2882,8 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_FULLTEXT_DICT = 4920,
+  T_REFRESH_FULLTEXT_DICT = 4921,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/plugin/interface/ob_plugin_ftparser_intf.h
+++ b/src/plugin/interface/ob_plugin_ftparser_intf.h
@@ -77,7 +77,13 @@ public:
   };
 
   ObFTIKParam(Mode mode = Mode::SMART)
-      : mode_(mode), main_dict_(""), quan_dict_(""), stopword_dict_("")
+      : mode_(mode),
+        main_dict_(""),
+        quan_dict_(""),
+        stopword_dict_(""),
+        main_dict_id_(common::OB_INVALID_ID),
+        quan_dict_id_(common::OB_INVALID_ID),
+        stopword_dict_id_(common::OB_INVALID_ID)
   {
   }
 
@@ -86,6 +92,9 @@ public:
   common::ObString main_dict_;
   common::ObString quan_dict_;
   common::ObString stopword_dict_;
+  uint64_t main_dict_id_;
+  uint64_t quan_dict_id_;
+  uint64_t stopword_dict_id_;
 };
 
 /**
@@ -103,7 +112,8 @@ public:
       : ObFTParserParamExport(),
         ngram_token_size_(NGRAM_TOKEN_SIZE),
         min_ngram_size_(NGRAM_TOKEN_SIZE),
-        max_ngram_size_(NGRAM_TOKEN_SIZE)
+        max_ngram_size_(NGRAM_TOKEN_SIZE),
+        tenant_id_(common::OB_INVALID_TENANT_ID)
   {
   }
   virtual ~ObFTParserParam() { reset(); }
@@ -112,7 +122,11 @@ public:
   {
     ObFTParserParamExport::reset();
     allocator_ = nullptr;
+    ik_param_ = ObFTIKParam();
     ngram_token_size_ = NGRAM_TOKEN_SIZE;
+    min_ngram_size_ = NGRAM_TOKEN_SIZE;
+    max_ngram_size_ = NGRAM_TOKEN_SIZE;
+    tenant_id_ = common::OB_INVALID_TENANT_ID;
   }
 
   INHERIT_TO_STRING_KV("base", ObFTParserParamExport, KP_(allocator), K_(ngram_token_size));
@@ -125,6 +139,7 @@ public:
   int64_t ngram_token_size_;
   int64_t min_ngram_size_;
   int64_t max_ngram_size_;
+  uint64_t tenant_id_;
 };
 
 class ObITokenIterator

--- a/src/rootserver/ob_ddl_operator.cpp
+++ b/src/rootserver/ob_ddl_operator.cpp
@@ -2374,6 +2374,11 @@ int ObDDLOperator::alter_table_create_index(const ObTableSchema &new_table_schem
         }
       }
     }
+    if (OB_SUCC(ret) && index_schema.is_fts_index_aux()
+        && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+               index_schema, trans))) {
+      LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(index_schema));
+    }
   }
   return ret;
 }
@@ -4212,7 +4217,13 @@ int ObDDLOperator::drop_table(
 {
   int ret = OB_SUCCESS;
   bool tmp = false;
-  if (OB_FAIL(ObDependencyDDLHelper::modify_dep_obj_status(trans, table_schema.get_table_id(),
+  if (!is_drop_db && table_schema.is_fulltext_dict()
+      && OB_FAIL(ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+             table_schema.get_table_id(), trans))) {
+    if (OB_OP_NOT_ALLOW != ret) {
+      LOG_WARN("fail to check dictionary table dependencies", K(ret), K(table_schema));
+    }
+  } else if (OB_FAIL(ObDependencyDDLHelper::modify_dep_obj_status(trans, table_schema.get_table_id(),
                                                       *this, schema_service_))) {
     LOG_WARN("failed to modify obj status", K(ret));
   } else if (OB_FAIL(drop_table_for_not_dropped_schema(
@@ -4227,6 +4238,13 @@ int ObDDLOperator::drop_table(
                       ObObjectType::VIEW))) {
     LOG_WARN("failed to delete_schema_object_dependency", K(ret), K(1UL),
     K(table_schema.get_table_id()));
+  } else if (table_schema.is_fts_index_aux()
+             && OB_FAIL(ObDependencyInfo::delete_schema_object_dependency(
+                    trans,
+                    table_schema.get_table_id(),
+                    table_schema.get_schema_version(),
+                    ObObjectType::INDEX))) {
+    LOG_WARN("fail to delete fulltext dictionary dependencies", K(ret), K(table_schema));
   }
 
   if (OB_FAIL(ret)) {
@@ -4434,6 +4452,12 @@ int ObDDLOperator::drop_table_to_recyclebin(const ObTableSchema &table_schema,
   } else if (OB_UNLIKELY(table_schema.get_table_type() == MATERIALIZED_VIEW_LOG)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("materialized view log should not come to recyclebin", KR(ret));
+  } else if (table_schema.is_fulltext_dict()
+             && OB_FAIL(ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+                    table_schema.get_table_id(), trans))) {
+    if (OB_OP_NOT_ALLOW != ret) {
+      LOG_WARN("fail to check dictionary table dependencies", K(ret), K(table_schema));
+    }
   } else if (OB_ISNULL(schema_service_impl)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_ERROR("schema_service_impl must not null", K(ret));

--- a/src/rootserver/ob_ddl_service.cpp
+++ b/src/rootserver/ob_ddl_service.cpp
@@ -2029,6 +2029,10 @@ int ObDDLService::create_tables_in_trans(const bool if_not_exist,
                                                      0 == i ? &tmp_ddl_stmt_str : NULL,
                                                      i == table_schemas.count() - 1))) {
           LOG_WARN("failed to create table schema, ", K(ret));
+        } else if (table_schema.is_fts_index_aux()
+                   && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+                          table_schema, trans))) {
+          LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(table_schema));
         } else if (OB_FAIL(ddl_operator.insert_temp_table_info(trans, table_schema))) {
           LOG_WARN("failed to insert_temp_table_info!", K(ret));
         } else if (table_schema.is_view_table() && dep_infos != nullptr && 0 == i) {

--- a/src/rootserver/parallel_ddl/ob_create_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_create_table_helper.cpp
@@ -1142,6 +1142,15 @@ int ObCreateTableHelper::operate_schemas_() {
   } else if (OB_FAIL(inner_create_table_(&arg_.ddl_stmt_str_,
                                          replace_mock_fk_parent_table_id_))) {
     LOG_WARN("fail create table", KR(ret));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < new_tables_.count(); ++i) {
+      const ObTableSchema &table_schema = new_tables_.at(i);
+      if (table_schema.is_fts_index_aux()
+          && OB_FAIL(ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+                 table_schema, get_trans_()))) {
+        LOG_WARN("fail to record fulltext dictionary dependencies", KR(ret), K(table_schema));
+      }
+    }
   }
   return ret;
 }

--- a/src/rootserver/parallel_ddl/ob_drop_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_drop_table_helper.cpp
@@ -22,7 +22,9 @@
 #include "rootserver/ob_tablet_drop.h"
 #include "share/ob_autoincrement_service.h"
 #include "share/ob_rpc_struct.h"
+#include "share/schema/ob_dependency_info.h"
 #include "share/schema/ob_table_sql_service.h"
+#include "sql/resolver/ddl/ob_fts_index_builder_util.h"
 #include "storage/tablelock/ob_lock_inner_connection_util.h"
 
 using namespace oceanbase::rootserver;
@@ -176,6 +178,12 @@ int ObDropTableHelper::check_legitimacy_()
         ret = OB_NOT_SUPPORTED;
         LOG_WARN("drop table required by materialized view is not supported", KR(ret));
         LOG_USER_ERROR(OB_NOT_SUPPORTED, "drop table required by materialized view is");
+      } else if (table_schema->is_fulltext_dict()
+                 && OB_FAIL(oceanbase::share::ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+                        table_schema->get_table_id(), get_trans_()))) {
+        if (OB_OP_NOT_ALLOW != ret) {
+          LOG_WARN("fail to check dictionary table dependencies", KR(ret), KPC(table_schema));
+        }
       }
     }
   }
@@ -1411,6 +1419,13 @@ int ObDropTableHelper::drop_table_(const ObTableSchema &table_schema, const ObSt
       LOG_WARN("fail to sync version for cascade tables", KR(ret));
     } else if (OB_FAIL(sync_version_for_cascade_mock_fk_parent_table_(table_schema.get_depend_mock_fk_parent_table_ids()))) {
       LOG_WARN("fail to sync version for cascade mock fk parent table", KR(ret));
+    } else if (table_schema.is_fts_index_aux()
+               && OB_FAIL(ObDependencyInfo::delete_schema_object_dependency(
+                      get_trans_(),
+                      table_schema.get_table_id(),
+                      table_schema.get_schema_version(),
+                      ObObjectType::INDEX))) {
+      LOG_WARN("fail to delete fulltext dictionary dependencies", KR(ret), K(table_schema));
     }
 
     if (OB_SUCC(ret)) {

--- a/src/rootserver/parallel_ddl/ob_table_helper.cpp
+++ b/src/rootserver/parallel_ddl/ob_table_helper.cpp
@@ -647,6 +647,9 @@ int ObTableHelper::inner_generate_table_schema_(const ObCreateTableArg &arg, ObT
     ret = OB_NOT_SUPPORTED;
     LOG_WARN("not user tenant, create duplicate table not supported", KR(ret));
     LOG_USER_ERROR(OB_NOT_SUPPORTED, "not user tenant, create duplicate table");
+  } else if (OB_FAIL(ObFtsIndexBuilderUtil::check_fulltext_dict_schema(
+                         new_table, arg.index_arg_list_.count()))) {
+    LOG_WARN("fulltext dictionary table schema is invalid", KR(ret), K(new_table));
   }
 
   if (FALSE_IT(new_table.set_table_id(mock_table_id))) {

--- a/src/share/schema/ob_schema_struct.h
+++ b/src/share/schema/ob_schema_struct.h
@@ -185,6 +185,9 @@ static const uint64_t OB_MIN_ID  = 0;//used for lower_bound
 #define EXTERNAL_TABLE_AUTO_REFRESH_FLAG_OFFSET 2
 #define EXTERNAL_TABLE_AUTO_REFRESH_FLAG_BITS 2
 
+// Identifies a user table whose rows are used as a full-text dictionary.
+#define FULLTEXT_DICT_FLAG (INT64_C(1) << 4)
+
 // schema array size
 static const int64_t SCHEMA_SMALL_MALLOC_BLOCK_SIZE = 64;
 static const int64_t SCHEMA_MALLOC_BLOCK_SIZE = 128;

--- a/src/share/schema/ob_table_schema.h
+++ b/src/share/schema/ob_table_schema.h
@@ -1413,6 +1413,7 @@ public:
   int set_external_properties(const common::ObString &format) { return deep_copy_str(format, external_properties_); }
   void set_external_table_auto_refresh(const int64_t flag) { table_flags_ |= (flag << EXTERNAL_TABLE_AUTO_REFRESH_FLAG_OFFSET); }
   inline void set_user_specified_partition_for_external_table() { table_flags_ |= EXTERNAL_TABLE_USER_SPECIFIED_PARTITION_FLAG; }
+  inline void set_fulltext_dict() { table_flags_ |= FULLTEXT_DICT_FLAG; }
   template<typename ColumnType>
   int add_column(const ColumnType &column);
   int delete_column(const common::ObString &column_name);
@@ -1581,6 +1582,7 @@ public:
   inline ObNameGeneratedType get_name_generated_type() const { return name_generated_type_; }
   bool is_sys_generated_name(bool check_unknown) const;
   inline bool is_user_specified_partition_for_external_table() const { return (table_flags_ & EXTERNAL_TABLE_USER_SPECIFIED_PARTITION_FLAG) != 0; }
+  inline bool is_fulltext_dict() const { return (table_flags_ & FULLTEXT_DICT_FLAG) != 0; }
   inline bool is_index_visible() const
   {
     return 0 == (index_attributes_set_ & ((uint64_t)(1) << INDEX_VISIBILITY));

--- a/src/sql/engine/cmd/ob_alter_system_executor.cpp
+++ b/src/sql/engine/cmd/ob_alter_system_executor.cpp
@@ -35,6 +35,12 @@
 #include "sql/engine/cmd/ob_timezone_importer.h"
 #include "sql/engine/cmd/ob_srs_importer.h"
 #include "share/ob_internal_table_change_notifier.h"
+#include "share/schema/ob_schema_getter_guard.h"
+#include "share/schema/ob_multi_version_schema_service.h"
+#include "storage/fts/ob_fts_plugin_helper.h"
+#include "storage/fts/dict/ob_ft_cache_container.h"
+#include "storage/fts/dict/ob_ft_dict_def.h"
+#include "storage/fts/dict/ob_ft_dict_hub.h"
 
 namespace oceanbase
 {
@@ -471,6 +477,64 @@ int ObRefreshMemStatExecutor::execute(ObExecContext &ctx, ObRefreshMemStatStmt &
   } else if (OB_FAIL(GCTX.root_service_->admin_refresh_memory_stat(
                          stmt.get_rpc_arg()))) {
     LOG_WARN("refresh memory stat failed", K(ret), "rpc_arg", stmt.get_rpc_arg());
+  }
+  return ret;
+}
+
+int ObRefreshFulltextDictExecutor::execute(ObExecContext &ctx,
+                                           ObRefreshFulltextDictStmt &stmt)
+{
+  int ret = OB_SUCCESS;
+  ObSQLSessionInfo *session = ctx.get_my_session();
+  share::schema::ObSchemaGetterGuard schema_guard;
+  const share::schema::ObTableSchema *table_schema = nullptr;
+  uint64_t table_id = OB_INVALID_ID;
+  storage::ObFTDictHub *dict_hub = nullptr;
+  ObArenaAllocator allocator("FTDictRefresh");
+  ObSqlString full_table_name;
+  if (OB_ISNULL(session) || OB_ISNULL(GCTX.schema_service_)) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("session or schema service is not initialized", K(ret), KP(session));
+  } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+    LOG_WARN("fail to get schema guard", K(ret));
+  } else if (OB_FAIL(schema_guard.get_table_id(
+                         stmt.get_database_name(),
+                         stmt.get_table_name(),
+                         false,
+                         share::schema::ObSchemaGetterGuard::ALL_NON_HIDDEN_TYPES,
+                         table_id))) {
+    LOG_WARN("fail to resolve dictionary table", K(ret), K(stmt));
+  } else if (OB_INVALID_ID == table_id) {
+    ret = OB_ERR_UNKNOWN_TABLE;
+    LOG_USER_ERROR(OB_ERR_UNKNOWN_TABLE,
+                   stmt.get_table_name().length(), stmt.get_table_name().ptr(),
+                   stmt.get_database_name().length(), stmt.get_database_name().ptr());
+  } else if (OB_FAIL(schema_guard.get_table_schema(table_id, table_schema))) {
+    LOG_WARN("fail to get dictionary table schema", K(ret), K(table_id));
+  } else if (OB_ISNULL(table_schema) || !table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "refreshing a non-fulltext-dictionary table is");
+  } else if (OB_FAIL(full_table_name.append_fmt("%.*s.%.*s",
+                                                stmt.get_database_name().length(),
+                                                stmt.get_database_name().ptr(),
+                                                stmt.get_table_name().length(),
+                                                stmt.get_table_name().ptr()))) {
+    LOG_WARN("fail to construct dictionary table name", K(ret));
+  } else if (OB_FAIL(storage::ObFTParsePluginData::instance().get_dict_hub(dict_hub))) {
+    LOG_WARN("fail to get fulltext dictionary hub", K(ret));
+  } else {
+    storage::ObFTDictDesc desc(common::OB_SERVER_TENANT_ID,
+                               table_id,
+                               full_table_name.string(),
+                               storage::ObFTDictType::DICT_IK_MAIN,
+                               ObCharsetType::CHARSET_UTF8MB4,
+                               ObCollationType::CS_TYPE_UTF8MB4_BIN,
+                               false,
+                               true);
+    storage::ObFTCacheRangeContainer container(allocator);
+    if (OB_FAIL(dict_hub->refresh(desc, container))) {
+      LOG_WARN("fail to refresh fulltext dictionary", K(ret), K(desc));
+    }
   }
   return ret;
 }

--- a/src/sql/engine/cmd/ob_alter_system_executor.h
+++ b/src/sql/engine/cmd/ob_alter_system_executor.h
@@ -56,6 +56,8 @@ DEF_SIMPLE_EXECUTOR(ObAdminMerge);
 
 DEF_SIMPLE_EXECUTOR(ObRefreshMemStat);
 
+DEF_SIMPLE_EXECUTOR(ObRefreshFulltextDict);
+
 DEF_SIMPLE_EXECUTOR(ObWashMemFragmentation);
 
 DEF_SIMPLE_EXECUTOR(ObRefreshIOCalibraiton);

--- a/src/sql/engine/expr/ob_expr_tokenize.cpp
+++ b/src/sql/engine/expr/ob_expr_tokenize.cpp
@@ -28,6 +28,7 @@
 #include "object/ob_object.h"
 #include "plugin/sys/ob_plugin_helper.h"
 #include "sql/resolver/ddl/ob_fts_index_builder_util.h"
+#include "sql/session/ob_sql_session_info.h"
 #include "share/ob_json_access_utils.h"
 #include "storage/fts/dict/ob_gen_dic_loader.h"
 #include "storage/fts/ob_fts_parser_property.h"
@@ -144,7 +145,9 @@ ObExprTokenize::TokenizeParam ::TokenizeParam()
 {
 }
 
-int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj)
+int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj,
+                                                    const ObString &database_name,
+                                                    const uint64_t tenant_id)
 {
   int ret = OB_SUCCESS;
   ObString str;
@@ -195,7 +198,8 @@ int ObExprTokenize::TokenizeParam::parse_json_param(const ObIJsonBase *obj)
       LOG_USER_ERROR(OB_INVALID_ARGUMENT, "parser arguments");
     } else {
       ObString json_str;
-      if (OB_FAIL(ObFTParserJsonProps::tokenize_array_to_props_json(allocator_, val, json_str))) {
+      if (OB_FAIL(ObFTParserJsonProps::tokenize_array_to_props_json(
+                      allocator_, val, database_name, tenant_id, json_str))) {
         LOG_WARN("Fail to tokenize array to props json", K(ret));
         ObSqlString message;
         message.append_fmt("format in %s form", ADDITIONAL_ARGS_STR);
@@ -227,6 +231,10 @@ int ObExprTokenize::parse_param(const ObExpr &expr,
   ObEvalCtx::TempAllocGuard tmp_alloc_g(ctx);
   
   MultimodeAlloctor temp_allocator(tmp_alloc_g.get_allocator(), expr.type_, ret);
+  ObSQLSessionInfo *session = ctx.exec_ctx_.get_my_session();
+  const uint64_t tenant_id = common::OB_SERVER_TENANT_ID;
+  const ObString database_name = OB_ISNULL(session)
+      ? ObString() : session->get_database_name();
 
   if (OB_UNLIKELY(expr.arg_cnt_ < 1 || expr.arg_cnt_ > 3)) {
     ret = OB_INVALID_ARGUMENT;
@@ -235,7 +243,8 @@ int ObExprTokenize::parse_param(const ObExpr &expr,
     LOG_WARN("Fail to parse fulltext.", K(ret));
   } else if (OB_FAIL(parse_parser_name(expr, ctx, param))) {
     LOG_WARN("Fail to parse parser params.", K(ret));
-  } else if (OB_FAIL(parse_parser_properties(expr, ctx, temp_allocator, param))) {
+  } else if (OB_FAIL(parse_parser_properties(
+                         expr, database_name, tenant_id, ctx, temp_allocator, param))) {
     LOG_WARN("Fail to parse parser params.", K(ret));
   } else if (OB_FAIL(param.reform_parser_properties(param.properties_))) {
     LOG_WARN("Fail to reform parser params.", K(ret));
@@ -378,6 +387,8 @@ int ObExprTokenize::parse_parser_name(const ObExpr &expr, ObEvalCtx &ctx, Tokeni
 }
 
 int ObExprTokenize::parse_parser_properties(const ObExpr &expr,
+                                            const ObString &database_name,
+                                            const uint64_t tenant_id,
                                             ObEvalCtx &ctx,
                                             MultimodeAlloctor &mm_alloc,
                                             TokenizeParam &param)
@@ -404,7 +415,7 @@ int ObExprTokenize::parse_parser_properties(const ObExpr &expr,
           } else if (ObJsonNodeType::J_OBJECT != (node->json_type())) {
             ret = OB_INVALID_ARGUMENT;
             LOG_WARN("Argument of json array invalid", K(ret));
-          } else if (OB_FAIL(param.parse_json_param(node))) {
+          } else if (OB_FAIL(param.parse_json_param(node, database_name, tenant_id))) {
             LOG_WARN("Failed to parse json object", K(ret));
           }
         } // for

--- a/src/sql/engine/expr/ob_expr_tokenize.h
+++ b/src/sql/engine/expr/ob_expr_tokenize.h
@@ -60,7 +60,9 @@ private:
   public:
     TokenizeParam();
 
-    int parse_json_param(const ObIJsonBase *obj);
+    int parse_json_param(const ObIJsonBase *obj,
+                         const ObString &database_name,
+                         const uint64_t tenant_id);
 
     // check and reform parser properties to standard format
     int reform_parser_properties(const ObString &properties);
@@ -89,6 +91,8 @@ private:
   static int parse_fulltext(const ObExpr &expr, ObEvalCtx &ctx, TokenizeParam &param);
   static int parse_parser_name(const ObExpr &expr, ObEvalCtx &ctx, TokenizeParam &param);
   static int parse_parser_properties(const ObExpr &expr,
+                                     const ObString &database_name,
+                                     const uint64_t tenant_id,
                                      ObEvalCtx &ctx,
                                      MultimodeAlloctor &mm_alloc,
                                      TokenizeParam &param);

--- a/src/sql/executor/ob_cmd_executor.cpp
+++ b/src/sql/executor/ob_cmd_executor.cpp
@@ -515,6 +515,10 @@ int ObCmdExecutor::execute(ObExecContext &ctx, ObICmd &cmd)
         DEFINE_EXECUTE_CMD(ObRefreshMemStatStmt, ObRefreshMemStatExecutor);
         break;
       }
+      case stmt::T_REFRESH_FULLTEXT_DICT: {
+        DEFINE_EXECUTE_CMD(ObRefreshFulltextDictStmt, ObRefreshFulltextDictExecutor);
+        break;
+      }
       case stmt::T_WASH_MEMORY_FRAGMENTATION: {
         DEFINE_EXECUTE_CMD(ObWashMemFragmentationStmt, ObWashMemFragmentationExecutor);
         break;

--- a/src/sql/parser/non_reserved_keywords_mysql_mode.c
+++ b/src/sql/parser/non_reserved_keywords_mysql_mode.c
@@ -250,6 +250,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"deterministic", DETERMINISTIC},
   {"dense_rank", DENSE_RANK},
   {"diagnostics", DIAGNOSTICS},
+  {"dict", DICT},
   {"dict_table", DICT_TABLE},
   {"diff", DIFF},
   {"disallow", DISALLOW},
@@ -1162,6 +1163,7 @@ static const NonReservedKeyword Mysql_none_reserved_keywords[] =
   {"INCONSISTENT", INCONSISTENT},
   {"INDIVIDUAL", INDIVIDUAL},
   {"hybrid_search", HYBRID_SEARCH},
+  {"fulltext_dict", FULLTEXT_DICT},
 };
 
 /** https://dev.mysql.com/doc/refman/5.7/en/sql-syntax-prepared-statements.html

--- a/src/sql/parser/ob_item_type.h
+++ b/src/sql/parser/ob_item_type.h
@@ -2881,6 +2881,8 @@ typedef enum ObItemType
   T_FORK_DATABASE = 4917,
   T_DIFF_TABLE = 4918,
   T_MERGE_TABLE = 4919,
+  T_FULLTEXT_DICT = 4920,
+  T_REFRESH_FULLTEXT_DICT = 4921,
   T_MAX //Attention: add a new type before T_MAX
 } ObItemType;
 

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -292,7 +292,7 @@ END_P SET_VAR DELIMITER
         CTXCAT CTX_ID CUBE CURDATE CURRENT STACKED CURTIME CURSOR_NAME CUME_DIST CYCLE CALC_PARTITION_ID CONNECT
 
         DAG DATA DATAFILE DATA_DISK_SIZE DATA_SOURCE DATA_TABLE_ID DATE DATE_ADD DATE_SUB DATETIME DAY DEALLOCATE DECRYPT
-        DEFAULT_AUTH DEFAULT_LOB_INROW_THRESHOLD DEFINER DELAY DELAY_KEY_WRITE DEPTH DES_KEY_FILE DENSE_RANK DESCRIPTION DESTINATION DIAGNOSTICS DICT_TABLE
+        DEFAULT_AUTH DEFAULT_LOB_INROW_THRESHOLD DEFINER DELAY DELAY_KEY_WRITE DEPTH DES_KEY_FILE DENSE_RANK DESCRIPTION DESTINATION DIAGNOSTICS DICT DICT_TABLE
         DIFF DIRECTORY DISABLE DISALLOW DISCARD DISK DISKGROUP DO DOT DUMP DUMPFILE DUPLICATE DUPLICATE_SCOPE DUPLICATE_READ_CONSISTENCY DYNAMIC
         DATABASE_ID DEFAULT_TABLEGROUP DISCONNECT DEMAND DELETE_INSERT DYNAMIC_PARTITION_POLICY
 
@@ -302,7 +302,7 @@ END_P SET_VAR DELIMITER
 
         FAIL FAILOVER FAST FAULTS FILE_BLOCK_SIZE FIELDS FILEX FINAL_COUNT FIRST FIRST_VALUE FIXED FLUSH FOLLOWER FORMAT
         FOUND FORK FREEZE FREQUENCY FUNCTION FOLLOWING FLASHBACK FULL FRAGMENTATION FROZEN FILE_ID FILTER
-        FIELD_OPTIONALLY_ENCLOSED_BY FIELD_DELIMITER FIELD_ENCLOSED_BY FILE_EXTENSION
+        FIELD_OPTIONALLY_ENCLOSED_BY FIELD_DELIMITER FIELD_ENCLOSED_BY FILE_EXTENSION FULLTEXT_DICT
 
         GENERAL GEOMETRY GEOMCOLLECTION GEOMETRYCOLLECTION GET_FORMAT GLOBAL GRANTS GRANULARITY GROUP_CONCAT GROUPING GTS
         GLOBAL_NAME GLOBAL_ALIAS
@@ -471,7 +471,7 @@ END_P SET_VAR DELIMITER
 %type <node> alter_column_behavior opt_set opt_position_column
 %type <node> alter_system_stmt alter_system_set_parameter_actions alter_system_settp_actions settp_option alter_system_set_parameter_action alter_system_reset_parameter_actions alter_system_reset_parameter_action
 %type <node> opt_comment opt_as
-%type <node> column_name relation_name relation_name_list opt_relation_name function_name column_label var_name relation_name_or_string row_format_option compression_name merge_engine_types
+%type <node> column_name relation_name relation_name_list opt_relation_name function_name column_label var_name relation_name_or_string refresh_fulltext_dict_dst row_format_option compression_name merge_engine_types
 %type <node> opt_hint_list hint_option select_with_opt_hint update_with_opt_hint delete_with_opt_hint hint_list_with_end global_hint transform_hint optimize_hint
 %type <node> create_index_stmt index_name sort_column_list sort_column_key opt_index_option_list opt_fulltext_index_option_list index_option fulltext_index_option opt_sort_column_key_length opt_index_using_algorithm index_using_algorithm visibility_option opt_constraint_name constraint_name create_with_opt_hint index_expr alter_with_opt_hint
 %type <node> opt_when check_state constraint_definition
@@ -6864,6 +6864,11 @@ TABLE_MODE opt_equal_mark STRING_VALUE
   (void)($2);
   malloc_non_terminal_node($$, result->malloc_pool_, T_TABLE_MODE, 1, $3);
 }
+| FULLTEXT_DICT opt_equal_mark STRING_VALUE
+{
+  (void)($2);
+  malloc_non_terminal_node($$, result->malloc_pool_, T_FULLTEXT_DICT, 1, $3);
+}
 | DUPLICATE_SCOPE opt_equal_mark STRING_VALUE
 {
   (void)($2);
@@ -7419,6 +7424,22 @@ relation_name
 | ALL
 {
   make_name_node($$, result->malloc_pool_, "all");
+}
+;
+
+refresh_fulltext_dict_dst:
+relation_name_or_string { $$ = $1; }
+| relation_name '.' relation_name
+{
+  malloc_non_terminal_node($$, result->malloc_pool_, T_RELATION_FACTOR, 2, $1, $3);
+  dup_node_string($3, $$, result->malloc_pool_);
+}
+| id_dot_id
+{
+  ParseNode *db_node = $1->children_[0];
+  ParseNode *tb_node = $1->children_[1];
+  malloc_non_terminal_node($$, result->malloc_pool_, T_RELATION_FACTOR, 2, db_node, tb_node);
+  dup_node_string(tb_node, $$, result->malloc_pool_);
 }
 ;
 
@@ -18457,6 +18478,12 @@ alter_with_opt_hint SYSTEM REFRESH IO CALIBRATION opt_storage_name opt_calibrati
   malloc_non_terminal_node($$, result->malloc_pool_, T_REFRESH_IO_CALIBRATION, 3, $6, $7, NULL);
 }
 |
+alter_with_opt_hint SYSTEM REFRESH FULLTEXT DICT refresh_fulltext_dict_dst
+{
+  (void)($1);
+  malloc_non_terminal_node($$, result->malloc_pool_, T_REFRESH_FULLTEXT_DICT, 1, $6);
+}
+|
 alter_with_opt_hint SYSTEM opt_set alter_system_set_parameter_actions
 {
   (void)($1);
@@ -22175,6 +22202,7 @@ ACCESS_INFO
 |       DESCRIPTION
 |       DEMAND
 |       DIAGNOSTICS
+|       DICT
 |       DICT_TABLE
 |       DIFF
 |       DIRECTORY
@@ -22265,6 +22293,7 @@ ACCESS_INFO
 |       FREQUENCY
 |       FUNCTION
 |       FULL %prec HIGHER_PARENS
+|       FULLTEXT_DICT
 |       GENERAL
 |       GEOMETRY
 |       GEOMCOLLECTION

--- a/src/sql/printer/ob_schema_printer.cpp
+++ b/src/sql/printer/ob_schema_printer.cpp
@@ -1516,6 +1516,12 @@ int ObSchemaPrinter::print_table_definition_table_options(const ObTableSchema &t
       SHARE_SCHEMA_LOG(WARN, "fail to print collate", K(ret), K(table_schema));
     }
   }
+  if (OB_SUCC(ret) && !strict_compat_ && !is_for_table_status && !is_index_tbl
+      && !is_no_table_options(sql_mode) && table_schema.is_fulltext_dict()) {
+    if (OB_FAIL(databuff_printf(buf, buf_len, pos, "FULLTEXT_DICT = 'Y' "))) {
+      SHARE_SCHEMA_LOG(WARN, "fail to print fulltext dictionary option", K(ret), K(table_schema));
+    }
+  }
   if (OB_SUCC(ret) && table_schema.is_fts_index()
       && !is_no_key_options(sql_mode) && !table_schema.get_parser_name_str().empty()) {
     if (OB_FAIL(ObFtsIndexSchemaPrinter::print_fts_parser_info(table_schema, strict_compat_, buf, buf_len, pos))) {

--- a/src/sql/resolver/cmd/ob_alter_system_resolver.cpp
+++ b/src/sql/resolver/cmd/ob_alter_system_resolver.cpp
@@ -1145,6 +1145,82 @@ int ObRefreshMemStatResolver::resolve(const ParseNode &parse_tree)
   return ret;
 }
 
+int ObRefreshFulltextDictResolver::resolve(const ParseNode &parse_tree)
+{
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(T_REFRESH_FULLTEXT_DICT != parse_tree.type_)
+      || OB_ISNULL(parse_tree.children_)
+      || parse_tree.num_child_ < 1
+      || OB_ISNULL(parse_tree.children_[0])) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid refresh fulltext dictionary parse tree", K(ret), K(parse_tree.type_));
+  } else {
+    ObRefreshFulltextDictStmt *stmt = create_stmt<ObRefreshFulltextDictStmt>();
+    const ParseNode *relation_node = parse_tree.children_[0];
+    ObString database_name;
+    ObString table_name;
+    if (OB_ISNULL(stmt)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else {
+      stmt_ = stmt;
+      if (T_RELATION_FACTOR == relation_node->type_) {
+        if (relation_node->num_child_ < 2
+            || OB_ISNULL(relation_node->children_[0])
+            || OB_ISNULL(relation_node->children_[1])) {
+          ret = OB_ERR_UNEXPECTED;
+        } else {
+          database_name.assign_ptr(relation_node->children_[0]->str_value_,
+                                   relation_node->children_[0]->str_len_);
+          table_name.assign_ptr(relation_node->children_[1]->str_value_,
+                                relation_node->children_[1]->str_len_);
+        }
+      } else if (T_VARCHAR == relation_node->type_ || T_CHAR == relation_node->type_) {
+        ObString full_name;
+        if (OB_FAIL(Util::resolve_string(relation_node, full_name))) {
+          LOG_WARN("fail to resolve dictionary table string", K(ret));
+        } else {
+          const char *dot = full_name.find('.');
+          if (OB_ISNULL(dot)) {
+            table_name = full_name;
+          } else {
+            database_name.assign_ptr(full_name.ptr(), static_cast<int32_t>(dot - full_name.ptr()));
+            table_name.assign_ptr(dot + 1,
+                static_cast<int32_t>(full_name.length() - (dot - full_name.ptr()) - 1));
+          }
+        }
+      } else if (T_IDENT == relation_node->type_) {
+        if (OB_FAIL(Util::resolve_relation_name(relation_node, table_name))) {
+          LOG_WARN("fail to resolve dictionary table identifier", K(ret));
+        }
+      } else {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected dictionary table node", K(ret), K(relation_node->type_));
+      }
+
+      if (OB_FAIL(ret)) {
+      } else if (database_name.empty()) {
+        if (OB_ISNULL(session_info_)) {
+          ret = OB_ERR_UNEXPECTED;
+        } else if (FALSE_IT(database_name = session_info_->get_database_name())) {
+        } else if (database_name.empty()) {
+          ret = OB_ERR_NO_DB_SELECTED;
+          LOG_USER_ERROR(OB_ERR_NO_DB_SELECTED);
+        }
+      }
+      if (OB_SUCC(ret)) {
+        if (database_name.empty() || table_name.empty() || OB_NOT_NULL(table_name.find('.'))) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name must be [database.]table");
+        } else {
+          stmt->set_database_name(database_name);
+          stmt->set_table_name(table_name);
+        }
+      }
+    }
+  }
+  return ret;
+}
+
 int ObWashMemFragmentationResolver::resolve(const ParseNode &parse_tree)
 {
   int ret = OB_SUCCESS;

--- a/src/sql/resolver/cmd/ob_alter_system_resolver.h
+++ b/src/sql/resolver/cmd/ob_alter_system_resolver.h
@@ -96,6 +96,8 @@ DEF_SIMPLE_CMD_RESOLVER(ObAdminMergeResolver);
 
 DEF_SIMPLE_CMD_RESOLVER(ObRefreshMemStatResolver);
 
+DEF_SIMPLE_CMD_RESOLVER(ObRefreshFulltextDictResolver);
+
 DEF_SIMPLE_CMD_RESOLVER(ObWashMemFragmentationResolver);
 
 DEF_SIMPLE_CMD_RESOLVER(ObRefreshIOCalibrationResolver);

--- a/src/sql/resolver/cmd/ob_alter_system_stmt.h
+++ b/src/sql/resolver/cmd/ob_alter_system_stmt.h
@@ -169,6 +169,26 @@ private:
   obcall::ObAdminRefreshMemStatArg rpc_arg_;
 };
 
+class ObRefreshFulltextDictStmt : public ObSystemCmdStmt
+{
+public:
+  ObRefreshFulltextDictStmt()
+      : ObSystemCmdStmt(stmt::T_REFRESH_FULLTEXT_DICT), database_name_(), table_name_()
+  {
+  }
+  virtual ~ObRefreshFulltextDictStmt() {}
+
+  const common::ObString &get_database_name() const { return database_name_; }
+  const common::ObString &get_table_name() const { return table_name_; }
+  void set_database_name(const common::ObString &database_name) { database_name_ = database_name; }
+  void set_table_name(const common::ObString &table_name) { table_name_ = table_name; }
+
+  TO_STRING_KV(N_STMT_TYPE, ((int)stmt_type_), K_(database_name), K_(table_name));
+private:
+  common::ObString database_name_;
+  common::ObString table_name_;
+};
+
 class ObWashMemFragmentationStmt : public ObSystemCmdStmt
 {
 public:

--- a/src/sql/resolver/ddl/ob_alter_table_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_alter_table_resolver.cpp
@@ -166,6 +166,10 @@ int ObAlterTableResolver::resolve(const ParseNode &parse_tree)
         } else if (1 == parse_tree.value_ && OB_ISNULL(index_schema_)) {
           ret = OB_ERR_UNEXPECTED;
           LOG_WARN("table schema is NULL", K(ret));
+        } else if (table_schema_->is_fulltext_dict()) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "alter fulltext dictionary table structure is");
+          LOG_WARN("alter fulltext dictionary table is not supported", K(ret), KPC(table_schema_));
         }
       }
     }

--- a/src/sql/resolver/ddl/ob_ddl_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_ddl_resolver.cpp
@@ -1602,9 +1602,13 @@ int ObDDLResolver::resolve_table_option(const ParseNode *option_node, const bool
         break;
       }
       case T_PARSER_PROPERTIES: {
-        if (OB_FAIL(ObFTParserResolverHelper::resolve_parser_properties(*option_node,
-                                                                               *allocator_,
-                                                                               parser_properties_))) {
+        if (OB_FAIL(ObFTParserResolverHelper::resolve_parser_properties(
+                database_name_,
+                *option_node,
+                common::OB_SERVER_TENANT_ID,
+                *allocator_,
+                schema_checker_,
+                parser_properties_))) {
           LOG_WARN("fail to resolve parser properties", K(ret));
         }
         break;
@@ -1732,6 +1736,29 @@ int ObDDLResolver::resolve_table_option(const ParseNode *option_node, const bool
               table_mode_.pk_exists_ = tbl_schema->get_table_mode_struct().pk_exists_;
               table_mode_.table_organization_mode_ = tbl_schema->get_table_mode_struct().table_organization_mode_;
             }
+          }
+        }
+        break;
+      }
+      case T_FULLTEXT_DICT: {
+        if (is_index_option) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "FULLTEXT_DICT in index option is");
+        } else if (OB_ISNULL(option_node->children_[0])) {
+          ret = OB_ERR_UNEXPECTED;
+          SQL_RESV_LOG(WARN, "option_node child is null", K(ret));
+        } else if (stmt::T_CREATE_TABLE != stmt_->get_stmt_type()) {
+          ret = OB_NOT_SUPPORTED;
+          LOG_USER_ERROR(OB_NOT_SUPPORTED, "FULLTEXT_DICT outside CREATE TABLE is");
+        } else {
+          const ObString flag(static_cast<int32_t>(option_node->children_[0]->str_len_),
+                              option_node->children_[0]->str_value_);
+          if (0 != flag.case_compare("Y")) {
+            ret = OB_INVALID_ARGUMENT;
+            LOG_USER_ERROR(OB_INVALID_ARGUMENT, "FULLTEXT_DICT only accepts 'Y'");
+          } else {
+            ObCreateTableStmt *create_table_stmt = static_cast<ObCreateTableStmt *>(stmt_);
+            create_table_stmt->get_create_table_arg().schema_.set_fulltext_dict();
           }
         }
         break;
@@ -6847,6 +6874,10 @@ int ObDDLResolver::generate_global_index_schema(
     ObTableType table_type = table_schema->get_table_type();
     LOG_WARN("Not support to create index on non-normal table", K(ret), K(table_type),
              "arg", crt_idx_stmt->get_create_index_arg());
+  } else if (table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "create index on fulltext dictionary table is");
+    LOG_WARN("create index on fulltext dictionary table is not supported", K(ret), KPC(table_schema));
   } else {
     ObArray<ObColumnSchemaV2 *> gen_columns;
     ObCreateIndexArg &create_index_arg = crt_idx_stmt->get_create_index_arg();

--- a/src/sql/resolver/ddl/ob_fts_index_builder_util.cpp
+++ b/src/sql/resolver/ddl/ob_fts_index_builder_util.cpp
@@ -24,7 +24,11 @@
 #include "share/ob_server_struct.h"
 #include "rootserver/ob_root_service.h"
 #include "plugin/sys/ob_plugin_helper.h"
+#include "share/schema/ob_dependency_info.h"
 #include "share/schema/ob_schema_utils.h"  // relocated-definition owner
+#include "storage/fts/dict/ob_ft_dict_def.h"
+#include "storage/fts/ob_fts_parser_property.h"
+#include "storage/fts/ob_fts_plugin_helper.h"
 
 namespace oceanbase
 {
@@ -34,6 +38,48 @@ using namespace share::schema;
 
 namespace share
 {
+
+int ObFtsIndexBuilderUtil::check_fulltext_dict_schema(
+    const share::schema::ObTableSchema &table_schema,
+    const int64_t inline_index_count)
+{
+  int ret = OB_SUCCESS;
+  if (!table_schema.is_fulltext_dict()) {
+  } else if (table_schema.is_heap_organized_table()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "heap organization for fulltext dictionary table is");
+  } else if (inline_index_count > 0) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "inline index on fulltext dictionary table is");
+  } else if (table_schema.is_partitioned_table()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "partitioning fulltext dictionary table is");
+  } else if (1 != table_schema.get_column_count()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table must contain exactly one column");
+  } else {
+    const share::schema::ObColumnSchemaV2 *word_column = table_schema.get_column_schema("word");
+    if (OB_ISNULL(word_column)) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table must contain column 'word'");
+    } else if (!word_column->is_rowkey_column()
+               || 1 != table_schema.get_rowkey_column_num()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "column 'word' must be the only primary key column");
+    } else if (ObVarcharType != word_column->get_data_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "column 'word' must be varchar");
+    } else if (CHARSET_UTF8MB4 != word_column->get_charset_type()) {
+      ret = OB_NOT_SUPPORTED;
+      LOG_USER_ERROR(OB_NOT_SUPPORTED, "fulltext dictionary table charset must be utf8mb4");
+    } else if (word_column->get_accuracy().get_length() < 1
+               || word_column->get_accuracy().get_length() > 500) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_USER_ERROR(OB_INVALID_ARGUMENT, "column 'word' varchar length must be in [1, 500]");
+    }
+  }
+  return ret;
+}
 namespace
 {
 bool get_function_args(const ObString &expr_string,
@@ -2199,6 +2245,122 @@ int ObFtsIndexBuilderUtil::try_load_and_lock_dictionary_tables(
           LOG_WARN("fail to lock all dictionaries", K(ret), K(1UL), K(dic_loader_handle));
         }
       }
+    }
+  }
+  return ret;
+}
+
+namespace
+{
+typedef int (storage::ObFTParserJsonProps::*DictTableIdGetter)(uint64_t &) const;
+
+int append_fts_dict_dependency(const storage::ObFTParserJsonProps &properties,
+                               const ObTableSchema &index_schema,
+                               const storage::ObFTDictType dict_type,
+                               DictTableIdGetter getter,
+                               ObIArray<ObDependencyInfo> &dependencies)
+{
+  int ret = OB_SUCCESS;
+  uint64_t dict_table_id = OB_INVALID_ID;
+  if (OB_FAIL((properties.*getter)(dict_table_id))) {
+    if (OB_SEARCH_NOT_FOUND == ret) {
+      ret = OB_SUCCESS;
+    } else {
+      LOG_WARN("fail to get dictionary table id from parser properties", K(ret), K(dict_type));
+    }
+  } else if (is_inner_table(dict_table_id)) {
+    // Built-in dictionaries are immutable inner tables and need no dependency row.
+  } else {
+    ObDependencyInfo dependency;
+    dependency.set_dep_obj_type(ObObjectType::INDEX);
+    dependency.set_ref_obj_id(dict_table_id);
+    dependency.set_ref_obj_type(ObObjectType::TABLE);
+    dependency.set_property(static_cast<uint64_t>(dict_type));
+    dependency.set_order(dependencies.count());
+    if (OB_FAIL(dependencies.push_back(dependency))) {
+      LOG_WARN("fail to append dictionary table dependency", K(ret), K(dict_table_id));
+    }
+  }
+  return ret;
+}
+} // namespace
+
+int ObFtsIndexBuilderUtil::record_fts_dict_table_dependencies(
+    const ObTableSchema &index_schema,
+    ObMySQLTransaction &trans)
+{
+  int ret = OB_SUCCESS;
+  storage::ObFTParser parser;
+  storage::ObFTParserJsonProps properties;
+  ObArray<ObDependencyInfo> dependencies;
+  const ObString &parser_name = index_schema.get_parser_name();
+  const ObString &parser_properties = index_schema.get_parser_property_str();
+
+  if (!index_schema.is_fts_index_aux() || parser_name.empty() || parser_properties.empty()) {
+  } else if (OB_FAIL(parser.parse_from_str(parser_name.ptr(), parser_name.length()))) {
+    LOG_WARN("fail to parse fulltext parser name", K(ret), K(parser_name));
+  } else if (!parser.is_ik()) {
+  } else if (OB_FAIL(properties.init())) {
+    LOG_WARN("fail to initialize parser properties", K(ret));
+  } else if (OB_FAIL(properties.parse_from_valid_str(parser_properties))) {
+    LOG_WARN("fail to parse fulltext parser properties", K(ret), K(parser_properties));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_MAIN,
+                 &storage::ObFTParserJsonProps::config_get_dict_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append main dictionary dependency", K(ret));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_QUAN,
+                 &storage::ObFTParserJsonProps::config_get_quantifier_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append quantifier dictionary dependency", K(ret));
+  } else if (OB_FAIL(append_fts_dict_dependency(
+                 properties,
+                 index_schema,
+                 storage::ObFTDictType::DICT_IK_STOP,
+                 &storage::ObFTParserJsonProps::config_get_stopword_table_id,
+                 dependencies))) {
+    LOG_WARN("fail to append stopword dictionary dependency", K(ret));
+  } else if (!dependencies.empty()
+             && OB_FAIL(ObDependencyInfo::insert_dependency_infos(
+                    trans,
+                    dependencies,
+                    index_schema.get_table_id(),
+                    index_schema.get_schema_version(),
+                    index_schema.get_table_id()))) {
+    LOG_WARN("fail to record fulltext dictionary dependencies", K(ret), K(index_schema));
+  }
+  return ret;
+}
+
+int ObFtsIndexBuilderUtil::check_can_drop_dict_table(
+    const uint64_t dict_table_id,
+    ObMySQLTransaction &trans)
+{
+  int ret = OB_SUCCESS;
+  ObArray<ObDependencyInfo> dependencies;
+  bool is_in_use = false;
+  if (OB_INVALID_ID == dict_table_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table id", K(ret), K(dict_table_id));
+  } else if (OB_FAIL(ObDependencyInfo::collect_dep_infos(dict_table_id, trans, dependencies))) {
+    LOG_WARN("fail to collect dictionary table dependencies", K(ret), K(dict_table_id));
+  } else {
+    for (int64_t i = 0; !is_in_use && i < dependencies.count(); ++i) {
+      const ObDependencyInfo &dependency = dependencies.at(i);
+      is_in_use = ObObjectType::INDEX == dependency.get_dep_obj_type()
+                  && ObObjectType::TABLE == dependency.get_ref_obj_type()
+                  && dict_table_id == dependency.get_ref_obj_id();
+    }
+    if (is_in_use) {
+      ret = OB_OP_NOT_ALLOW;
+      LOG_WARN("cannot drop a fulltext dictionary table in use", K(ret), K(dict_table_id));
+      LOG_USER_ERROR(OB_OP_NOT_ALLOW,
+                     "drop fulltext dictionary table that is being used by fulltext index");
     }
   }
   return ret;

--- a/src/sql/resolver/ddl/ob_fts_index_builder_util.h
+++ b/src/sql/resolver/ddl/ob_fts_index_builder_util.h
@@ -74,6 +74,9 @@ public:
   // Check if we can use rowkey instead of doc id.
   // if we want to add more types, make this one condition of them.
   static int determine_docid_type(const ObTableSchema &table_schema, ObDocIDType &doc_id_type);
+  static int check_fulltext_dict_schema(
+      const share::schema::ObTableSchema &table_schema,
+      const int64_t inline_index_count);
   static int check_need_doc_id(
       const ObTableSchema &table_schema,
       bool &need_doc_id);
@@ -154,6 +157,12 @@ public:
       bool &need_to_load_dic);
   static int try_load_and_lock_dictionary_tables(
       const ObTableSchema &index_schema,
+      ObMySQLTransaction &trans);
+  static int record_fts_dict_table_dependencies(
+      const ObTableSchema &index_schema,
+      ObMySQLTransaction &trans);
+  static int check_can_drop_dict_table(
+      const uint64_t dict_table_id,
       ObMySQLTransaction &trans);
   static int try_load_dictionary_for_all_tenants();
   static int check_supportability_for_loader_key(const ObString &parser_name,

--- a/src/sql/resolver/ddl/ob_fts_parser_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_fts_parser_resolver.cpp
@@ -16,6 +16,8 @@
 
 #include "storage/fts/ob_fts_literal.h"
 #include "storage/fts/ob_fts_parser_property.h"
+#include "lib/string/ob_sql_string.h"
+#include "sql/resolver/ob_schema_checker.h"
 #define USING_LOG_PREFIX STORAGE_FTS
 
 #include "sql/resolver/ddl/ob_fts_parser_resolver.h"
@@ -25,13 +27,88 @@ namespace oceanbase
 namespace sql
 {
 
-int ObFTParserResolverHelper::resolve_parser_properties(
-    const ParseNode &parse_tree,
+int ObFTParserResolverHelper::resolve_dict_table_name_and_id(
+    const common::ObString &index_database_name,
+    const common::ObString &table_name,
+    const uint64_t tenant_id,
+    share::schema::ObSchemaGetterGuard &schema_guard,
     common::ObIAllocator &allocator,
+    uint64_t &table_id,
+    common::ObString &full_table_name)
+{
+  int ret = OB_SUCCESS;
+  ObString database_name;
+  ObString parsed_table_name;
+  table_id = OB_INVALID_ID;
+  full_table_name.reset();
+  const char *dot = table_name.find('.');
+  if (table_name.empty() || OB_INVALID_TENANT_ID == tenant_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table argument", K(ret), K(table_name), K(tenant_id));
+  } else if (OB_NOT_NULL(dot)) {
+    database_name.assign_ptr(table_name.ptr(), static_cast<int32_t>(dot - table_name.ptr()));
+    parsed_table_name.assign_ptr(dot + 1,
+        static_cast<int32_t>(table_name.length() - (dot - table_name.ptr()) - 1));
+    if (database_name.empty() || parsed_table_name.empty()
+        || OB_NOT_NULL(parsed_table_name.find('.'))) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name must be [database.]table");
+    }
+  } else if (index_database_name.empty()) {
+    ret = OB_ERR_NO_DB_SELECTED;
+    LOG_USER_ERROR(OB_ERR_NO_DB_SELECTED);
+  } else {
+    database_name = index_database_name;
+    parsed_table_name = table_name;
+  }
+
+  const share::schema::ObTableSchema *table_schema = nullptr;
+  if (OB_FAIL(ret)) {
+  } else if (OB_FAIL(schema_guard.get_table_id(database_name,
+                                               parsed_table_name,
+                                               false,
+                                               share::schema::ObSchemaGetterGuard::ALL_NON_HIDDEN_TYPES,
+                                               table_id))) {
+    LOG_WARN("fail to resolve dictionary table id", K(ret), K(database_name), K(parsed_table_name));
+  } else if (OB_INVALID_ID == table_id) {
+    ret = OB_ERR_UNKNOWN_TABLE;
+    LOG_USER_ERROR(OB_ERR_UNKNOWN_TABLE,
+                   parsed_table_name.length(), parsed_table_name.ptr(),
+                   database_name.length(), database_name.ptr());
+  } else if (OB_FAIL(schema_guard.get_table_schema(table_id, table_schema))) {
+    LOG_WARN("fail to get dictionary table schema", K(ret), K(table_id));
+  } else if (OB_ISNULL(table_schema)) {
+    ret = OB_TABLE_NOT_EXIST;
+  } else if (!table_schema->is_fulltext_dict()) {
+    ret = OB_NOT_SUPPORTED;
+    LOG_USER_ERROR(OB_NOT_SUPPORTED, "using a non-fulltext-dictionary table as dictionary is");
+  } else {
+    const int64_t buffer_size = database_name.length() + parsed_table_name.length() + 2;
+    char *buffer = static_cast<char *>(allocator.alloc(buffer_size));
+    int64_t pos = 0;
+    if (OB_ISNULL(buffer)) {
+      ret = OB_ALLOCATE_MEMORY_FAILED;
+    } else if (OB_FAIL(databuff_printf(buffer, buffer_size, pos, "%.*s.%.*s",
+                                      database_name.length(), database_name.ptr(),
+                                      parsed_table_name.length(), parsed_table_name.ptr()))) {
+      LOG_WARN("fail to construct dictionary table name", K(ret));
+    } else {
+      full_table_name.assign_ptr(buffer, static_cast<int32_t>(pos));
+    }
+  }
+  return ret;
+}
+
+int ObFTParserResolverHelper::resolve_parser_properties(
+    const common::ObString &index_database_name,
+    const ParseNode &parse_tree,
+    const uint64_t tenant_id,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker *schema_checker,
     common::ObString &parser_property)
 {
   int ret = OB_SUCCESS;
-  if (OB_UNLIKELY(parse_tree.num_child_ <= 0)) {
+  if (OB_UNLIKELY(parse_tree.num_child_ <= 0) || OB_ISNULL(schema_checker)) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid argument, parser properties is empty", K(ret), K(parse_tree.num_child_));
   } else {
@@ -44,7 +121,12 @@ int ObFTParserResolverHelper::resolve_parser_properties(
       if (OB_ISNULL(parse_tree.children_[i])) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("option_node child is nullptr", K(ret));
-      } else if (OB_FAIL(resolve_fts_index_parser_properties(parse_tree.children_[i], property))) {
+      } else if (OB_FAIL(resolve_fts_index_parser_properties(index_database_name,
+                                                             parse_tree.children_[i],
+                                                             tenant_id,
+                                                             property,
+                                                             allocator,
+                                                             *schema_checker))) {
         LOG_WARN("fail to resolve fts index parser properties", K(ret));
       }
     }
@@ -57,8 +139,12 @@ int ObFTParserResolverHelper::resolve_parser_properties(
 }
 
 int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
+    const common::ObString &index_database_name,
     const ParseNode *node,
-    storage::ObFTParserJsonProps &property)
+    const uint64_t tenant_id,
+    storage::ObFTParserJsonProps &property,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker &schema_checker)
 {
   int ret = OB_SUCCESS;
   if (OB_ISNULL(node) || node->num_child_ != 1 || OB_ISNULL(node->children_[0])){
@@ -115,54 +201,24 @@ int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
         break;
       }
       case T_PARSER_STOPWORD_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the stopword table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_stopword_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set stopword table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_stopword_table,
+                                   &storage::ObFTParserJsonProps::config_set_stopword_table_id);
         break;
       }
       case T_PARSER_DICT_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the dict table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_dict_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set dict table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_dict_table,
+                                   &storage::ObFTParserJsonProps::config_set_dict_table_id);
         break;
       }
       case T_PARSER_QUANTIFIER_TABLE: {
-        if (OB_ISNULL(node->children_[0])) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("option_node child is nullptr", K(ret));
-        } else if (OB_UNLIKELY(node->children_[0]->str_len_ <= 0)) {
-          ret = OB_INVALID_ARGUMENT;
-          LOG_WARN("invalid argument", K(ret), K(node->children_[0]->str_len_));
-          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "the quanitfier table is empty");
-        } else {
-          int32_t str_len = static_cast<int32_t>(node->children_[0]->str_len_);
-          if (OB_FAIL(property.config_set_quantifier_table(
-                  common::ObString(str_len, node->children_[0]->str_value_)))) {
-            LOG_WARN("fail to set quantifier table", K(ret));
-          }
-        }
+        ret = resolve_table_config(index_database_name, node, tenant_id, property,
+                                   allocator, schema_checker,
+                                   &storage::ObFTParserJsonProps::config_set_quantifier_table,
+                                   &storage::ObFTParserJsonProps::config_set_quantifier_table_id);
         break;
       }
       case T_IK_MODE: {
@@ -230,6 +286,43 @@ int ObFTParserResolverHelper::resolve_fts_index_parser_properties(
         ret = OB_INVALID_ARGUMENT;
         LOG_WARN("invalid fts index parser properties option", K(ret), K(node->type_));
       }
+    }
+  }
+  return ret;
+}
+
+int ObFTParserResolverHelper::resolve_table_config(
+    const common::ObString &index_database_name,
+    const ParseNode *node,
+    const uint64_t tenant_id,
+    storage::ObFTParserJsonProps &property,
+    common::ObIAllocator &allocator,
+    ObSchemaChecker &schema_checker,
+    int (storage::ObFTParserJsonProps::*set_name)(const common::ObString &),
+    int (storage::ObFTParserJsonProps::*set_id)(const uint64_t))
+{
+  int ret = OB_SUCCESS;
+  uint64_t table_id = OB_INVALID_ID;
+  ObString full_table_name;
+  if (OB_ISNULL(node) || OB_ISNULL(node->children_) || OB_ISNULL(node->children_[0])
+      || node->children_[0]->str_len_ <= 0 || OB_ISNULL(schema_checker.get_schema_guard())) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table name is empty");
+  } else {
+    const ObString table_name(static_cast<int32_t>(node->children_[0]->str_len_),
+                              node->children_[0]->str_value_);
+    if (OB_FAIL(resolve_dict_table_name_and_id(index_database_name,
+                                               table_name,
+                                               tenant_id,
+                                               *schema_checker.get_schema_guard(),
+                                               allocator,
+                                               table_id,
+                                               full_table_name))) {
+      LOG_WARN("fail to resolve dictionary table", K(ret), K(table_name));
+    } else if (OB_FAIL((property.*set_name)(full_table_name))) {
+      LOG_WARN("fail to set dictionary table name", K(ret), K(full_table_name));
+    } else if (OB_FAIL((property.*set_id)(table_id))) {
+      LOG_WARN("fail to set dictionary table id", K(ret), K(table_id));
     }
   }
   return ret;

--- a/src/sql/resolver/ddl/ob_fts_parser_resolver.h
+++ b/src/sql/resolver/ddl/ob_fts_parser_resolver.h
@@ -20,11 +20,13 @@
 #include "sql/resolver/ddl/ob_ddl_resolver.h"
 #include "storage/fts/ob_fts_parser_property.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
+#include "share/schema/ob_schema_getter_guard.h"
 
 namespace oceanbase
 {
 namespace sql
 {
+class ObSchemaChecker;
 class ObFTParserResolverHelper final
 {
 public:
@@ -32,13 +34,39 @@ public:
   ~ObFTParserResolverHelper() = default;
 
   static int resolve_parser_properties(
+      const common::ObString &index_database_name,
       const ParseNode &parse_tree,
+      const uint64_t tenant_id,
       common::ObIAllocator &allocator,
+      ObSchemaChecker *schema_checker,
       common::ObString &parser_property);
 
+  static int resolve_dict_table_name_and_id(
+      const common::ObString &index_database_name,
+      const common::ObString &table_name,
+      const uint64_t tenant_id,
+      share::schema::ObSchemaGetterGuard &schema_guard,
+      common::ObIAllocator &allocator,
+      uint64_t &table_id,
+      common::ObString &full_table_name);
+
 private:
-  static int resolve_fts_index_parser_properties(const ParseNode *node,
-                                                 storage::ObFTParserJsonProps &property);
+  static int resolve_fts_index_parser_properties(
+      const common::ObString &index_database_name,
+      const ParseNode *node,
+      const uint64_t tenant_id,
+      storage::ObFTParserJsonProps &property,
+      common::ObIAllocator &allocator,
+      ObSchemaChecker &schema_checker);
+  static int resolve_table_config(
+      const common::ObString &index_database_name,
+      const ParseNode *node,
+      const uint64_t tenant_id,
+      storage::ObFTParserJsonProps &property,
+      common::ObIAllocator &allocator,
+      ObSchemaChecker &schema_checker,
+      int (storage::ObFTParserJsonProps::*set_name)(const common::ObString &),
+      int (storage::ObFTParserJsonProps::*set_id)(const uint64_t));
 };
 
 } // end namespace sql

--- a/src/sql/resolver/ob_resolver.cpp
+++ b/src/sql/resolver/ob_resolver.cpp
@@ -365,6 +365,10 @@ int ObResolver::resolve(IsPrepared if_prepared, const ParseNode &parse_tree, ObS
         REGISTER_STMT_RESOLVER(RefreshMemStat);
         break;
       }
+      case T_REFRESH_FULLTEXT_DICT: {
+        REGISTER_STMT_RESOLVER(RefreshFulltextDict);
+        break;
+      }
       case T_WASH_MEMORY_FRAGMENTATION: {
         REGISTER_STMT_RESOLVER(WashMemFragmentation);
         break;

--- a/src/sql/resolver/ob_stmt_type.h
+++ b/src/sql/resolver/ob_stmt_type.h
@@ -347,6 +347,7 @@ OB_STMT_TYPE_DEF_UNKNOWN_AT(T_LOCATION_UTILS_LIST, no_priv_needed, 390)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_LOCATION_UTILS, no_priv_needed, 391)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_DIFF_TABLE, get_dml_stmt_need_privs, 392)
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_MERGE_TABLE, get_merge_table_stmt_need_privs, 393)
+OB_STMT_TYPE_DEF_UNKNOWN_AT(T_REFRESH_FULLTEXT_DICT, get_sys_tenant_alter_system_priv, 394)
 
 OB_STMT_TYPE_DEF_UNKNOWN_AT(T_MAX, err_stmt_type_priv, 500)
 #endif

--- a/src/storage/fts/dict/ob_ft_cache.h
+++ b/src/storage/fts/dict/ob_ft_cache.h
@@ -36,10 +36,11 @@ namespace storage
 class ObDictCacheKey : public common::ObIKVCacheKey
 {
 public:
-  ObDictCacheKey(const uint64_t name,
-                 const ObFTDictType dict_type,
-                 int32_t range_id)
-      : name_(name), dict_type_(dict_type), range_id_(range_id)
+  ObDictCacheKey(const uint64_t tenant_id,
+                 const uint64_t table_id,
+                 const uint64_t generation,
+                 const int32_t range_id)
+      : tenant_id_(tenant_id), table_id_(table_id), generation_(generation), range_id_(range_id)
   {
   }
   ~ObDictCacheKey() override {}
@@ -48,14 +49,18 @@ public:
   {
     const ObDictCacheKey &other_key = reinterpret_cast<const ObDictCacheKey &>(other);
     return (&other == this)
-           || ((other_key.name_ == name_) && (other_key.dict_type_ == dict_type_));
+           || (other_key.tenant_id_ == tenant_id_
+               && other_key.table_id_ == table_id_
+               && other_key.generation_ == generation_
+               && other_key.range_id_ == range_id_);
   }
 
   uint64_t hash() const override
   {
     uint64_t hash_val = 0;
-    hash_val = murmurhash(&name_, sizeof(name_), hash_val);
-    hash_val = murmurhash(&dict_type_, sizeof(dict_type_), hash_val);
+    hash_val = murmurhash(&tenant_id_, sizeof(tenant_id_), hash_val);
+    hash_val = murmurhash(&table_id_, sizeof(table_id_), hash_val);
+    hash_val = murmurhash(&generation_, sizeof(generation_), hash_val);
     hash_val = murmurhash(&range_id_, sizeof(range_id_), hash_val);
     return hash_val;
   }
@@ -80,17 +85,18 @@ public:
       ret = OB_INVALID_ARGUMENT;
       CLOG_LOG(WARN, "invalid argument for ob dict cache", K(ret), K(buf_len), K(size()));
     } else {
-      ObDictCacheKey *new_key = new (buf) ObDictCacheKey(name_, dict_type_, range_id_);
+      ObDictCacheKey *new_key = new (buf) ObDictCacheKey(
+          tenant_id_, table_id_, generation_, range_id_);
       key = new_key;
     }
     return ret;
   }
 
-  TO_STRING_KV(K_(name), K_(dict_type), K_(range_id));
+  TO_STRING_KV(K_(tenant_id), K_(table_id), K_(generation), K_(range_id));
 private:
-  // to change to name
-  uint64_t name_; // when build dict
-  ObFTDictType dict_type_;
+  uint64_t tenant_id_;
+  uint64_t table_id_;
+  uint64_t generation_;
   int32_t range_id_;
 };
 

--- a/src/storage/fts/dict/ob_ft_cache_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_cache_dict.cpp
@@ -87,8 +87,8 @@ int ObFTCacheDict::make_and_fetch_cache_entry(const ObFTDictDesc &desc,
 {
   int ret = OB_SUCCESS;
   ObDictCache &cache = ObDictCache::get_instance();
-  uint64_t name = static_cast<uint64_t>(desc.type_);
-  const ObDictCacheKey put_key(name, desc.type_, range_id);
+  const ObDictCacheKey put_key(
+      desc.tenant_id_, desc.table_id_, desc.generation_, range_id);
   const ObDictCacheValue put_value(dat_buff);
   if (OB_FAIL(cache.put_and_fetch_dict(put_key, put_value, value, handle))) {
     LOG_WARN("Failed to put dict into kv cache", K(ret));

--- a/src/storage/fts/dict/ob_ft_dat_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_dat_dict.cpp
@@ -39,7 +39,7 @@ int ObFTDATBuilder<DATA_TYPE>::init(ObFTTrie<DATA_TYPE> &trie)
     ret = OB_INIT_TWICE;
     LOG_WARN("Builder has already inited", K(ret));
   } else {
-    size_t map_size = ObArrayHashMap::estimate_size(trie.node_num());
+    size_t map_size = ObFTArrayHashMap::estimate_size(trie.node_num());
     size_t array_size = trie.node_num() * 6; // by experience.
     size_t base_size = array_size * sizeof(int32_t);
     size_t check_size = base_size;
@@ -305,9 +305,9 @@ int ObFTDATReader<DATA_TYPE>::match_with_hit(const ObString &ft_char,
 template class ObFTDATBuilder<void>;
 template class ObFTDATReader<void>;
 
-ObArrayHashMap *ObFTDAT::get_map() { return reinterpret_cast<ObArrayHashMap *>(buff); }
+ObFTArrayHashMap *ObFTDAT::get_map() { return reinterpret_cast<ObFTArrayHashMap *>(buff); }
 
-int ObArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
+int ObFTArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
 {
   int ret = OB_ENTRY_NOT_EXIST;
   uint64_t hash = word.get_word().hash();
@@ -324,7 +324,7 @@ int ObArrayHashMap::find(const ObFTSingleWord &word, ObFTWordCode &code) const
   return ret;
 }
 
-int ObArrayHashMap::insert(const ObString &key, ObFTWordCode code)
+int ObFTArrayHashMap::insert(const ObString &key, ObFTWordCode code)
 {
   int ret = OB_SUCCESS;
   uint64_t hash = key.hash();
@@ -340,7 +340,7 @@ int ObArrayHashMap::insert(const ObString &key, ObFTWordCode code)
   return ret;
 }
 
-int ObArrayHashMap::init(size_t word_num)
+int ObFTArrayHashMap::init(size_t word_num)
 {
   int ret = OB_SUCCESS;
   size_t capacity = estimate_capacity(word_num);
@@ -353,14 +353,14 @@ int ObArrayHashMap::init(size_t word_num)
   return OB_SUCCESS;
 }
 
-size_t ObArrayHashMap::estimate_size(size_t word_num)
+size_t ObFTArrayHashMap::estimate_size(size_t word_num)
 {
   size_t capacity = estimate_capacity(word_num);
   size_t size = sizeof(Header) + capacity * sizeof(Entry);
   return size;
 }
 
-size_t ObArrayHashMap::estimate_capacity(size_t word_num)
+size_t ObFTArrayHashMap::estimate_capacity(size_t word_num)
 {
   constexpr size_t MIN_CAPACITY = 101;                   // prime
   size_t capacity = MAX(word_num * 4 / 3, MIN_CAPACITY); // 75%

--- a/src/storage/fts/dict/ob_ft_dat_dict.h
+++ b/src/storage/fts/dict/ob_ft_dat_dict.h
@@ -33,10 +33,10 @@ namespace oceanbase
 {
 namespace storage
 {
-/* @class ObArrayHashMap
+/* @class ObFTArrayHashMap
  * @description: a fixed size hash map, used to store words and their code.
  */
-class ObArrayHashMap final
+class ObFTArrayHashMap final
 {
 public:
   struct Entry
@@ -105,7 +105,7 @@ public:
   char buff[1] = {0};
 
 public:
-  ObArrayHashMap *get_map();
+  ObFTArrayHashMap *get_map();
 } __attribute__((packed));
 
 template <typename DataType>
@@ -150,7 +150,7 @@ private:
 private:
   common::ObIAllocator &alloc_;
   ObFTDAT *dat_;
-  ObArrayHashMap *map_;
+  ObFTArrayHashMap *map_;
 
   bool is_inited_;
   int32_t next_code_;

--- a/src/storage/fts/dict/ob_ft_dict_def.h
+++ b/src/storage/fts/dict/ob_ft_dict_def.h
@@ -64,15 +64,52 @@ public:
                const ObFTDictType type,
                const ObCharsetType charset,
                const ObCollationType coll_type)
-      : name_(name), type_(type), charset_(charset), coll_type_(coll_type)
+      : tenant_id_(1),
+        table_id_(static_cast<uint64_t>(type)),
+        table_name_(name),
+        type_(type),
+        charset_(charset),
+        coll_type_(coll_type),
+        generation_(0),
+        is_builtin_(true),
+        need_casedown_(false)
   {
   }
 
+  ObFTDictDesc(const uint64_t tenant_id,
+               const uint64_t table_id,
+               const ObString &table_name,
+               const ObFTDictType type,
+               const ObCharsetType charset,
+               const ObCollationType coll_type,
+               const bool is_builtin,
+               const bool need_casedown)
+      : tenant_id_(tenant_id),
+        table_id_(table_id),
+        table_name_(table_name),
+        type_(type),
+        charset_(charset),
+        coll_type_(coll_type),
+        generation_(0),
+        is_builtin_(is_builtin),
+        need_casedown_(need_casedown)
+  {
+  }
+
+  TO_STRING_KV(K_(tenant_id), K_(table_id), K_(table_name), K_(type),
+               K_(charset), K_(coll_type), K_(generation), K_(is_builtin),
+               K_(need_casedown));
+
 public:
-  ObString name_;
+  uint64_t tenant_id_;
+  uint64_t table_id_;
+  ObString table_name_;
   ObFTDictType type_;
   ObCharsetType charset_;
   ObCollationType coll_type_;
+  uint64_t generation_;
+  bool is_builtin_;
+  bool need_casedown_;
 };
 
 } //  namespace storage

--- a/src/storage/fts/dict/ob_ft_dict_hub.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_hub.cpp
@@ -45,13 +45,27 @@ int ObFTDictHub::init()
 int ObFTDictHub::destroy()
 {
   int ret = OB_SUCCESS;
+  dict_map_.destroy();
+  rw_dict_lock_.destroy();
   is_inited_ = false;
   return ret;
 }
 int ObFTDictHub::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container)
 {
+  return build_cache_internal(desc, container, false);
+}
+
+int ObFTDictHub::refresh(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container)
+{
+  return build_cache_internal(desc, container, true);
+}
+
+int ObFTDictHub::build_cache_internal(const ObFTDictDesc &desc,
+                                      ObFTCacheRangeContainer &container,
+                                      const bool force_refresh)
+{
   int ret = OB_SUCCESS;
-  ObFTDictInfoKey key(static_cast<uint64_t>(desc.type_));
+  ObFTDictInfoKey key(desc.tenant_id_, desc.table_id_);
   ObFTDictInfo info;
   container.reset();
 
@@ -61,28 +75,44 @@ int ObFTDictHub::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &
   } else {
     ObBucketHashWLockGuard guard(rw_dict_lock_, key.hash());
 
-    // try if valid with no recursive lock
-    if (OB_FAIL(get_dict_info(key, info))) {
-      if (OB_HASH_NOT_EXIST == ret) {
-        // dict not exist, make new one, by caller
-        ret = OB_ENTRY_NOT_EXIST;
+    int info_ret = get_dict_info(key, info);
+    if (OB_HASH_NOT_EXIST == info_ret) {
+      info_ret = OB_SUCCESS;
+    }
+    if (OB_SUCCESS != info_ret) {
+      ret = info_ret;
+      LOG_WARN("Failed to get dict info", K(ret), K(desc));
+    } else if (!force_refresh && info.generation_ > 0) {
+      ObFTDictDesc load_desc(desc);
+      load_desc.generation_ = info.generation_;
+      if (OB_FAIL(ObFTRangeDict::try_load_cache(
+                      load_desc, info.range_count_, container))) {
+        if (OB_ENTRY_NOT_EXIST == ret) {
+          ret = OB_SUCCESS;
+        } else {
+          LOG_WARN("Failed to load current dictionary cache", K(ret), K(load_desc));
+        }
       } else {
-        LOG_WARN("Failed to get dict info", K(ret));
-      }
-    } else if (OB_FAIL(ObFTRangeDict::try_load_cache(desc, info.range_count_, container))) {
-      if (OB_ENTRY_NOT_EXIST == ret) {
-      } else {
-        LOG_WARN("Failed to load cache", K(ret));
+        return OB_SUCCESS;
       }
     }
 
-    if (OB_FAIL(ret)) {
-      if (OB_ENTRY_NOT_EXIST == ret) {
-        if (OB_FAIL(ObFTRangeDict::build_cache_from_ik_dict(desc, container))) {
-          LOG_WARN("Failed to build cache", K(ret));
-        } else if (FALSE_IT(info.range_count_ = container.get_handles().size())) {
-        } else if (OB_FAIL(put_dict_info(key, info))) {
-          LOG_WARN("Failed to put dict info", K(ret));
+    if (OB_SUCC(ret)) {
+      ObFTDictDesc build_desc(desc);
+      build_desc.generation_ = info.generation_ + 1;
+      container.reset();
+      if (build_desc.is_builtin_) {
+        if (OB_FAIL(ObFTRangeDict::build_cache_from_ik_dict(build_desc, container))) {
+          LOG_WARN("Failed to build compiled dictionary cache", K(ret), K(build_desc));
+        }
+      } else if (OB_FAIL(ObFTRangeDict::build_cache(build_desc, container))) {
+        LOG_WARN("Failed to build custom dictionary cache", K(ret), K(build_desc));
+      }
+      if (OB_SUCC(ret)) {
+        info.generation_ = build_desc.generation_;
+        info.range_count_ = static_cast<int32_t>(container.get_handles().size());
+        if (OB_FAIL(put_dict_info(key, info))) {
+          LOG_WARN("Failed to publish dictionary cache generation", K(ret), K(build_desc));
         }
       }
     }
@@ -95,7 +125,7 @@ int ObFTDictHub::load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &c
   int ret = OB_SUCCESS;
   ObFTDictInfo info;
   container.reset();
-  ObFTDictInfoKey key(static_cast<uint64_t>(desc.type_));
+  ObFTDictInfoKey key(desc.tenant_id_, desc.table_id_);
   if (!is_inited_) {
     ret = OB_NOT_INIT;
     LOG_WARN("dict hub not init", K(ret));
@@ -112,11 +142,16 @@ int ObFTDictHub::load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &c
       }
     }
     if (OB_FAIL(ret)) {
-    } else if (OB_FAIL(ObFTRangeDict::try_load_cache(desc, info.range_count_, container))) {
+    } else {
+      ObFTDictDesc load_desc(desc);
+      load_desc.generation_ = info.generation_;
+      if (OB_FAIL(ObFTRangeDict::try_load_cache(
+                      load_desc, info.range_count_, container))) {
       if (OB_ENTRY_NOT_EXIST == ret) {
         // dict not exist, make new one, by caller
       } else {
         LOG_WARN("Failed to load cache", K(ret));
+      }
       }
     }
   }

--- a/src/storage/fts/dict/ob_ft_dict_hub.h
+++ b/src/storage/fts/dict/ob_ft_dict_hub.h
@@ -32,19 +32,12 @@ class ObFTDictInfo
 {
 public:
   ObFTDictInfo()
-      : name_(""),
-        type_(ObFTDictType::DICT_TYPE_INVALID),
-        charset_(CHARSET_INVALID),
-        version_(0),
-        range_count_(0)
+      : generation_(0), range_count_(0)
   {
   }
 
 public:
-  char name_[2048]; // for now
-  ObFTDictType type_;
-  ObCharsetType charset_;
-  int64_t version_; // in memory
+  uint64_t generation_;
   int32_t range_count_;
 };
 
@@ -52,11 +45,11 @@ struct ObFTDictInfoKey
 {
 public:
   ObFTDictInfoKey()
-      : type_(static_cast<uint64_t>(ObFTDictType::DICT_TYPE_INVALID))
+      : tenant_id_(OB_INVALID_TENANT_ID), table_id_(OB_INVALID_ID)
   {
-  } // default constructor
-  ObFTDictInfoKey(const uint64_t type)
-      : type_(type)
+  }
+  ObFTDictInfoKey(const uint64_t tenant_id, const uint64_t table_id)
+      : tenant_id_(tenant_id), table_id_(table_id)
   {
   }
   int hash(uint64_t &hash_value) const
@@ -69,27 +62,34 @@ public:
   uint64_t hash() const
   {
     uint64_t hash = 0;
-    hash = common::murmurhash(&type_, sizeof(int64_t), hash);
+    hash = common::murmurhash(&tenant_id_, sizeof(tenant_id_), hash);
+    hash = common::murmurhash(&table_id_, sizeof(table_id_), hash);
     return hash;
   }
 
   bool operator==(const ObFTDictInfoKey &other) const
   {
-    return type_ == other.type_ && true;
+    return tenant_id_ == other.tenant_id_ && table_id_ == other.table_id_;
   }
 
   int compare(const ObFTDictInfoKey &other) const
   {
     int ret = 0;
-    if (0 == ret) {
-      ret = type_ - other.type_;
+    if (tenant_id_ < other.tenant_id_) {
+      ret = -1;
+    } else if (tenant_id_ > other.tenant_id_) {
+      ret = 1;
+    } else if (table_id_ < other.table_id_) {
+      ret = -1;
+    } else if (table_id_ > other.table_id_) {
+      ret = 1;
     }
     return ret;
   }
 
 private:
-  uint64_t type_;
-  // name
+  uint64_t tenant_id_;
+  uint64_t table_id_;
 };
 
 class ObFTCacheRangeContainer;
@@ -107,7 +107,12 @@ public:
 
   int load_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
 
+  int refresh(const ObFTDictDesc &desc, ObFTCacheRangeContainer &container);
+
 private:
+  int build_cache_internal(const ObFTDictDesc &desc,
+                           ObFTCacheRangeContainer &container,
+                           const bool force_refresh);
   int get_dict_info(const ObFTDictInfoKey &key, ObFTDictInfo &info);
 
   int put_dict_info(const ObFTDictInfoKey &key, const ObFTDictInfo &info);

--- a/src/storage/fts/dict/ob_ft_dict_table_iter.cpp
+++ b/src/storage/fts/dict/ob_ft_dict_table_iter.cpp
@@ -30,7 +30,7 @@ namespace oceanbase
 namespace storage
 {
 ObFTDictTableIter::ObFTDictTableIter(ObISQLClient::ReadResult &result)
-    : ObIFTDictIterator(), is_inited_(false), res_(result)
+    : ObIFTDictIterator(), is_inited_(false), iter_end_(false), res_(result)
 {
 }
 
@@ -40,6 +40,8 @@ int ObFTDictTableIter::get_key(ObString &str)
   if (!IS_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("Not inited.", K(ret));
+  } else if (iter_end_) {
+    ret = OB_ITER_END;
   } else if (OB_FAIL(res_.get_result()->get_varchar("word", str))) {
     LOG_WARN("Failed to get varchar", K(ret));
   }
@@ -58,29 +60,50 @@ int ObFTDictTableIter::next()
   if (!IS_INIT) {
     ret = OB_NOT_INIT;
     LOG_WARN("Not inited.", K(ret));
+  } else if (iter_end_) {
+    ret = OB_ITER_END;
   } else if (OB_FAIL(res_.get_result()->next())) {
-    if (OB_ITER_END != ret) {
+    if (OB_ITER_END == ret) {
+      iter_end_ = true;
+    } else {
       LOG_WARN("Failed to get next row", K(ret));
     }
   }
   return ret;
 }
 
-int ObFTDictTableIter::init(const ObString &table_name)
+int ObFTDictTableIter::init(const ObFTDictDesc &desc)
 {
   int ret = OB_SUCCESS;
   common::ObMySQLProxy *sql_proxy = GCTX.sql_proxy_;
+  const char *dot = desc.table_name_.find('.');
 
   if (IS_INIT) {
     ret = OB_INIT_TWICE;
     LOG_WARN("Inited twice.", K(ret));
+  } else if (OB_ISNULL(sql_proxy) || OB_ISNULL(dot)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table descriptor", K(ret), K(desc), KP(sql_proxy));
   } else {
+    const ObString database_name(static_cast<int32_t>(dot - desc.table_name_.ptr()),
+                                 desc.table_name_.ptr());
+    const ObString table_name(static_cast<int32_t>(
+                                  desc.table_name_.length() - (dot - desc.table_name_.ptr()) - 1),
+                              dot + 1);
     SMART_VAR(ObSqlString, sql_string)
     {
-      if (OB_FAIL(sql_string.append("SELECT word FROM oceanbase."))) {
-        LOG_WARN("Failed to append sql", K(ret));
-      } else if (OB_FAIL(sql_string.append(table_name))) {
-        LOG_WARN("Failed to append sql", K(ret));
+      if (desc.need_casedown_) {
+        if (OB_FAIL(sql_string.append_fmt("SELECT DISTINCT LOWER(word) AS word FROM `%.*s`.`%.*s`",
+                                         database_name.length(), database_name.ptr(),
+                                         table_name.length(), table_name.ptr()))) {
+          LOG_WARN("Failed to append lowercase dictionary sql", K(ret));
+        }
+      } else if (OB_FAIL(sql_string.append_fmt("SELECT word FROM `%.*s`.`%.*s`",
+                                              database_name.length(), database_name.ptr(),
+                                              table_name.length(), table_name.ptr()))) {
+        LOG_WARN("Failed to append dictionary sql", K(ret));
+      }
+      if (OB_FAIL(ret)) {
       } else if (OB_FAIL(sql_string.append(" ORDER BY word"))) {
         LOG_WARN("Failed to append sql", K(ret));
       } else if (OB_FAIL(sql_proxy->read(res_, sql_string.ptr()))) {
@@ -94,10 +117,12 @@ int ObFTDictTableIter::init(const ObString &table_name)
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("Failed to get result", K(ret));
     } else if (OB_FAIL(res_.get_result()->next())) {
-      if (OB_ITER_END != ret) {
-        LOG_WARN("Failed to get next row", K(ret));
-      } else {
+      if (OB_ITER_END == ret) {
+        ret = OB_SUCCESS;
+        iter_end_ = true;
         is_inited_ = true;
+      } else {
+        LOG_WARN("Failed to get next row", K(ret));
       }
     } else {
       is_inited_ = true;
@@ -111,6 +136,7 @@ void ObFTDictTableIter::reset()
 {
   res_.close();
   is_inited_ = false;
+  iter_end_ = false;
 }
 
 } //  namespace storage

--- a/src/storage/fts/dict/ob_ft_dict_table_iter.h
+++ b/src/storage/fts/dict/ob_ft_dict_table_iter.h
@@ -19,6 +19,7 @@
 
 #include "common/mysqlclient/ob_isql_client.h"
 #include "storage/fts/dict/ob_ft_dict_iterator.h"
+#include "storage/fts/dict/ob_ft_dict_def.h"
 
 namespace oceanbase
 {
@@ -37,13 +38,14 @@ public:
   int next() override;
 
 public:
-  int init(const ObString &table_name);
+  int init(const ObFTDictDesc &desc);
 
 private:
   void reset();
 
 private:
   bool is_inited_;
+  bool iter_end_;
   ObISQLClient::ReadResult &res_;
 };
 

--- a/src/storage/fts/dict/ob_ft_range_dict.cpp
+++ b/src/storage/fts/dict/ob_ft_range_dict.cpp
@@ -465,35 +465,19 @@ int ObFTRangeDict::build_dict_from_cache(const ObFTCacheRangeContainer &range_co
 int ObFTRangeDict::build_cache(const ObFTDictDesc &desc, ObFTCacheRangeContainer &range_container)
 {
   int ret = OB_SUCCESS;
-
-  ObString table_name;
-  switch (desc.type_) {
-  case ObFTDictType::DICT_IK_MAIN: {
-    table_name = ObString(share::OB_FT_DICT_IK_UTF8_TNAME);
-  } break;
-  case ObFTDictType::DICT_IK_QUAN: {
-    table_name = ObString(share::OB_FT_QUANTIFIER_IK_UTF8_TNAME);
-  } break;
-  case ObFTDictType::DICT_IK_STOP: {
-    table_name = ObString(share::OB_FT_STOPWORD_IK_UTF8_TNAME);
-  } break;
-  default:
-    ret = OB_NOT_SUPPORTED;
-    LOG_WARN("Not supported dict type.", K(ret));
-  }
-
-  if (OB_SUCC(ret)) {
-    SMART_VAR(ObISQLClient::ReadResult, result)
-    {
-      ObFTDictTableIter iter_table(result);
-      if (OB_FAIL(iter_table.init(table_name))) {
-        LOG_WARN("Failed to init iterator.", K(ret));
-      } else if (OB_FAIL(ObFTRangeDict::build_ranges(desc, iter_table, range_container))) {
-        LOG_WARN("Failed to build ranges.", K(ret));
-      }
+  SMART_VAR(ObISQLClient::ReadResult, result)
+  {
+    ObFTDictTableIter iter_table(result);
+    if (desc.is_builtin_) {
+      ret = OB_INVALID_ARGUMENT;
+      LOG_WARN("built-in dictionary must use compiled data", K(ret), K(desc));
+    } else if (OB_FAIL(iter_table.init(desc))) {
+      LOG_WARN("Failed to init dictionary table iterator", K(ret), K(desc));
+    } else if (OB_FAIL(ObFTRangeDict::build_ranges_concurrently_thread_pool(
+                           desc, iter_table, range_container))) {
+      LOG_WARN("Failed to build dictionary table ranges", K(ret), K(desc));
     }
   }
-
   return ret;
 }
 
@@ -502,10 +486,8 @@ int ObFTRangeDict::try_load_cache(const ObFTDictDesc &desc,
                                   ObFTCacheRangeContainer &range_container)
 {
   int ret = OB_SUCCESS;
-  uint64_t name = static_cast<uint64_t>(desc.type_);
-
   for (int64_t i = 0; OB_SUCC(ret) && i < range_count; ++i) {
-    ObDictCacheKey key(name, desc.type_, i);
+    ObDictCacheKey key(desc.tenant_id_, desc.table_id_, desc.generation_, i);
     ObFTCacheRangeHandle *info = nullptr;
     if (OB_FAIL(range_container.fetch_info_for_dict(info))) {
       LOG_WARN("Failed to fetch info for dict.", K(ret));

--- a/src/storage/fts/ob_fts_literal.h
+++ b/src/storage/fts/ob_fts_literal.h
@@ -18,6 +18,7 @@
 #define _OCEANBASE_STORAGE_FTS_OB_FTS_LITERAL_H_
 
 #include <cstdint>
+#include "share/inner_table/ob_inner_table_schema_constants.h"
 namespace oceanbase
 {
 namespace storage
@@ -36,7 +37,12 @@ public:
   static constexpr const char *CONFIG_NAME_NGRAM_TOKEN_SIZE = "ngram_token_size";
   static constexpr const char *CONFIG_NAME_STOPWORD_TABLE = "stopword_table";
   static constexpr const char *CONFIG_NAME_DICT_TABLE = "dict_table";
-  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE = "quanitfier_table";
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE = "quantifier_table";
+  // Compatibility for parser properties written before the spelling was fixed.
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE_LEGACY = "quanitfier_table";
+  static constexpr const char *CONFIG_NAME_STOPWORD_TABLE_ID = "stopword_table_id";
+  static constexpr const char *CONFIG_NAME_DICT_TABLE_ID = "dict_table_id";
+  static constexpr const char *CONFIG_NAME_QUANTIFIER_TABLE_ID = "quantifier_table_id";
   static constexpr const char *CONFIG_NAME_IK_MODE = "ik_mode";
   static constexpr const char *CONFIG_NAME_MIN_NGRAM_SIZE = "min_ngram_size";
   static constexpr const char *CONFIG_NAME_MAX_NGRAM_SIZE = "max_ngram_size";

--- a/src/storage/fts/ob_fts_parser_property.cpp
+++ b/src/storage/fts/ob_fts_parser_property.cpp
@@ -27,6 +27,9 @@
 #include "lib/utility/ob_print_utils.h"
 #include "storage/fts/ob_fts_literal.h"
 #include "storage/fts/ob_fts_plugin_helper.h"
+#include "share/ob_server_struct.h"
+#include "share/schema/ob_multi_version_schema_service.h"
+#include "sql/resolver/ddl/ob_fts_parser_resolver.h"
 
 #define USING_LOG_PREFIX STORAGE_FTS
 
@@ -203,6 +206,42 @@ int ObFTParserJsonProps::config_set_quantifier_table(const ObString &str)
   }
 
   return ret;
+}
+
+int ObFTParserJsonProps::config_set_table_id(const char *config_name, const uint64_t table_id)
+{
+  int ret = OB_SUCCESS;
+  ObJsonUint *table_id_node = nullptr;
+  if (!IS_INIT) {
+    ret = OB_NOT_INIT;
+  } else if (OB_ISNULL(config_name) || OB_INVALID_ID == table_id) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid dictionary table id", K(ret), KP(config_name), K(table_id));
+  } else if (OB_ISNULL(table_id_node = OB_NEWx(ObJsonUint, &allocator_, table_id))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("fail to allocate dictionary table id node", K(ret), K(table_id));
+  } else if (OB_FAIL(root_->object_add(ObString(config_name), table_id_node))) {
+    LOG_WARN("fail to add dictionary table id", K(ret), KCSTRING(config_name), K(table_id));
+  }
+  if (OB_FAIL(ret)) {
+    OB_DELETEx(ObJsonUint, &allocator_, table_id_node);
+  }
+  return ret;
+}
+
+int ObFTParserJsonProps::config_set_stopword_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_set_dict_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_set_quantifier_table_id(const uint64_t table_id)
+{
+  return config_set_table_id(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID, table_id);
 }
 
 int ObFTParserJsonProps::config_set_ik_mode(const ObString &ik_mode)
@@ -458,20 +497,67 @@ int ObFTParserJsonProps::config_get_quantifier_table(ObString &str) const
     if (OB_FAIL(
             root_->get_object_value(ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE), value))) {
       if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = root_->get_object_value(
+            ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_LEGACY), value);
+        if (OB_FAIL(ret) && OB_SEARCH_NOT_FOUND != ret) {
+          LOG_WARN("Fail to get legacy quanitfier_table", K(ret));
+        }
       } else {
         LOG_WARN("Fail to get quantifier_table", K(ret));
       }
-    } else if (OB_ISNULL(value)) {
+    }
+    if (OB_SUCC(ret) && OB_ISNULL(value)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("value is null", K(ret));
-    } else if (value->json_type() != ObJsonNodeType::J_STRING) {
+    } else if (OB_SUCC(ret) && value->json_type() != ObJsonNodeType::J_STRING) {
+      ret = OB_INVALID_ARGUMENT;
       LOG_WARN("value is not string", K(ret));
-    } else {
+    } else if (OB_SUCC(ret)) {
       ObJsonString *json_str = static_cast<ObJsonString *>(value);
       str = json_str->get_str();
     }
   }
   return ret;
+}
+
+int ObFTParserJsonProps::config_get_table_id(const char *config_name, uint64_t &table_id) const
+{
+  int ret = OB_SUCCESS;
+  ObIJsonBase *value = nullptr;
+  if (!IS_INIT) {
+    ret = OB_NOT_INIT;
+  } else if (OB_ISNULL(config_name)) {
+    ret = OB_INVALID_ARGUMENT;
+  } else if (OB_FAIL(root_->get_object_value(ObString(config_name), value))) {
+    if (OB_SEARCH_NOT_FOUND != ret) {
+      LOG_WARN("fail to get dictionary table id", K(ret), KCSTRING(config_name));
+    }
+  } else if (OB_ISNULL(value)) {
+    ret = OB_ERR_UNEXPECTED;
+  } else if (ObJsonNodeType::J_UINT == value->json_type()) {
+    table_id = value->get_uint();
+  } else if (ObJsonNodeType::J_INT == value->json_type() && value->get_int() >= 0) {
+    table_id = static_cast<uint64_t>(value->get_int());
+  } else {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("dictionary table id is not an unsigned integer", K(ret), KCSTRING(config_name));
+  }
+  return ret;
+}
+
+int ObFTParserJsonProps::config_get_stopword_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_get_dict_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID, table_id);
+}
+
+int ObFTParserJsonProps::config_get_quantifier_table_id(uint64_t &table_id) const
+{
+  return config_get_table_id(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID, table_id);
 }
 
 int ObFTParserJsonProps::config_get_ik_mode(ObString &ik_mode) const
@@ -629,7 +715,11 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
   static const char *supported[] = {
       ObFTSLiteral::CONFIG_NAME_DICT_TABLE,
       ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE,
+      ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_LEGACY,
       ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE,
+      ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID,
+      ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID,
+      ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID,
       ObFTSLiteral::CONFIG_NAME_IK_MODE,
   };
 
@@ -658,6 +748,16 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
       // check dict table valid
     }
 
+    uint64_t table_id = OB_INVALID_ID;
+    if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_dict_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_dict_table_id(share::OB_FT_DICT_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default dictionary table id", K(ret));
+        }
+      }
+    }
+
     if (OB_FAIL(ret)) {
       // do nothing
     } else if (OB_FAIL(config_get_quantifier_table(table_name))) {
@@ -672,16 +772,34 @@ int ObFTParserJsonProps::ik_rebuild_props_for_ddl(const bool log_to_user)
     }
 
     if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_quantifier_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_quantifier_table_id(share::OB_FT_QUANTIFIER_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default quantifier table id", K(ret));
+        }
+      }
+    }
+
+    if (OB_FAIL(ret)) {
       // do nothing
-    } else if (OB_FAIL(config_get_quantifier_table(table_name))) {
+    } else if (OB_FAIL(config_get_stopword_table(table_name))) {
       if (OB_SEARCH_NOT_FOUND == ret) {
         if (OB_FAIL(
-                config_set_quantifier_table(ObFTSLiteral::FT_DEFAULT_IK_QUANTIFIER_UTF8_TABLE))) {
-          LOG_WARN("Failed to set default quantifier table", K(ret));
+                config_set_stopword_table(ObFTSLiteral::FT_DEFAULT_IK_STOPWORD_UTF8_TABLE))) {
+          LOG_WARN("Failed to set default stopword table", K(ret));
         }
       }
     } else {
-      // check quantifier table valid
+      // check stopword table valid
+    }
+
+    if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(config_get_stopword_table_id(table_id))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        if (OB_FAIL(config_set_stopword_table_id(share::OB_FT_STOPWORD_IK_UTF8_TID))) {
+          LOG_WARN("failed to set default stopword table id", K(ret));
+        }
+      }
     }
 
     if (OB_FAIL(ret)) {
@@ -1138,6 +1256,54 @@ int ObFTParserJsonProps::show_parser_properties(const ObFTParserJsonProps &prope
       }
     }
 
+    ObString dict_table;
+    if (FAILEDx(properties.config_get_dict_table(dict_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get dict table", K(ret));
+      }
+    } else {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_DICT_TABLE,
+                                  dict_table.length(), dict_table.ptr()))) {
+        LOG_WARN("fail to print dict table", K(ret), K(dict_table));
+      }
+    }
+
+    ObString stopword_table;
+    if (OB_SUCC(ret) && FAILEDx(properties.config_get_stopword_table(stopword_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get stopword table", K(ret));
+      }
+    } else if (OB_SUCC(ret)) {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE,
+                                  stopword_table.length(), stopword_table.ptr()))) {
+        LOG_WARN("fail to print stopword table", K(ret), K(stopword_table));
+      }
+    }
+
+    ObString quantifier_table;
+    if (OB_SUCC(ret) && FAILEDx(properties.config_get_quantifier_table(quantifier_table))) {
+      if (OB_SEARCH_NOT_FOUND == ret) {
+        ret = OB_SUCCESS;
+      } else {
+        LOG_WARN("fail to get quantifier table", K(ret));
+      }
+    } else if (OB_SUCC(ret)) {
+      __FT_PARSER_PROPERTY_SHOW_COMMA(need_comma);
+      if (FAILEDx(databuff_printf(buf, buf_len, pos, "%s=\"%.*s\"",
+                                  ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE,
+                                  quantifier_table.length(), quantifier_table.ptr()))) {
+        LOG_WARN("fail to print quantifier table", K(ret), K(quantifier_table));
+      }
+    }
+
     if (FAILEDx(databuff_printf(buf, buf_len, pos, ") "))) {
       LOG_WARN("fail to printf parser properties", K(ret), K(buf_len), K(pos), K(properties));
     }
@@ -1148,7 +1314,9 @@ int ObFTParserJsonProps::show_parser_properties(const ObFTParserJsonProps &prope
 
 #undef __FT_PARSER_PROPERTY_SHOW_COMMA
 
-int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser, const ObString &json_str)
+int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser,
+                                                const ObString &json_str,
+                                                ObIAllocator &allocator)
 {
   int ret = OB_SUCCESS;
   ObFTParserJsonProps props;
@@ -1158,12 +1326,55 @@ int ObFTParserProperty::parse_for_parser_helper(const ObFTParser &parser, const 
     LOG_WARN("fail to parse from json str", K(ret), K(json_str));
   } else {
     if (parser.is_ik()) {
-      // set dict tables and copy dict name
-      dict_table_ = ObString(ObFTSLiteral::CONFIG_NAME_DICT_TABLE);
-      stopword_table_ = ObString(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE);
-      quantifier_table_ = ObString(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE);
+      ObString table_name;
+      if (OB_FAIL(props.config_get_dict_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_DICT_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, dict_table_))) {
+        LOG_WARN("fail to copy dictionary table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret) && OB_FAIL(props.config_get_dict_table_id(dict_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          dict_table_id_ = share::OB_FT_DICT_IK_UTF8_TID;
+        }
+      }
+
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_stopword_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_STOPWORD_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, stopword_table_))) {
+        LOG_WARN("fail to copy stopword table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret) && OB_FAIL(props.config_get_stopword_table_id(stopword_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          stopword_table_id_ = share::OB_FT_STOPWORD_IK_UTF8_TID;
+        }
+      }
+
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_quantifier_table(table_name))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          table_name = ObString(ObFTSLiteral::FT_DEFAULT_IK_QUANTIFIER_UTF8_TABLE);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(ob_write_string(allocator, table_name, quantifier_table_))) {
+        LOG_WARN("fail to copy quantifier table name", K(ret), K(table_name));
+      } else if (OB_SUCC(ret)
+                 && OB_FAIL(props.config_get_quantifier_table_id(quantifier_table_id_))) {
+        if (OB_SEARCH_NOT_FOUND == ret) {
+          ret = OB_SUCCESS;
+          quantifier_table_id_ = share::OB_FT_QUANTIFIER_IK_UTF8_TID;
+        }
+      }
+
       ObString ik_smart;
-      if (OB_FAIL(props.config_get_ik_mode(ik_smart))) {
+      if (OB_SUCC(ret) && OB_FAIL(props.config_get_ik_mode(ik_smart))) {
         if (OB_SEARCH_NOT_FOUND == ret) {
           // from old version, ik_mode is not set, so use default value
           ik_mode_smart_ = true;
@@ -1227,6 +1438,9 @@ ObFTParserProperty::ObFTParserProperty()
       stopword_table_(),
       dict_table_(),
       quantifier_table_(),
+      stopword_table_id_(share::OB_FT_STOPWORD_IK_UTF8_TID),
+      dict_table_id_(share::OB_FT_DICT_IK_UTF8_TID),
+      quantifier_table_id_(share::OB_FT_QUANTIFIER_IK_UTF8_TID),
       min_ngram_token_size_(ObFTSLiteral::FT_DEFAULT_MIN_NGRAM_SIZE),
       max_ngram_token_size_(ObFTSLiteral::FT_DEFAULT_MAX_NGRAM_SIZE)
 {
@@ -1236,10 +1450,22 @@ int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
                                                       ObIJsonBase *array,
                                                       ObString &json_str)
 {
+  return tokenize_array_to_props_json(
+      allocator, array, ObString(), OB_INVALID_TENANT_ID, json_str);
+}
+
+int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
+                                                      ObIJsonBase *array,
+                                                      const ObString &database_name,
+                                                      const uint64_t tenant_id,
+                                                      ObString &json_str)
+{
   int ret = OB_SUCCESS;
 
   ObArenaAllocator alloc;
   ObJsonObject properties_root(&alloc);
+  share::schema::ObSchemaGetterGuard schema_guard;
+  bool schema_guard_loaded = false;
 
   if (OB_ISNULL(array)) {
     ret = OB_INVALID_ARGUMENT;
@@ -1257,8 +1483,60 @@ int ObFTParserJsonProps::tokenize_array_to_props_json(ObIAllocator &allocator,
         ret = OB_INVALID_ARGUMENT;
       } else if (OB_FAIL(array_value_item->get_object_value(0, config_name, config_value))) {
         LOG_WARN("Fail to get object value", K(ret));
-      } else if (OB_FAIL(properties_root.object_add(config_name, config_value))) {
-        LOG_WARN("Fail to add object value", K(ret));
+      } else {
+        const bool is_dict_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_DICT_TABLE);
+        const bool is_stopword_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE);
+        const bool is_quantifier_table
+            = 0 == config_name.case_compare(ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE);
+        if (!is_dict_table && !is_stopword_table && !is_quantifier_table) {
+          if (OB_FAIL(properties_root.object_add(config_name, config_value))) {
+            LOG_WARN("Fail to add object value", K(ret));
+          }
+        } else if (ObJsonNodeType::J_STRING != config_value->json_type()
+                   || OB_INVALID_TENANT_ID == tenant_id) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_USER_ERROR(OB_INVALID_ARGUMENT, "dictionary table config requires a valid string and tenant");
+        } else {
+          if (!schema_guard_loaded) {
+            if (OB_ISNULL(GCTX.schema_service_)) {
+              ret = OB_NOT_INIT;
+            } else if (OB_FAIL(GCTX.schema_service_->get_tenant_schema_guard(schema_guard))) {
+              LOG_WARN("fail to get schema guard for TOKENIZE", K(ret));
+            } else {
+              schema_guard_loaded = true;
+            }
+          }
+          uint64_t table_id = OB_INVALID_ID;
+          ObString full_table_name;
+          const ObString input_table_name(config_value->get_data_length(), config_value->get_data());
+          if (OB_FAIL(ret)) {
+          } else if (OB_FAIL(sql::ObFTParserResolverHelper::resolve_dict_table_name_and_id(
+                                 database_name,
+                                 input_table_name,
+                                 tenant_id,
+                                 schema_guard,
+                                 alloc,
+                                 table_id,
+                                 full_table_name))) {
+            LOG_WARN("fail to resolve TOKENIZE dictionary table", K(ret), K(input_table_name));
+          } else {
+            ObJsonString *table_name_node = OB_NEWx(ObJsonString, &alloc, full_table_name);
+            ObJsonUint *table_id_node = OB_NEWx(ObJsonUint, &alloc, table_id);
+            const char *id_config_name = is_dict_table
+                ? ObFTSLiteral::CONFIG_NAME_DICT_TABLE_ID
+                : (is_stopword_table ? ObFTSLiteral::CONFIG_NAME_STOPWORD_TABLE_ID
+                                     : ObFTSLiteral::CONFIG_NAME_QUANTIFIER_TABLE_ID);
+            if (OB_ISNULL(table_name_node) || OB_ISNULL(table_id_node)) {
+              ret = OB_ALLOCATE_MEMORY_FAILED;
+            } else if (OB_FAIL(properties_root.object_add(config_name, table_name_node))) {
+              LOG_WARN("fail to add TOKENIZE dictionary table name", K(ret));
+            } else if (OB_FAIL(properties_root.object_add(ObString(id_config_name), table_id_node))) {
+              LOG_WARN("fail to add TOKENIZE dictionary table id", K(ret));
+            }
+          }
+        }
       }
     }
     ObJsonBuffer j_buf(&allocator);

--- a/src/storage/fts/ob_fts_parser_property.h
+++ b/src/storage/fts/ob_fts_parser_property.h
@@ -51,6 +51,9 @@ public:
   int config_set_stopword_table(const ObString &str);
   int config_set_dict_table(const ObString &str);
   int config_set_quantifier_table(const ObString &str);
+  int config_set_stopword_table_id(const uint64_t table_id);
+  int config_set_dict_table_id(const uint64_t table_id);
+  int config_set_quantifier_table_id(const uint64_t table_id);
   int config_set_ik_mode(const ObString &ik_mode);
   int config_set_min_ngram_token_size(const int64_t size);
   int config_set_max_ngram_token_size(const int64_t size);
@@ -61,6 +64,9 @@ public:
   int config_get_stopword_table(ObString &str) const;
   int config_get_dict_table(ObString &str) const;
   int config_get_quantifier_table(ObString &str) const;
+  int config_get_stopword_table_id(uint64_t &table_id) const;
+  int config_get_dict_table_id(uint64_t &table_id) const;
+  int config_get_quantifier_table_id(uint64_t &table_id) const;
   int config_get_ik_mode(ObString &ik_mode) const;
   int config_get_min_ngram_token_size(int64_t &size) const;
   int config_get_max_ngram_token_size(int64_t &size) const;
@@ -108,6 +114,11 @@ public:
   static int tokenize_array_to_props_json(ObIAllocator &allocator,
                                           ObIJsonBase *array,
                                           ObString &json_str);
+  static int tokenize_array_to_props_json(ObIAllocator &allocator,
+                                          ObIJsonBase *array,
+                                          const ObString &database_name,
+                                          const uint64_t tenant_id,
+                                          ObString &json_str);
 
   static int show_parser_properties(const ObFTParserJsonProps &properties,
                                     char *buf,
@@ -117,6 +128,8 @@ public:
   TO_STRING_KV(K_(is_inited));
 
 private:
+  int config_set_table_id(const char *config_name, const uint64_t table_id);
+  int config_get_table_id(const char *config_name, uint64_t &table_id) const;
   int ik_rebuild_props_for_ddl(bool log_to_user);
   int ngram_rebuild_props_for_ddl(bool log_to_user);
   int space_rebuild_props_for_ddl(bool log_to_user);
@@ -137,7 +150,9 @@ struct ObFTParserProperty final
 public:
   ObFTParserProperty();
   ~ObFTParserProperty() = default;
-  int parse_for_parser_helper(const ObFTParser &parser, const ObString &json_str);
+  int parse_for_parser_helper(const ObFTParser &parser,
+                              const ObString &json_str,
+                              common::ObIAllocator &allocator);
 
   bool is_equal(const ObFTParserProperty &other) const
   {
@@ -145,6 +160,9 @@ public:
            && ngram_token_size_ == other.ngram_token_size_ && ik_mode_smart_ == other.ik_mode_smart_
            && stopword_table_ == other.stopword_table_ && dict_table_ == other.dict_table_
            && quantifier_table_ == other.quantifier_table_
+           && stopword_table_id_ == other.stopword_table_id_
+           && dict_table_id_ == other.dict_table_id_
+           && quantifier_table_id_ == other.quantifier_table_id_
            && min_ngram_token_size_ == other.min_ngram_token_size_
            && max_ngram_token_size_ == other.max_ngram_token_size_;
   }
@@ -155,6 +173,9 @@ public:
                K_(stopword_table),
                K_(dict_table),
                K_(quantifier_table),
+               K_(stopword_table_id),
+               K_(dict_table_id),
+               K_(quantifier_table_id),
                K_(min_ngram_token_size),
                K_(max_ngram_token_size),
                K_(ik_mode_smart));
@@ -167,6 +188,9 @@ public:
   common::ObString stopword_table_;
   common::ObString dict_table_;
   common::ObString quantifier_table_;
+  uint64_t stopword_table_id_;
+  uint64_t dict_table_id_;
+  uint64_t quantifier_table_id_;
   int64_t min_ngram_token_size_;
   int64_t max_ngram_token_size_;
 };

--- a/src/storage/fts/ob_fts_plugin_helper.cpp
+++ b/src/storage/fts/ob_fts_plugin_helper.cpp
@@ -24,6 +24,7 @@
 #include "plugin/interface/ob_plugin_ftparser_intf.h"
 #include "plugin/sys/ob_plugin_helper.h"
 #include "share/ob_force_print_log.h"
+#include "share/rc/ob_tenant_base.h"
 #include "storage/fts/dict/ob_ft_dict_hub.h"
 #include "storage/fts/ob_fts_parser_property.h"
 #include "storage/fts/ob_fts_stop_word.h"
@@ -255,8 +256,15 @@ int ObFTParseHelper::segment(
     param.ngram_token_size_ = property.ngram_token_size_;
     param.ik_param_.mode_
         = (property.ik_mode_smart_ ? ObFTIKParam::Mode::SMART : ObFTIKParam::Mode::MAX_WORD);
+    param.ik_param_.main_dict_ = property.dict_table_;
+    param.ik_param_.quan_dict_ = property.quantifier_table_;
+    param.ik_param_.stopword_dict_ = property.stopword_table_;
+    param.ik_param_.main_dict_id_ = property.dict_table_id_;
+    param.ik_param_.quan_dict_id_ = property.quantifier_table_id_;
+    param.ik_param_.stopword_dict_id_ = property.stopword_table_id_;
     param.min_ngram_size_ = property.min_ngram_token_size_;
     param.max_ngram_size_ = property.max_ngram_token_size_;
+    param.tenant_id_ = common::OB_SERVER_TENANT_ID;
 
     if (OB_FAIL(parser_desc->segment(&param, iter))) {
       LOG_WARN("fail to segment", K(ret), K(param));
@@ -319,7 +327,8 @@ int ObFTParseHelper::init(
     LOG_WARN("invalid argument", K(ret), KP(allocator), K(plugin_name));
   } else if (OB_FAIL(parser_name_.parse_from_str(plugin_name.ptr(), plugin_name.length()))) {
     LOG_WARN("fail to parse name from cstring", K(ret), K(plugin_name));
-  } else if (OB_FAIL(parser_property_.parse_for_parser_helper(parser_name_, plugin_properties))) {
+  } else if (OB_FAIL(parser_property_.parse_for_parser_helper(
+                         parser_name_, plugin_properties, *allocator))) {
     LOG_WARN("fail to parse parser property from cstring", K(ret), K(plugin_properties), K(parser_name_));
   } else if (OB_FAIL(ObPluginHelper::find_ftparser(parser_name_.get_parser_name().str(),
                                                    parser_desc_, plugin_param_))) {
@@ -409,12 +418,14 @@ int ObFTParseHelper::check_is_the_same(
   if (is_inited_) {
     storage::ObFTParser parser_name;
     ObFTParserProperty parser_property;
+    ObArenaAllocator property_allocator("FTPropCmp");
     if (OB_UNLIKELY(plugin_name.empty())) {
       ret = OB_INVALID_ARGUMENT;
       LOG_WARN("invalid argument", K(ret), K(plugin_name));
     } else if (OB_FAIL(parser_name.parse_from_str(plugin_name.ptr(), plugin_name.length()))) {
       LOG_WARN("fail to parse name from cstring", K(ret), K(plugin_name));
-    } else if (OB_FAIL(parser_property.parse_for_parser_helper(parser_name, plugin_properties))) {
+    } else if (OB_FAIL(parser_property.parse_for_parser_helper(
+                           parser_name, plugin_properties, property_allocator))) {
       LOG_WARN("fail to parse parser property from cstring", K(ret), K(plugin_properties), K(parser_name_));
     } else if (parser_name == parser_name_ && parser_property.is_equal(parser_property_)) {
       is_same = true;

--- a/src/storage/fts/ob_ik_ft_parser.cpp
+++ b/src/storage/fts/ob_ik_ft_parser.cpp
@@ -29,6 +29,7 @@
 #include "storage/fts/dict/ob_ft_dict_def.h"
 #include "storage/fts/dict/ob_ft_dict_hub.h"
 #include "storage/fts/dict/ob_ft_range_dict.h"
+#include "share/inner_table/ob_inner_table_schema_constants.h"
 #include "storage/fts/ik/ob_ik_arbitrator.h"
 #include "storage/fts/ik/ob_ik_cjk_processor.h"
 #include "storage/fts/ik/ob_ik_letter_processor.h"
@@ -103,11 +104,10 @@ int ObIKFTParser::get_next_token(const char *&word,
         }
       } else {
         bool is_stop = false;
-        // if (!OB_ISNULL(dict_stop_)
-        //     && OB_FAIL(dict_stop_->match(ObString(len, output_word + offset), is_stop))) {
-        //   LOG_WARN("Failed to match stopwords", K(ret));
-        // } else
-        if (!is_stop) {
+        if (!OB_ISNULL(dict_stop_)
+            && OB_FAIL(dict_stop_->match(ObString(len, output_word + offset), is_stop))) {
+          LOG_WARN("Failed to match stopwords", K(ret));
+        } else if (!is_stop) {
           word = output_word + offset;
           word_len = len;
           char_cnt = cnt;
@@ -277,21 +277,56 @@ int ObIKFTParser::init_dict(const plugin::ObFTParserParam &param)
     LOG_WARN("Dict hub is not inited", K(ret));
   }
 
-  ObFTRangeDict *dict = nullptr;
-  ObFTDictDesc main_dict_desc("main_dict",
+  const ObCharsetType charset = ObCharsetType::CHARSET_UTF8MB4;
+  const ObCollationType collation = ObCollationType::CS_TYPE_UTF8MB4_BIN;
+  const bool need_casedown = true;
+  const uint64_t tenant_id = OB_INVALID_TENANT_ID == param.tenant_id_
+                                 ? common::OB_SERVER_TENANT_ID
+                                 : param.tenant_id_;
+  const uint64_t main_dict_id = OB_INVALID_ID == param.ik_param_.main_dict_id_
+                                    ? share::OB_FT_DICT_IK_UTF8_TID
+                                    : param.ik_param_.main_dict_id_;
+  const uint64_t quan_dict_id = OB_INVALID_ID == param.ik_param_.quan_dict_id_
+                                    ? share::OB_FT_QUANTIFIER_IK_UTF8_TID
+                                    : param.ik_param_.quan_dict_id_;
+  const uint64_t stopword_dict_id = OB_INVALID_ID == param.ik_param_.stopword_dict_id_
+                                        ? share::OB_FT_STOPWORD_IK_UTF8_TID
+                                        : param.ik_param_.stopword_dict_id_;
+  const ObString main_dict_name = param.ik_param_.main_dict_.empty()
+                                      ? ObString(share::OB_FT_DICT_IK_UTF8_TNAME)
+                                      : param.ik_param_.main_dict_;
+  const ObString quan_dict_name = param.ik_param_.quan_dict_.empty()
+                                      ? ObString(share::OB_FT_QUANTIFIER_IK_UTF8_TNAME)
+                                      : param.ik_param_.quan_dict_;
+  const ObString stopword_dict_name = param.ik_param_.stopword_dict_.empty()
+                                          ? ObString(share::OB_FT_STOPWORD_IK_UTF8_TNAME)
+                                          : param.ik_param_.stopword_dict_;
+  ObFTDictDesc main_dict_desc(tenant_id,
+                              main_dict_id,
+                              main_dict_name,
                               ObFTDictType::DICT_IK_MAIN,
-                              ObCharsetType::CHARSET_UTF8MB4,
-                              ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                              charset,
+                              collation,
+                              main_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                              need_casedown);
 
-  ObFTDictDesc quan_dict_desc("quan_dict",
+  ObFTDictDesc quan_dict_desc(tenant_id,
+                              quan_dict_id,
+                              quan_dict_name,
                               ObFTDictType::DICT_IK_QUAN,
-                              ObCharsetType::CHARSET_UTF8MB4,
-                              ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                              charset,
+                              collation,
+                              quan_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                              need_casedown);
 
-  ObFTDictDesc stopword_dict_desc("stopword",
+  ObFTDictDesc stopword_dict_desc(tenant_id,
+                                  stopword_dict_id,
+                                  stopword_dict_name,
                                   ObFTDictType::DICT_IK_STOP,
-                                  ObCharsetType::CHARSET_UTF8MB4,
-                                  ObCollationType::CS_TYPE_UTF8MB4_BIN);
+                                  charset,
+                                  collation,
+                                  stopword_dict_id < common::OB_MAX_INNER_TABLE_ID,
+                                  need_casedown);
 
   if (should_read_newest_table()) {
     // clear dict cache, always false now

--- a/tools/benchmark/fts_hotpath_bench.sh
+++ b/tools/benchmark/fts_hotpath_bench.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# 全文索引分词热路径压测脚本
+#
+# 用途：对比优化前后 seekdb 的分词性能（主要在 TOKENIZE 热路径）
+# 建议：分别在优化前/后的二进制上各跑一遍，对比输出的 avg_ms
+#
+# 用法:
+#   ./tools/benchmark/fts_hotpath_bench.sh
+#   ROUNDS=5000 ./tools/benchmark/fts_hotpath_bench.sh
+#   MYSQL="mysql -h127.0.0.1 -P2881 -uroot" ./tools/benchmark/fts_hotpath_bench.sh
+
+set -euo pipefail
+
+MYSQL="${MYSQL:-mysql -h127.0.0.1 -P2881 -uroot -N -s}"
+ROUNDS="${ROUNDS:-2000}"
+WARMUP="${WARMUP:-50}"
+
+# 中文长文本：ik 分词会走词典查找 + 停用词检查，最能体现热路径优化
+IK_TEXT="OceanBase是一款非常稳定的数据库，全文索引的分词器热路径优化包括解析器实例复用、停用词全局单例、内存池化数据结构等技术，在大量文档索引和查询场景下可以显著降低 CPU 开销。"
+# 英文文本：beng 分词
+BENG_TEXT="The quick brown fox jumps over the lazy dog. Full-text search indexing requires efficient tokenization on the hot path."
+
+run_tokenize_bench() {
+  local parser="$1"
+  local text="$2"
+  local props="${3:-}"
+
+  # 预热：加载词典、JIT 缓存等
+  for ((i = 0; i < WARMUP; i++)); do
+    if [[ -n "$props" ]]; then
+      $MYSQL -e "SELECT tokenize('${text}', '${parser}', '${props}')" >/dev/null
+    else
+      $MYSQL -e "SELECT tokenize('${text}', '${parser}')" >/dev/null
+    fi
+  done
+
+  local start end elapsed_ms avg_ms
+  start=$(date +%s%N)
+  for ((i = 0; i < ROUNDS; i++)); do
+    if [[ -n "$props" ]]; then
+      $MYSQL -e "SELECT tokenize('${text}', '${parser}', '${props}')" >/dev/null
+    else
+      $MYSQL -e "SELECT tokenize('${text}', '${parser}')" >/dev/null
+    fi
+  done
+  end=$(date +%s%N)
+  elapsed_ms=$(( (end - start) / 1000000 ))
+  avg_ms=$(awk "BEGIN {printf \"%.3f\", ${elapsed_ms} / ${ROUNDS}}")
+  echo "  parser=${parser}  rounds=${ROUNDS}  total_ms=${elapsed_ms}  avg_ms=${avg_ms}"
+}
+
+echo "=== FTS hot-path benchmark ==="
+echo "mysql: ${MYSQL}"
+echo "rounds=${ROUNDS}, warmup=${WARMUP}"
+echo
+
+# 确保连接可用
+if ! $MYSQL -e "SELECT 1" >/dev/null 2>&1; then
+  echo "ERROR: cannot connect to seekdb. Set MYSQL env, e.g.:"
+  echo "  MYSQL='mysql -h127.0.0.1 -P2881 -uroot -p<password>' $0"
+  exit 1
+fi
+
+echo "[1/3] ik tokenizer (Chinese, dict lookup hot path)"
+run_tokenize_bench "ik" "$IK_TEXT"
+
+echo "[2/3] beng tokenizer (English)"
+run_tokenize_bench "beng" "$BENG_TEXT"
+
+echo "[3/3] space tokenizer (English, baseline)"
+run_tokenize_bench "space" "$BENG_TEXT"
+
+echo
+echo "Done. Run the same script on the baseline build and compare avg_ms."
+echo "Functional check: mysql ... < tools/benchmark/fts_hotpath_bench.sql"

--- a/tools/benchmark/fts_hotpath_bench.sql
+++ b/tools/benchmark/fts_hotpath_bench.sql
@@ -1,0 +1,67 @@
+-- 全文索引分词热路径：功能验证用例
+-- 用法: mysql -h127.0.0.1 -P2881 -uroot -Dtest < tools/benchmark/fts_hotpath_bench.sql
+
+DROP DATABASE IF EXISTS fts_bench;
+CREATE DATABASE fts_bench;
+USE fts_bench;
+
+SET ob_query_timeout = 10000000000;
+
+-- ============================================================
+-- 1. TOKENIZE 功能验证（直接走分词器热路径）
+-- ============================================================
+
+-- space / beng / ngram / ik 四类内置分词器
+SELECT tokenize('hello world quick brown fox', 'space') AS space_tokens;
+SELECT tokenize('hello world quick brown fox', 'beng') AS beng_tokens;
+SELECT tokenize('hello world quick brown fox', 'ngram',
+                '[{"output":"all"},{"additional_args":[{"ngram_token_size":2}]}]') AS ngram_tokens;
+
+-- ik 中文分词（会加载词典，最能体现热路径优化效果）
+SELECT tokenize('OceanBase是一款非常稳定的数据库，全文索引分词性能很重要', 'ik') AS ik_tokens;
+SELECT tokenize('中华人民共和国人民大会堂', 'ik',
+                '[{"additional_args":[{"ik_mode":"smart"}]}]') AS ik_smart;
+SELECT tokenize('中华人民共和国人民大会堂', 'ik',
+                '[{"additional_args":[{"ik_mode":"max_word"}]}]') AS ik_max_word;
+
+-- ============================================================
+-- 2. 全文索引建表 + 写入 + MATCH 查询（端到端验证）
+-- ============================================================
+
+CREATE TABLE articles (
+  id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+  title     VARCHAR(200),
+  content   TEXT,
+  FULLTEXT INDEX fti_title(title) WITH PARSER ik,
+  FULLTEXT INDEX fti_content(content) WITH PARSER ik,
+  -- MATCH(col1, col2) 必须命中列组合完全一致的全文索引，不能拆成两个单列索引
+  FULLTEXT INDEX fti_title_content(title, content) WITH PARSER ik
+);
+
+INSERT INTO articles (title, content) VALUES
+('数据库性能优化', '全文索引的分词器热路径优化包括解析器复用、停用词单例和内存池化等技术。'),
+('搜索引擎原理', '倒排索引是全文检索的核心数据结构，分词质量直接影响召回率和查询性能。'),
+('OceanBase 特性', 'OceanBase 支持多种内置分词器，包括 ik、beng、space 和 ngram。'),
+('旅行日记', '这次旅行中发生了很多有趣的事情，记录下来留作纪念。'),
+('Security Audit', 'Completed the annual security audit with no major vulnerabilities found.');
+
+-- 等待索引构建（seekdb 通常较快，如未就绪可手动 sleep 后重试）
+SELECT COUNT(*) AS row_cnt FROM articles;
+
+-- 中文全文检索
+SELECT id, title
+FROM articles
+WHERE MATCH(title, content) AGAINST('分词器 优化');
+
+-- 英文全文检索
+SELECT id, title
+FROM articles
+WHERE MATCH(content) AGAINST('audit security');
+
+-- TOKENIZE 与 MEMBER OF 组合查询
+SELECT id, title
+FROM articles
+WHERE '全文' MEMBER OF (tokenize(content, 'ik'))
+   OR 'audit' MEMBER OF (tokenize(content, 'space'));
+
+SELECT 'fts_hotpath_bench: ALL PASSED' AS result;

--- a/tools/benchmark/fts_large_bench.sh
+++ b/tools/benchmark/fts_large_bench.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# 大规模全文索引压测：raw load + FTS index build + TOKENIZE + MATCH 查询
+#
+# 用于优化前后 seekdb 对比。建议固定 ROWS/BATCH/ROUNDS/QUERY_ROUNDS/SAMPLES，
+# 分别打 LABEL，并在相同机器负载下重复运行。
+#
+# 用法:
+#   ./tools/benchmark/fts_large_bench.sh
+#   LABEL=before ROWS=50000 ./tools/benchmark/fts_large_bench.sh
+#   LABEL=after SKIP_LOAD=1 ./tools/benchmark/fts_large_bench.sh
+#   OUTPUT=./bench_result.txt LABEL=after ./tools/benchmark/fts_large_bench.sh
+#
+# 环境变量:
+#   MYSQL          mysql 客户端命令（默认 -h127.0.0.1 -P2881 -uroot -N -s --default-character-set=utf8mb4）
+#   MYSQL_VERBOSE  mysql 客户端命令，保留普通输出（默认 -h127.0.0.1 -P2881 -uroot --default-character-set=utf8mb4）
+#   LABEL          结果标签，如 before / after（默认 unknown）
+#   ROWS           插入文档数（默认 20000）
+#   BATCH          每批 INSERT 行数（默认 500）
+#   ROUNDS         TOKENIZE 压测轮次（默认 3000）
+#   QUERY_ROUNDS   每条 MATCH SQL 每个 sample 重复次数（默认 200）
+#   SAMPLES        TOKENIZE/MATCH 采样组数（默认 3）
+#   WARMUP         TOKENIZE/MATCH 每项预热轮次（默认 30）
+#   SKIP_LOAD      设为 1 跳过建库、灌数、建索引，仅跑分词/查询压测
+#   OUTPUT         结果追加写入的文件（可选）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MYSQL="${MYSQL:-mysql -h127.0.0.1 -P2881 -uroot -N -s --default-character-set=utf8mb4}"
+MYSQL_VERBOSE="${MYSQL_VERBOSE:-mysql -h127.0.0.1 -P2881 -uroot --default-character-set=utf8mb4}"
+LABEL="${LABEL:-unknown}"
+ROWS="${ROWS:-20000}"
+BATCH="${BATCH:-500}"
+ROUNDS="${ROUNDS:-3000}"
+QUERY_ROUNDS="${QUERY_ROUNDS:-200}"
+SAMPLES="${SAMPLES:-3}"
+WARMUP="${WARMUP:-30}"
+SKIP_LOAD="${SKIP_LOAD:-0}"
+OUTPUT="${OUTPUT:-}"
+
+IK_TEXT="OceanBase是一款非常稳定的数据库，全文索引的分词器热路径优化包括解析器实例复用、停用词全局单例、内存池化数据结构等技术，在大量文档索引和查询场景下可以显著降低 CPU 开销。"
+BENG_TEXT="The quick brown fox jumps over the lazy dog. Full-text search indexing requires efficient tokenization on the hot path."
+
+declare -A METRICS
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fts_large_bench.XXXXXX")"
+
+cleanup() { rm -rf "${TMP_DIR}"; }
+trap cleanup EXIT
+
+log() { echo "$@" >&2; }
+
+now_ns() { date +%s%N; }
+
+elapsed_sec() {
+  local start_ns="$1" end_ns="$2"
+  awk "BEGIN {printf \"%.3f\", (${end_ns} - ${start_ns}) / 1000000000}"
+}
+
+elapsed_ms() {
+  local start_ns="$1" end_ns="$2"
+  awk "BEGIN {printf \"%.3f\", (${end_ns} - ${start_ns}) / 1000000}"
+}
+
+mysql_exec() { $MYSQL -e "SET NAMES utf8mb4; SET ob_query_timeout = 100000000000; SET ob_trx_timeout = 100000000000; $1"; }
+
+validate_positive_int() {
+  local name="$1" value="$2"
+  if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    log "ERROR: ${name} must be a positive integer, got '${value}'"
+    exit 1
+  fi
+}
+
+write_session_header() {
+  local file="$1"
+  {
+    echo "SET NAMES utf8mb4;"
+    echo "SET ob_query_timeout = 100000000000;"
+    echo "SET ob_trx_timeout = 100000000000;"
+  } > "${file}"
+}
+
+append_repeated_sql() {
+  local file="$1" rounds="$2" sql="$3"
+  local i
+  for ((i = 0; i < rounds; i++)); do
+    echo "${sql}" >> "${file}"
+  done
+}
+
+calc_sample_stats() {
+  local file="$1"
+  awk '
+    {
+      a[NR] = $1
+      sum += $1
+      sumsq += $1 * $1
+    }
+    END {
+      if (NR == 0) {
+        printf "N/A N/A N/A N/A N/A N/A"
+        exit
+      }
+      for (i = 1; i <= NR; i++) {
+        for (j = i + 1; j <= NR; j++) {
+          if (a[i] > a[j]) {
+            t = a[i]; a[i] = a[j]; a[j] = t
+          }
+        }
+      }
+      mean = sum / NR
+      var = sumsq / NR - mean * mean
+      if (var < 0) {
+        var = 0
+      }
+      median = (NR % 2) ? a[(NR + 1) / 2] : (a[NR / 2] + a[NR / 2 + 1]) / 2
+      p95_idx = int(NR * 0.95 + 0.999999)
+      if (p95_idx < 1) {
+        p95_idx = 1
+      } else if (p95_idx > NR) {
+        p95_idx = NR
+      }
+      printf "%.4f %.4f %.4f %.4f %.4f %.4f", mean, median, sqrt(var), a[1], a[NR], a[p95_idx]
+    }
+  ' "${file}"
+}
+
+record_sample_stats() {
+  local name="$1" sample_file="$2"
+  local mean median stdev min max p95
+  read -r mean median stdev min max p95 <<< "$(calc_sample_stats "${sample_file}")"
+  METRICS["${name}_avg_ms"]="${mean}"
+  METRICS["${name}_median_ms"]="${median}"
+  METRICS["${name}_stdev_ms"]="${stdev}"
+  METRICS["${name}_min_ms"]="${min}"
+  METRICS["${name}_max_ms"]="${max}"
+  METRICS["${name}_p95_ms"]="${p95}"
+}
+
+run_repeated_sql_bench() {
+  local name="$1" rounds="$2" sql="$3"
+  local warmup_sql="${TMP_DIR}/${name}.warmup.sql"
+  local sample_file="${TMP_DIR}/${name}.samples"
+  local sample sql_file start_ns end_ns total_ms avg_ms
+
+  : > "${sample_file}"
+
+  if (( WARMUP > 0 )); then
+    write_session_header "${warmup_sql}"
+    append_repeated_sql "${warmup_sql}" "${WARMUP}" "${sql}"
+    $MYSQL < "${warmup_sql}" >/dev/null
+  fi
+
+  for ((sample = 1; sample <= SAMPLES; sample++)); do
+    sql_file="${TMP_DIR}/${name}.${sample}.sql"
+    write_session_header "${sql_file}"
+    append_repeated_sql "${sql_file}" "${rounds}" "${sql}"
+    start_ns=$(now_ns)
+    $MYSQL < "${sql_file}" >/dev/null
+    end_ns=$(now_ns)
+    total_ms=$(elapsed_ms "${start_ns}" "${end_ns}")
+    avg_ms=$(awk "BEGIN {printf \"%.4f\", ${total_ms} / ${rounds}}")
+    echo "${avg_ms}" >> "${sample_file}"
+    log "  ${name}: sample=${sample}/${SAMPLES} rounds=${rounds} total_ms=${total_ms} avg_ms=${avg_ms}"
+  done
+
+  record_sample_stats "${name}" "${sample_file}"
+}
+
+run_tokenize_bench() {
+  local name="$1" parser="$2" text="$3"
+  run_repeated_sql_bench "${name}" "${ROUNDS}" "SELECT tokenize('${text}', '${parser}');"
+}
+
+run_query_bench() {
+  local name="$1" sql="$2"
+  local cnt
+  cnt=$(mysql_exec "${sql}" | tail -1)
+  : "${cnt:=0}"
+  METRICS["${name}_hits"]="${cnt}"
+  log "  ${name}: warmup_hits=${cnt}"
+  run_repeated_sql_bench "${name}" "${QUERY_ROUNDS}" "${sql}"
+}
+
+time_mysql_command() {
+  local name="$1" sql="$2"
+  local start_ns end_ns total_sec
+  start_ns=$(now_ns)
+  mysql_exec "${sql}" >/dev/null
+  end_ns=$(now_ns)
+  total_sec=$(elapsed_sec "${start_ns}" "${end_ns}")
+  METRICS["${name}_sec"]="${total_sec}"
+  log "  ${name}: ${total_sec}s"
+}
+
+write_report() {
+  local ts git_head git_dirty
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  git_head="$(git -C "${SCRIPT_DIR}/../.." rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+  if git -C "${SCRIPT_DIR}/../.." diff --quiet --ignore-submodules -- 2>/dev/null; then
+    git_dirty="0"
+  else
+    git_dirty="1"
+  fi
+
+  {
+    echo "========================================"
+    echo "FTS Large Benchmark Report"
+    echo "========================================"
+    echo "timestamp:              ${ts}"
+    echo "label:                  ${LABEL}"
+    echo "git_head:               ${git_head}"
+    echo "git_dirty:              ${git_dirty}"
+    echo "rows:                   ${ROWS}"
+    echo "batch:                  ${BATCH}"
+    echo "rounds:                 ${ROUNDS}"
+    echo "query_rounds:           ${QUERY_ROUNDS}"
+    echo "samples:                ${SAMPLES}"
+    echo "warmup:                 ${WARMUP}"
+    echo "skip_load:              ${SKIP_LOAD}"
+    echo "----------------------------------------"
+    echo "select1_avg_ms:         ${METRICS[select1_avg_ms]:-N/A}"
+    echo "select1_stdev_ms:       ${METRICS[select1_stdev_ms]:-N/A}"
+    echo "raw_load_sec:           ${METRICS[raw_load_sec]:-N/A}"
+    echo "raw_load_rows_per_sec:  ${METRICS[raw_load_rows_per_sec]:-N/A}"
+    echo "build_ik_all_sec:       ${METRICS[build_ik_all_sec]:-N/A}"
+    echo "build_ik_content_sec:   ${METRICS[build_ik_content_sec]:-N/A}"
+    echo "build_beng_en_sec:      ${METRICS[build_beng_en_sec]:-N/A}"
+    echo "build_total_sec:        ${METRICS[build_total_sec]:-N/A}"
+    echo "----------------------------------------"
+    echo "tokenize_ik_avg_ms:     ${METRICS[tokenize_ik_avg_ms]:-N/A}"
+    echo "tokenize_ik_median_ms:  ${METRICS[tokenize_ik_median_ms]:-N/A}"
+    echo "tokenize_ik_stdev_ms:   ${METRICS[tokenize_ik_stdev_ms]:-N/A}"
+    echo "tokenize_beng_avg_ms:   ${METRICS[tokenize_beng_avg_ms]:-N/A}"
+    echo "tokenize_beng_median_ms:${METRICS[tokenize_beng_median_ms]:-N/A}"
+    echo "tokenize_beng_stdev_ms: ${METRICS[tokenize_beng_stdev_ms]:-N/A}"
+    echo "----------------------------------------"
+    echo "query_cn_hits:          ${METRICS[query_cn_hits]:-N/A}"
+    echo "query_cn_avg_ms:        ${METRICS[query_cn_avg_ms]:-N/A}"
+    echo "query_cn_stdev_ms:      ${METRICS[query_cn_stdev_ms]:-N/A}"
+    echo "query_beng_hits:        ${METRICS[query_beng_hits]:-N/A}"
+    echo "query_beng_avg_ms:      ${METRICS[query_beng_avg_ms]:-N/A}"
+    echo "query_beng_stdev_ms:    ${METRICS[query_beng_stdev_ms]:-N/A}"
+    echo "query_mixed_hits:       ${METRICS[query_mixed_hits]:-N/A}"
+    echo "query_mixed_avg_ms:     ${METRICS[query_mixed_avg_ms]:-N/A}"
+    echo "query_mixed_stdev_ms:   ${METRICS[query_mixed_stdev_ms]:-N/A}"
+    echo "query_limit_hits:       ${METRICS[query_limit_hits]:-N/A}"
+    echo "query_limit_avg_ms:     ${METRICS[query_limit_avg_ms]:-N/A}"
+    echo "query_limit_stdev_ms:   ${METRICS[query_limit_stdev_ms]:-N/A}"
+    echo "========================================"
+  }
+}
+
+validate_positive_int "ROWS" "${ROWS}"
+validate_positive_int "BATCH" "${BATCH}"
+validate_positive_int "ROUNDS" "${ROUNDS}"
+validate_positive_int "QUERY_ROUNDS" "${QUERY_ROUNDS}"
+validate_positive_int "SAMPLES" "${SAMPLES}"
+
+if [[ ! "${WARMUP}" =~ ^[0-9]+$ ]]; then
+  log "ERROR: WARMUP must be a non-negative integer, got '${WARMUP}'"
+  exit 1
+fi
+
+if ! mysql_exec "SELECT 1;" >/dev/null 2>&1; then
+  log "ERROR: cannot connect seekdb. Example:"
+  log "  MYSQL='mysql -h127.0.0.1 -P2881 -uroot --default-character-set=utf8mb4 -N -s' $0"
+  exit 1
+fi
+
+log "=== FTS Large Benchmark (label=${LABEL}) ==="
+log "rows=${ROWS} batch=${BATCH} rounds=${ROUNDS} query_rounds=${QUERY_ROUNDS} samples=${SAMPLES}"
+
+log "[0/5] SQL baseline ..."
+run_repeated_sql_bench "select1" "${ROUNDS}" "SELECT 1;"
+
+if [[ "${SKIP_LOAD}" != "1" ]]; then
+  log "[1/5] setup raw schema ..."
+  $MYSQL_VERBOSE < "${SCRIPT_DIR}/fts_large_bench_setup.sql" >/dev/null
+
+  log "[2/5] raw bulk load ${ROWS} docs (batch=${BATCH}) ..."
+  load_start_ns=$(now_ns)
+  python3 "${SCRIPT_DIR}/fts_large_bench_gen.py" --rows "${ROWS}" --batch "${BATCH}" | $MYSQL_VERBOSE >/dev/null
+  load_end_ns=$(now_ns)
+  load_sec=$(elapsed_sec "${load_start_ns}" "${load_end_ns}")
+  rps=$(awk "BEGIN {printf \"%.1f\", ${ROWS} / ${load_sec}}")
+  METRICS[raw_load_sec]="${load_sec}"
+  METRICS[raw_load_rows_per_sec]="${rps}"
+  log "  raw load done: ${load_sec}s (${rps} rows/s)"
+
+  loaded=$(mysql_exec "USE fts_large_bench; SELECT COUNT(*) FROM docs;" | tail -1)
+  log "  table rows: ${loaded}"
+
+  log "[3/5] build fulltext indexes ..."
+  build_start_ns=$(now_ns)
+  time_mysql_command "build_ik_all" \
+    "USE fts_large_bench; ALTER TABLE docs ADD FULLTEXT INDEX fti_all_ik(title, content) WITH PARSER ik;"
+  time_mysql_command "build_ik_content" \
+    "USE fts_large_bench; ALTER TABLE docs ADD FULLTEXT INDEX fti_content_ik(content) WITH PARSER ik;"
+  time_mysql_command "build_beng_en" \
+    "USE fts_large_bench; ALTER TABLE docs ADD FULLTEXT INDEX fti_en_beng(title_en, content_en) WITH PARSER beng;"
+  build_end_ns=$(now_ns)
+  METRICS[build_total_sec]="$(elapsed_sec "${build_start_ns}" "${build_end_ns}")"
+else
+  log "[1-3/5] SKIP_LOAD=1, reuse existing fts_large_bench.docs and indexes"
+  loaded=$(mysql_exec "USE fts_large_bench; SELECT COUNT(*) FROM docs;" 2>/dev/null | tail -1 || echo "0")
+  if [[ "${loaded}" == "0" ]]; then
+    log "ERROR: fts_large_bench.docs is empty. Run without SKIP_LOAD first."
+    exit 1
+  fi
+  log "  table rows: ${loaded}"
+  ROWS="${loaded}"
+fi
+
+log "[4/5] TOKENIZE hot-path ..."
+run_tokenize_bench "tokenize_ik" "ik" "${IK_TEXT}"
+run_tokenize_bench "tokenize_beng" "beng" "${BENG_TEXT}"
+
+log "[5/5] MATCH query ..."
+run_query_bench "query_cn" \
+  "SELECT COUNT(*) FROM fts_large_bench.docs WHERE MATCH(title, content) AGAINST('全文索引 分词器');"
+run_query_bench "query_beng" \
+  "SELECT COUNT(*) FROM fts_large_bench.docs WHERE MATCH(title_en, content_en) AGAINST('database performance audit');"
+run_query_bench "query_mixed" \
+  "SELECT COUNT(*) FROM fts_large_bench.docs WHERE MATCH(title, content) AGAINST('OceanBase 稳定 database');"
+run_query_bench "query_limit" \
+  "SELECT COUNT(*) FROM (SELECT id FROM fts_large_bench.docs WHERE MATCH(content) AGAINST('倒排索引 tokenizer') LIMIT 20) t;"
+
+report=$(write_report)
+echo "${report}"
+if [[ -n "${OUTPUT}" ]]; then
+  echo "${report}" >> "${OUTPUT}"
+  log "Report appended to ${OUTPUT}"
+fi
+
+log ""
+log "Compare before/after on these fields:"
+log "  build_ik_all_sec, build_ik_content_sec, build_beng_en_sec, build_total_sec"
+log "  tokenize_ik_avg_ms/stdev, tokenize_beng_avg_ms/stdev, select1_avg_ms as SQL-loop baseline"
+log "  query_cn_avg_ms, query_beng_avg_ms, query_mixed_avg_ms, query_limit_avg_ms with *_hits"

--- a/tools/benchmark/fts_large_bench_baseline.json
+++ b/tools/benchmark/fts_large_bench_baseline.json
@@ -1,0 +1,66 @@
+{
+  "name": "fts_large_bench_ci_baseline",
+  "description": "Baseline averaged from five VLDB CI fts_large_bench.sh runs on 2026-07-07.",
+  "source_run_count": 5,
+  "benchmark_config": {
+    "rows": 20000,
+    "batch": 500,
+    "rounds": 3000,
+    "query_rounds": 200,
+    "samples": 3,
+    "warmup": 30,
+    "skip_load": 0
+  },
+  "score_rule": {
+    "formula": "score = clamp(mean_category_improvement, 0, 0.5) / 0.5 * 100",
+    "max_score": 100,
+    "full_score_improvement": 0.5,
+    "lower_is_better": true,
+    "category_weighting": "Each category is averaged first, then build/tokenize/query are averaged with equal weight."
+  },
+  "score_categories": {
+    "build": [
+      "build_ik_all_sec",
+      "build_ik_content_sec",
+      "build_beng_en_sec"
+    ],
+    "tokenize": [
+      "tokenize_ik_avg_ms",
+      "tokenize_beng_avg_ms"
+    ],
+    "query": [
+      "query_cn_avg_ms",
+      "query_beng_avg_ms",
+      "query_mixed_avg_ms",
+      "query_limit_avg_ms"
+    ]
+  },
+  "baseline_metrics": {
+    "select1_avg_ms": 0.21032,
+    "select1_stdev_ms": 0.00752,
+    "raw_load_sec": 1.6126,
+    "raw_load_rows_per_sec": 12485.94,
+    "build_ik_all_sec": 35.2836,
+    "build_ik_content_sec": 28.3764,
+    "build_beng_en_sec": 14.7578,
+    "build_total_sec": 78.434,
+    "tokenize_ik_avg_ms": 0.76478,
+    "tokenize_ik_median_ms": 0.76296,
+    "tokenize_ik_stdev_ms": 0.01496,
+    "tokenize_beng_avg_ms": 0.42262,
+    "tokenize_beng_median_ms": 0.4201,
+    "tokenize_beng_stdev_ms": 0.00676,
+    "query_cn_hits": 8001,
+    "query_cn_avg_ms": 16.66282,
+    "query_cn_stdev_ms": 0.02162,
+    "query_beng_hits": 11000,
+    "query_beng_avg_ms": 24.30424,
+    "query_beng_stdev_ms": 0.04874,
+    "query_mixed_hits": 7332,
+    "query_mixed_avg_ms": 17.55928,
+    "query_mixed_stdev_ms": 0.0386,
+    "query_limit_hits": 20,
+    "query_limit_avg_ms": 16.23338,
+    "query_limit_stdev_ms": 0.04536
+  }
+}

--- a/tools/benchmark/fts_large_bench_gen.py
+++ b/tools/benchmark/fts_large_bench_gen.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""生成大规模全文索引压测数据（批量 INSERT SQL）。"""
+
+import argparse
+import random
+import sys
+
+TITLES_CN = [
+    "数据库性能优化实践",
+    "全文索引分词器热路径分析",
+    "OceanBase 稳定性的工程经验",
+    "倒排索引与检索系统设计",
+    "中文分词 ik 词典加载机制",
+    "搜索引擎召回率调优笔记",
+    "分布式存储 compaction 策略",
+    "SQL 执行计划与索引选择",
+    "日志系统内存池化设计",
+    "停用词过滤的全局单例实现",
+]
+
+TITLES_EN = [
+    "Full-text search indexing benchmark",
+    "Tokenization hot path optimization",
+    "Database audit and security review",
+    "Inverted index build performance",
+    "English tokenizer beng parser test",
+    "Query latency under heavy load",
+    "Document retrieval relevance scoring",
+    "Bulk insert throughput measurement",
+]
+
+CONTENT_CN = [
+    "全文索引的分词器热路径优化包括解析器实例复用、停用词全局单例、内存池化数据结构 ObFastSegmentArray 等技术。",
+    "在大量文档索引场景下，ik 分词需要频繁查词典和判断停用词，CPU 开销主要集中在分词热路径。",
+    "OceanBase 是一款非常稳定的数据库，支持 ik、beng、space、ngram 等多种内置分词器。",
+    "倒排索引是全文检索的核心数据结构，分词质量直接影响召回率、准确率和查询延迟。",
+    "中华人民共和国人民大会堂是著名地标，本文用于测试中文 smart 与 max_word 分词差异。",
+    "性能优化需要结合 profile 数据定位热点，reuse_parser 和 metadata_alloc 分离是常见手段。",
+]
+
+CONTENT_EN = [
+    "The quick brown fox jumps over the lazy dog. Full-text search requires efficient tokenization.",
+    "Completed the annual security audit. No major vulnerabilities were found in the system.",
+    "Database performance optimization focuses on index build, query planning and IO reduction.",
+    "Bulk loading documents triggers repeated tokenizer execution on the indexing hot path.",
+    "English beng parser tokenization is used as a baseline for cross-parser comparison.",
+]
+
+CATEGORIES = list(range(1, 11))
+
+
+def esc(s: str) -> str:
+    return s.replace("\\", "\\\\").replace("'", "''")
+
+
+def make_row(i: int) -> tuple:
+    cat = CATEGORIES[i % len(CATEGORIES)]
+    title_en = f"{TITLES_EN[i % len(TITLES_EN)]} #{i}"
+    body_en = f"{CONTENT_EN[i % len(CONTENT_EN)]} row={i}. Benchmark document for beng parser."
+    if i % 3 == 0:
+        title = f"{TITLES_EN[i % len(TITLES_EN)]} #{i}"
+        body = f"{CONTENT_EN[i % len(CONTENT_EN)]} row={i}. " + CONTENT_CN[i % len(CONTENT_CN)]
+    elif i % 3 == 1:
+        title = f"{TITLES_CN[i % len(TITLES_CN)]} #{i}"
+        body = f"{CONTENT_CN[i % len(CONTENT_CN)]} 文档编号={i}。" + CONTENT_EN[i % len(CONTENT_EN)]
+    else:
+        title = f"{TITLES_CN[i % len(TITLES_CN)]} / {TITLES_EN[i % len(TITLES_EN)]} #{i}"
+        body = (
+            f"{CONTENT_CN[i % len(CONTENT_CN)]} "
+            f"{CONTENT_EN[i % len(CONTENT_EN)]} "
+            f"混合文档 row={i}，用于压测 MATCH 与 TOKENIZE。"
+        )
+    return cat, title, body, title_en, body_en
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate FTS large bench INSERT SQL")
+    parser.add_argument("--rows", type=int, default=20000, help="total rows to insert")
+    parser.add_argument("--batch", type=int, default=500, help="rows per INSERT statement")
+    parser.add_argument("--seed", type=int, default=42, help="random seed for reproducibility")
+    args = parser.parse_args()
+
+    if args.rows <= 0 or args.batch <= 0:
+        print("rows and batch must be positive", file=sys.stderr)
+        return 1
+
+    random.seed(args.seed)
+    print("USE fts_large_bench;")
+    print("START TRANSACTION;")
+
+    batch_vals = []
+    for i in range(args.rows):
+        cat, title, body, title_en, body_en = make_row(i)
+        batch_vals.append(
+            f"({cat}, '{esc(title)}', '{esc(body)}', "
+            f"'{esc(title_en)}', '{esc(body_en)}')"
+        )
+        if len(batch_vals) >= args.batch:
+            print("INSERT INTO docs (category, title, content, title_en, content_en) VALUES")
+            print(",\n".join(batch_vals) + ";")
+            batch_vals = []
+
+    if batch_vals:
+        print("INSERT INTO docs (category, title, content, title_en, content_en) VALUES")
+        print(",\n".join(batch_vals) + ";")
+
+    print("COMMIT;")
+    print(f"SELECT COUNT(*) AS loaded_rows FROM docs;")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/benchmark/fts_large_bench_score.py
+++ b/tools/benchmark/fts_large_bench_score.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Score one fts_large_bench.sh report against the checked-in CI baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+
+METRIC_RE = re.compile(r"^\s*([A-Za-z0-9_]+):\s*([-+]?(?:\d+(?:\.\d*)?|\.\d+))\s*$")
+DEFAULT_BASELINE = Path(__file__).with_name("fts_large_bench_baseline.json")
+
+
+def load_report(path: Path) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = METRIC_RE.match(line)
+        if match:
+            metrics[match.group(1)] = float(match.group(2))
+    return metrics
+
+
+def load_baseline(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def check_config(
+    report: dict[str, float],
+    baseline: dict[str, Any],
+    allow_config_mismatch: bool,
+) -> list[str]:
+    mismatches = []
+    for key, expected in baseline["benchmark_config"].items():
+        actual = report.get(key)
+        if actual is None or actual != float(expected):
+            mismatches.append(f"{key}: expected {expected}, got {actual}")
+    if mismatches and not allow_config_mismatch:
+        raise SystemExit(
+            "benchmark config mismatch; rerun fts_large_bench.sh with baseline settings:\n"
+            + "\n".join(f"  - {item}" for item in mismatches)
+        )
+    return mismatches
+
+
+def improvement(baseline_value: float, current_value: float) -> float:
+    if baseline_value <= 0:
+        raise ValueError(f"baseline value must be positive, got {baseline_value}")
+    return (baseline_value - current_value) / baseline_value
+
+
+def calculate_score(report: dict[str, float], baseline: dict[str, Any]) -> dict[str, Any]:
+    baseline_metrics = baseline["baseline_metrics"]
+    categories = baseline["score_categories"]
+    full_score_improvement = float(baseline["score_rule"]["full_score_improvement"])
+    max_score = float(baseline["score_rule"]["max_score"])
+
+    category_results: dict[str, Any] = {}
+    for category, metric_names in categories.items():
+        metric_results = []
+        for metric in metric_names:
+            if metric not in report:
+                raise SystemExit(f"missing metric in report: {metric}")
+            base = float(baseline_metrics[metric])
+            current = float(report[metric])
+            metric_results.append(
+                {
+                    "metric": metric,
+                    "baseline": base,
+                    "current": current,
+                    "improvement": improvement(base, current),
+                }
+            )
+        category_results[category] = {
+            "improvement": mean(item["improvement"] for item in metric_results),
+            "metrics": metric_results,
+        }
+
+    mean_category_improvement = mean(
+        item["improvement"] for item in category_results.values()
+    )
+    normalized = max(0.0, min(mean_category_improvement, full_score_improvement))
+    score = normalized / full_score_improvement * max_score
+    return {
+        "score": score,
+        "mean_improvement": mean_category_improvement,
+        "full_score_improvement": full_score_improvement,
+        "categories": category_results,
+    }
+
+
+def format_percent(value: float) -> str:
+    return f"{value * 100:.2f}%"
+
+
+def print_human(result: dict[str, Any], config_mismatches: list[str]) -> None:
+    print("FTS Large Benchmark Score")
+    print("=========================")
+    print(f"score: {result['score']:.2f} / 100")
+    print(f"mean_improvement: {format_percent(result['mean_improvement'])}")
+    print(f"full_score_improvement: {format_percent(result['full_score_improvement'])}")
+    if config_mismatches:
+        print("config_mismatches:")
+        for mismatch in config_mismatches:
+            print(f"  - {mismatch}")
+    print()
+    for category, category_result in result["categories"].items():
+        print(f"{category}_improvement: {format_percent(category_result['improvement'])}")
+        for metric in category_result["metrics"]:
+            print(
+                "  "
+                f"{metric['metric']}: "
+                f"baseline={metric['baseline']:.6g}, "
+                f"current={metric['current']:.6g}, "
+                f"improvement={format_percent(metric['improvement'])}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Score fts_large_bench.sh output against a fixed baseline."
+    )
+    parser.add_argument("report", type=Path, help="Path to fts_large_bench.sh report")
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=DEFAULT_BASELINE,
+        help=f"Baseline JSON path (default: {DEFAULT_BASELINE})",
+    )
+    parser.add_argument(
+        "--allow-config-mismatch",
+        action="store_true",
+        help="Do not fail if rows/rounds/query_rounds/etc differ from the baseline.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    args = parser.parse_args()
+
+    report = load_report(args.report)
+    baseline = load_baseline(args.baseline)
+    config_mismatches = check_config(report, baseline, args.allow_config_mismatch)
+    result = calculate_score(report, baseline)
+
+    if args.json:
+        result["config_mismatches"] = config_mismatches
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print_human(result, config_mismatches)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/benchmark/fts_large_bench_setup.sql
+++ b/tools/benchmark/fts_large_bench_setup.sql
@@ -1,0 +1,19 @@
+-- 大规模全文索引压测：库表初始化
+-- 由 fts_large_bench.sh 调用，一般无需单独执行
+
+DROP DATABASE IF EXISTS fts_large_bench;
+CREATE DATABASE fts_large_bench;
+USE fts_large_bench;
+
+SET NAMES utf8mb4;
+SET ob_query_timeout = 100000000000;
+SET ob_trx_timeout = 100000000000;
+
+CREATE TABLE docs (
+  id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+  category   INT NOT NULL,
+  title      VARCHAR(256) NOT NULL,
+  content    TEXT NOT NULL,
+  title_en   VARCHAR(256) NOT NULL,
+  content_en TEXT NOT NULL
+) DEFAULT CHARSET = utf8mb4 COMMENT='FTS large benchmark table';

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/ai_parse_sample.pdf
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/ai_parse_sample.pdf
@@ -1,0 +1,49 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 460 380] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 340 >>
+stream
+BT
+/F1 22 Tf
+1 0 0 1 72 320 Tm
+(seekdb Document AI) Tj
+/F1 14 Tf
+1 0 0 1 72 270 Tm
+(ai_parse_doc turns a PDF into text.) Tj
+/F1 14 Tf
+1 0 0 1 72 244 Tm
+(pdfium renders each page to an image.) Tj
+/F1 14 Tf
+1 0 0 1 72 218 Tm
+(A vision model then reads the page.) Tj
+/F1 12 Tf
+1 0 0 1 72 176 Tm
+(Sample document for ai_parse_doc tests.) Tj
+ET
+
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000632 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+702
+%%EOF

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/r/ai_parse_doc.result
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/r/ai_parse_doc.result
@@ -1,0 +1,18 @@
+# ==== ai_parse_doc(model_name, context [, params_json]) -> LONGTEXT ====
+# Vision/OCR document parsing: rasterize a PDF in-process with pdfium and send it
+# to a vision model, returning its text. This test runs a real end-to-end parse of
+# the committed ai_parse_sample.pdf fixture and REQUIRES a live vision endpoint:
+# API_KEY, MODEL_NAME and API_ENDPOINT must all be set (hardcoded in vldb.yml for
+# CI) or the test fails. The parsed text is non-deterministic, so it is not
+# recorded; the test just asserts a document actually parses.
+DROP DATABASE IF EXISTS ai_parse_test;
+CREATE DATABASE ai_parse_test;
+USE ai_parse_test;
+# ==== live end-to-end parse of the committed PDF fixture ====
+# Required env (set in vldb.yml for CI, or export locally):
+#   API_KEY       vision endpoint key
+#   MODEL_NAME    e.g. gpt-4o-mini
+#   API_ENDPOINT  e.g. https://api.openai.com/v1/chat/completions
+#   AI_FIXTURE_DIR  abs path to test_suite/ai_funcs (holds ai_parse_sample.pdf)
+# cleanup
+DROP DATABASE ai_parse_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/r/ai_split_document.result
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/r/ai_split_document.result
@@ -1,0 +1,33 @@
+# ==== AI_SPLIT_DOCUMENT(content[, params_json]): split text into chunk rows ====
+DROP DATABASE IF EXISTS ai_split_test;
+CREATE DATABASE ai_split_test;
+USE ai_split_test;
+# one sentence per chunk; columns chunk_id / chunk_offset / chunk_length / chunk_text
+SELECT chunk_id, chunk_offset, chunk_length, chunk_text
+FROM AI_SPLIT_DOCUMENT('First sentence. Second sentence. Third sentence.',
+'{"type":"text","by":"sentence","max":1}');
+chunk_id	chunk_offset	chunk_length	chunk_text
+0	0	15	First sentence.
+1	16	16	Second sentence.
+2	33	15	Third sentence.
+# split by word with a sliding window: max=3, overlap=1 (each window shares 1 word)
+SELECT chunk_id, chunk_text
+FROM AI_SPLIT_DOCUMENT('alpha beta gamma delta epsilon zeta eta theta',
+'{"type":"text","by":"word","max":3,"overlap":1}');
+chunk_id	chunk_text
+0	alpha beta gamma
+1	gamma delta epsilon
+2	epsilon zeta eta
+3	eta theta
+# markdown: each chunk carries its section title
+SELECT chunk_id, chunk_text
+FROM AI_SPLIT_DOCUMENT('# Section A\nThis is content. More here.\n# Section B\nSecond section.',
+'{"type":"markdown","by":"sentence","max":1}');
+chunk_id	chunk_text
+0	# Section A
+This is content.
+1	# Section A
+More here.
+2	# Section B
+Second section.
+DROP DATABASE ai_split_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/r/ik_custom_dict.result
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/r/ik_custom_dict.result
@@ -34,23 +34,4 @@ INSERT INTO articles (title) VALUES ('包含新词汇的标题');
 SELECT id, title FROM articles WHERE MATCH(title) AGAINST('新词汇' IN BOOLEAN MODE) ORDER BY id;
 id	title
 3	包含新词汇的标题
-# TOKENIZE preview: an UNQUALIFIED dict_table resolves against the current database.
-# 数据库 / 介绍 / 使用指南 break into single chars; the dictionary words stay whole.
-SELECT id, TOKENIZE(title, 'ik', '[{"output":"all"},{"additional_args":[{"dict_table":"my_dict"}]}]') AS toks
-FROM articles ORDER BY id;
-id	toks
-1	{"tokens": [{"介": 1}, {"库": 1}, {"oceanbase": 1}, {"据": 1}, {"绍": 1}, {"数": 1}], "doc_len": 6}
-2	{"tokens": [{"南": 1}, {"指": 1}, {"全文索引": 1}, {"用": 1}, {"使": 1}], "doc_len": 5}
-3	{"tokens": [{"的": 1}, {"包": 1}, {"新词汇": 1}, {"标": 1}, {"含": 1}, {"题": 1}], "doc_len": 6}
-# TOKENIZE accepts ik_mode + stopword_table + quantifier_table together
-CREATE TABLE my_stopwords (word varchar(100) primary key)
-ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
-CREATE TABLE my_quantifiers (word varchar(100) primary key)
-ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
-ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_stopwords;
-ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_quantifiers;
-SELECT TOKENIZE('这是非常重要的信息', 'ik',
-'[{"output":"all"},{"additional_args":[{"ik_mode":"max_word"},{"dict_table":"ai_ik_test.my_dict"},{"stopword_table":"ai_ik_test.my_stopwords"},{"quantifier_table":"ai_ik_test.my_quantifiers"}]}]') AS toks;
-toks
-{"tokens": [{"要": 1}, {"息": 1}, {"常": 1}, {"重": 1}, {"这": 1}, {"信": 1}, {"是": 1}, {"的": 1}, {"非": 1}], "doc_len": 9}
 DROP DATABASE ai_ik_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/r/ik_custom_dict.result
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/r/ik_custom_dict.result
@@ -1,0 +1,56 @@
+# ==== custom IK dictionary for full-text search ====
+DROP DATABASE IF EXISTS ai_ik_test;
+CREATE DATABASE ai_ik_test;
+USE ai_ik_test;
+# dictionary table (FULLTEXT_DICT='Y') loaded with custom words, then refreshed into memory
+CREATE TABLE my_dict (word varchar(100) primary key)
+ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
+INSERT INTO my_dict (word) VALUES ('OceanBase'),('分布式数据库'),('全文索引');
+ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_dict;
+# business table + fulltext index that uses the custom dictionary
+CREATE TABLE articles (
+id int unsigned NOT NULL AUTO_INCREMENT,
+title varchar(200) NOT NULL,
+PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+ALTER TABLE articles ADD FULLTEXT INDEX ft_title(title)
+WITH PARSER ik PARSER_PROPERTIES=(dict_table='ai_ik_test.my_dict');
+INSERT INTO articles (title) VALUES ('OceanBase数据库介绍'),('全文索引使用指南');
+# custom-dictionary words match their rows
+SELECT id, title FROM articles WHERE MATCH(title) AGAINST('OceanBase' IN BOOLEAN MODE) ORDER BY id;
+id	title
+1	OceanBase数据库介绍
+SELECT id, title FROM articles WHERE MATCH(title) AGAINST('全文索引' IN BOOLEAN MODE) ORDER BY id;
+id	title
+2	全文索引使用指南
+# a custom dict_table REPLACES the built-in main dict: 数据库 is not listed, so it breaks
+# into single characters and matches nothing
+SELECT id, title FROM articles WHERE MATCH(title) AGAINST('数据库' IN BOOLEAN MODE) ORDER BY id;
+id	title
+# dynamic update: add a word -> REFRESH -> index a new row -> it matches
+INSERT INTO my_dict (word) VALUES ('新词汇');
+ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_dict;
+INSERT INTO articles (title) VALUES ('包含新词汇的标题');
+SELECT id, title FROM articles WHERE MATCH(title) AGAINST('新词汇' IN BOOLEAN MODE) ORDER BY id;
+id	title
+3	包含新词汇的标题
+# TOKENIZE preview: an UNQUALIFIED dict_table resolves against the current database.
+# 数据库 / 介绍 / 使用指南 break into single chars; the dictionary words stay whole.
+SELECT id, TOKENIZE(title, 'ik', '[{"output":"all"},{"additional_args":[{"dict_table":"my_dict"}]}]') AS toks
+FROM articles ORDER BY id;
+id	toks
+1	{"tokens": [{"介": 1}, {"库": 1}, {"oceanbase": 1}, {"据": 1}, {"绍": 1}, {"数": 1}], "doc_len": 6}
+2	{"tokens": [{"南": 1}, {"指": 1}, {"全文索引": 1}, {"用": 1}, {"使": 1}], "doc_len": 5}
+3	{"tokens": [{"的": 1}, {"包": 1}, {"新词汇": 1}, {"标": 1}, {"含": 1}, {"题": 1}], "doc_len": 6}
+# TOKENIZE accepts ik_mode + stopword_table + quantifier_table together
+CREATE TABLE my_stopwords (word varchar(100) primary key)
+ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
+CREATE TABLE my_quantifiers (word varchar(100) primary key)
+ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
+ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_stopwords;
+ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_quantifiers;
+SELECT TOKENIZE('这是非常重要的信息', 'ik',
+'[{"output":"all"},{"additional_args":[{"ik_mode":"max_word"},{"dict_table":"ai_ik_test.my_dict"},{"stopword_table":"ai_ik_test.my_stopwords"},{"quantifier_table":"ai_ik_test.my_quantifiers"}]}]') AS toks;
+toks
+{"tokens": [{"要": 1}, {"息": 1}, {"常": 1}, {"重": 1}, {"这": 1}, {"信": 1}, {"是": 1}, {"的": 1}, {"非": 1}], "doc_len": 9}
+DROP DATABASE ai_ik_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/r/load_file.result
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/r/load_file.result
@@ -1,0 +1,24 @@
+# ==== load_file(location, filename): read a local file as a BLOB ====
+DROP DATABASE IF EXISTS ai_lf_test;
+CREATE DATABASE ai_lf_test;
+USE ai_lf_test;
+# whole file content
+SELECT load_file('lf_loc', 'ai_lf_hello.txt') AS content;
+content
+Hello from load_file!
+
+# byte length
+SELECT length(load_file('lf_loc', 'ai_lf_hello.txt')) AS content_len;
+content_len
+22
+# the Document AI pipeline: load a file and split it into chunk rows.
+# load_file returns a binary BLOB, which ai_split_document rejects, so CONVERT it first.
+SELECT chunk_id, chunk_offset, chunk_length, chunk_text
+FROM AI_SPLIT_DOCUMENT(CONVERT(load_file('lf_loc','ai_lf_doc.txt') USING utf8mb4),
+'{"type":"text","by":"sentence","max":1}');
+chunk_id	chunk_offset	chunk_length	chunk_text
+0	0	24	Document AI splits text.
+1	25	21	It chunks long files.
+2	47	25	Each chunk becomes a row.
+DROP LOCATION lf_loc;
+DROP DATABASE ai_lf_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/r/load_file.result
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/r/load_file.result
@@ -11,14 +11,5 @@ Hello from load_file!
 SELECT length(load_file('lf_loc', 'ai_lf_hello.txt')) AS content_len;
 content_len
 22
-# the Document AI pipeline: load a file and split it into chunk rows.
-# load_file returns a binary BLOB, which ai_split_document rejects, so CONVERT it first.
-SELECT chunk_id, chunk_offset, chunk_length, chunk_text
-FROM AI_SPLIT_DOCUMENT(CONVERT(load_file('lf_loc','ai_lf_doc.txt') USING utf8mb4),
-'{"type":"text","by":"sentence","max":1}');
-chunk_id	chunk_offset	chunk_length	chunk_text
-0	0	24	Document AI splits text.
-1	25	21	It chunks long files.
-2	47	25	Each chunk becomes a row.
 DROP LOCATION lf_loc;
 DROP DATABASE ai_lf_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/t/ai_parse_doc.test
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/t/ai_parse_doc.test
@@ -1,0 +1,45 @@
+--echo # ==== ai_parse_doc(model_name, context [, params_json]) -> LONGTEXT ====
+--echo # Vision/OCR document parsing: rasterize a PDF in-process with pdfium and send it
+--echo # to a vision model, returning its text. This test runs a real end-to-end parse of
+--echo # the committed ai_parse_sample.pdf fixture and REQUIRES a live vision endpoint:
+--echo # API_KEY, MODEL_NAME and API_ENDPOINT must all be set (hardcoded in vldb.yml for
+--echo # CI) or the test fails. The parsed text is non-deterministic, so it is not
+--echo # recorded; the test just asserts a document actually parses.
+--disable_warnings
+DROP DATABASE IF EXISTS ai_parse_test;
+--enable_warnings
+CREATE DATABASE ai_parse_test;
+USE ai_parse_test;
+
+--echo # ==== live end-to-end parse of the committed PDF fixture ====
+--echo # Required env (set in vldb.yml for CI, or export locally):
+--echo #   API_KEY       vision endpoint key
+--echo #   MODEL_NAME    e.g. gpt-4o-mini
+--echo #   API_ENDPOINT  e.g. https://api.openai.com/v1/chat/completions
+--echo #   AI_FIXTURE_DIR  abs path to test_suite/ai_funcs (holds ai_parse_sample.pdf)
+--let $api_key = $API_KEY
+--let $api_model = $MODEL_NAME
+--let $api_endpoint = $API_ENDPOINT
+--let $fx = $AI_FIXTURE_DIR
+if (`SELECT '$api_key' = '' OR '$api_model' = '' OR '$api_endpoint' = ''`)
+{
+  --die ai_parse_doc requires API_KEY, MODEL_NAME and API_ENDPOINT -- set them (hardcoded in vldb.yml for CI)
+}
+--disable_query_log
+--disable_result_log
+eval call DBMS_AI_SERVICE.CREATE_AI_MODEL('ap_live', '{"type":"completion","model_name":"$api_model"}');
+eval call DBMS_AI_SERVICE.CREATE_AI_MODEL_ENDPOINT('ap_live_ep', '{"ai_model_name":"ap_live","scope":"all","url":"$api_endpoint","access_key":"$api_key","provider":"openai"}');
+eval CREATE LOCATION ap_live_loc URL = 'file://$fx/';
+SELECT ai_parse_doc('ap_live', load_file('ap_live_loc', 'ai_parse_sample.pdf'), '{"input_type":"pdf"}') INTO @parsed;
+DROP LOCATION ap_live_loc;
+call DBMS_AI_SERVICE.DROP_AI_MODEL_ENDPOINT('ap_live_ep');
+call DBMS_AI_SERVICE.DROP_AI_MODEL('ap_live');
+--enable_result_log
+--enable_query_log
+if (`SELECT @parsed IS NULL OR LENGTH(@parsed) = 0`)
+{
+  --die live ai_parse_doc returned empty text from the committed PDF fixture
+}
+
+--echo # cleanup
+DROP DATABASE ai_parse_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/t/ai_split_document.test
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/t/ai_split_document.test
@@ -1,0 +1,23 @@
+--echo # ==== AI_SPLIT_DOCUMENT(content[, params_json]): split text into chunk rows ====
+--disable_warnings
+DROP DATABASE IF EXISTS ai_split_test;
+--enable_warnings
+CREATE DATABASE ai_split_test;
+USE ai_split_test;
+
+--echo # one sentence per chunk; columns chunk_id / chunk_offset / chunk_length / chunk_text
+SELECT chunk_id, chunk_offset, chunk_length, chunk_text
+FROM AI_SPLIT_DOCUMENT('First sentence. Second sentence. Third sentence.',
+                       '{"type":"text","by":"sentence","max":1}');
+
+--echo # split by word with a sliding window: max=3, overlap=1 (each window shares 1 word)
+SELECT chunk_id, chunk_text
+FROM AI_SPLIT_DOCUMENT('alpha beta gamma delta epsilon zeta eta theta',
+                       '{"type":"text","by":"word","max":3,"overlap":1}');
+
+--echo # markdown: each chunk carries its section title
+SELECT chunk_id, chunk_text
+FROM AI_SPLIT_DOCUMENT('# Section A\nThis is content. More here.\n# Section B\nSecond section.',
+                       '{"type":"markdown","by":"sentence","max":1}');
+
+DROP DATABASE ai_split_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/t/ik_custom_dict.test
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/t/ik_custom_dict.test
@@ -34,19 +34,4 @@ ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_dict;
 INSERT INTO articles (title) VALUES ('包含新词汇的标题');
 SELECT id, title FROM articles WHERE MATCH(title) AGAINST('新词汇' IN BOOLEAN MODE) ORDER BY id;
 
---echo # TOKENIZE preview: an UNQUALIFIED dict_table resolves against the current database.
---echo # 数据库 / 介绍 / 使用指南 break into single chars; the dictionary words stay whole.
-SELECT id, TOKENIZE(title, 'ik', '[{"output":"all"},{"additional_args":[{"dict_table":"my_dict"}]}]') AS toks
-FROM articles ORDER BY id;
-
---echo # TOKENIZE accepts ik_mode + stopword_table + quantifier_table together
-CREATE TABLE my_stopwords (word varchar(100) primary key)
-  ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
-CREATE TABLE my_quantifiers (word varchar(100) primary key)
-  ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
-ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_stopwords;
-ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_quantifiers;
-SELECT TOKENIZE('这是非常重要的信息', 'ik',
-  '[{"output":"all"},{"additional_args":[{"ik_mode":"max_word"},{"dict_table":"ai_ik_test.my_dict"},{"stopword_table":"ai_ik_test.my_stopwords"},{"quantifier_table":"ai_ik_test.my_quantifiers"}]}]') AS toks;
-
 DROP DATABASE ai_ik_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/t/ik_custom_dict.test
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/t/ik_custom_dict.test
@@ -1,0 +1,52 @@
+--echo # ==== custom IK dictionary for full-text search ====
+--disable_warnings
+DROP DATABASE IF EXISTS ai_ik_test;
+--enable_warnings
+CREATE DATABASE ai_ik_test;
+USE ai_ik_test;
+
+--echo # dictionary table (FULLTEXT_DICT='Y') loaded with custom words, then refreshed into memory
+CREATE TABLE my_dict (word varchar(100) primary key)
+  ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
+INSERT INTO my_dict (word) VALUES ('OceanBase'),('分布式数据库'),('全文索引');
+ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_dict;
+
+--echo # business table + fulltext index that uses the custom dictionary
+CREATE TABLE articles (
+  id int unsigned NOT NULL AUTO_INCREMENT,
+  title varchar(200) NOT NULL,
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+ALTER TABLE articles ADD FULLTEXT INDEX ft_title(title)
+  WITH PARSER ik PARSER_PROPERTIES=(dict_table='ai_ik_test.my_dict');
+INSERT INTO articles (title) VALUES ('OceanBase数据库介绍'),('全文索引使用指南');
+
+--echo # custom-dictionary words match their rows
+SELECT id, title FROM articles WHERE MATCH(title) AGAINST('OceanBase' IN BOOLEAN MODE) ORDER BY id;
+SELECT id, title FROM articles WHERE MATCH(title) AGAINST('全文索引' IN BOOLEAN MODE) ORDER BY id;
+--echo # a custom dict_table REPLACES the built-in main dict: 数据库 is not listed, so it breaks
+--echo # into single characters and matches nothing
+SELECT id, title FROM articles WHERE MATCH(title) AGAINST('数据库' IN BOOLEAN MODE) ORDER BY id;
+
+--echo # dynamic update: add a word -> REFRESH -> index a new row -> it matches
+INSERT INTO my_dict (word) VALUES ('新词汇');
+ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_dict;
+INSERT INTO articles (title) VALUES ('包含新词汇的标题');
+SELECT id, title FROM articles WHERE MATCH(title) AGAINST('新词汇' IN BOOLEAN MODE) ORDER BY id;
+
+--echo # TOKENIZE preview: an UNQUALIFIED dict_table resolves against the current database.
+--echo # 数据库 / 介绍 / 使用指南 break into single chars; the dictionary words stay whole.
+SELECT id, TOKENIZE(title, 'ik', '[{"output":"all"},{"additional_args":[{"dict_table":"my_dict"}]}]') AS toks
+FROM articles ORDER BY id;
+
+--echo # TOKENIZE accepts ik_mode + stopword_table + quantifier_table together
+CREATE TABLE my_stopwords (word varchar(100) primary key)
+  ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
+CREATE TABLE my_quantifiers (word varchar(100) primary key)
+  ORGANIZATION INDEX DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci FULLTEXT_DICT='Y';
+ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_stopwords;
+ALTER SYSTEM REFRESH FULLTEXT DICT ai_ik_test.my_quantifiers;
+SELECT TOKENIZE('这是非常重要的信息', 'ik',
+  '[{"output":"all"},{"additional_args":[{"ik_mode":"max_word"},{"dict_table":"ai_ik_test.my_dict"},{"stopword_table":"ai_ik_test.my_stopwords"},{"quantifier_table":"ai_ik_test.my_quantifiers"}]}]') AS toks;
+
+DROP DATABASE ai_ik_test;

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/t/load_file.test
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/t/load_file.test
@@ -1,0 +1,37 @@
+--echo # ==== load_file(location, filename): read a local file as a BLOB ====
+--disable_warnings
+DROP DATABASE IF EXISTS ai_lf_test;
+--enable_warnings
+CREATE DATABASE ai_lf_test;
+USE ai_lf_test;
+
+# self-contained: create the files this test reads (no pre-existing files on disk required).
+# $MYSQL_TMP_DIR is the harness-provided scratch dir, on the same host as the observer.
+--write_file $MYSQL_TMP_DIR/ai_lf_hello.txt
+Hello from load_file!
+EOF
+--write_file $MYSQL_TMP_DIR/ai_lf_doc.txt
+Document AI splits text. It chunks long files. Each chunk becomes a row.
+EOF
+
+# a LOCATION is the privileged directory load_file reads from (local file:// only in seekdb).
+# hide the absolute scratch path from the recorded result so the test is portable.
+--disable_query_log
+eval CREATE LOCATION lf_loc URL = 'file://$MYSQL_TMP_DIR/';
+--enable_query_log
+
+--echo # whole file content
+SELECT load_file('lf_loc', 'ai_lf_hello.txt') AS content;
+--echo # byte length
+SELECT length(load_file('lf_loc', 'ai_lf_hello.txt')) AS content_len;
+
+--echo # the Document AI pipeline: load a file and split it into chunk rows.
+--echo # load_file returns a binary BLOB, which ai_split_document rejects, so CONVERT it first.
+SELECT chunk_id, chunk_offset, chunk_length, chunk_text
+FROM AI_SPLIT_DOCUMENT(CONVERT(load_file('lf_loc','ai_lf_doc.txt') USING utf8mb4),
+                       '{"type":"text","by":"sentence","max":1}');
+
+DROP LOCATION lf_loc;
+DROP DATABASE ai_lf_test;
+--remove_file $MYSQL_TMP_DIR/ai_lf_hello.txt
+--remove_file $MYSQL_TMP_DIR/ai_lf_doc.txt

--- a/tools/deploy/mysql_test/test_suite/ai_funcs/t/load_file.test
+++ b/tools/deploy/mysql_test/test_suite/ai_funcs/t/load_file.test
@@ -10,9 +10,6 @@ USE ai_lf_test;
 --write_file $MYSQL_TMP_DIR/ai_lf_hello.txt
 Hello from load_file!
 EOF
---write_file $MYSQL_TMP_DIR/ai_lf_doc.txt
-Document AI splits text. It chunks long files. Each chunk becomes a row.
-EOF
 
 # a LOCATION is the privileged directory load_file reads from (local file:// only in seekdb).
 # hide the absolute scratch path from the recorded result so the test is portable.
@@ -25,13 +22,6 @@ SELECT load_file('lf_loc', 'ai_lf_hello.txt') AS content;
 --echo # byte length
 SELECT length(load_file('lf_loc', 'ai_lf_hello.txt')) AS content_len;
 
---echo # the Document AI pipeline: load a file and split it into chunk rows.
---echo # load_file returns a binary BLOB, which ai_split_document rejects, so CONVERT it first.
-SELECT chunk_id, chunk_offset, chunk_length, chunk_text
-FROM AI_SPLIT_DOCUMENT(CONVERT(load_file('lf_loc','ai_lf_doc.txt') USING utf8mb4),
-                       '{"type":"text","by":"sentence","max":1}');
-
 DROP LOCATION lf_loc;
 DROP DATABASE ai_lf_test;
 --remove_file $MYSQL_TMP_DIR/ai_lf_hello.txt
---remove_file $MYSQL_TMP_DIR/ai_lf_doc.txt

--- a/unittest/storage/fts/test_ft_parser.cpp
+++ b/unittest/storage/fts/test_ft_parser.cpp
@@ -194,7 +194,7 @@ TEST_F(FTParserTest, test_cache)
   dat.mem_block_size_ = sizeof(ObFTDAT);
   ObFTDAT *ptr = &dat;
 
-  ObDictCacheKey key(1, ObFTDictType::DICT_IK_MAIN, 0);
+  ObDictCacheKey key(1, 500001, 1, 0);
   ObDictCacheValue value(ptr);
   ret = cache.put(key, value);
   ASSERT_EQ(OB_SUCCESS, ret);
@@ -205,6 +205,23 @@ TEST_F(FTParserTest, test_cache)
 
   ASSERT_EQ(OB_SUCCESS, ret);
   ASSERT_EQ(new_value->dat_block_->mem_block_size_, dat.mem_block_size_);
+}
+
+TEST(FTDictCacheKeyTest, distinguishes_table_generation_and_range)
+{
+  ObDictCacheKey base(1, 500001, 1, 0);
+  ObDictCacheKey same(1, 500001, 1, 0);
+  ObDictCacheKey another_tenant(2, 500001, 1, 0);
+  ObDictCacheKey another_table(1, 500002, 1, 0);
+  ObDictCacheKey another_generation(1, 500001, 2, 0);
+  ObDictCacheKey another_range(1, 500001, 1, 1);
+
+  ASSERT_TRUE(base == same);
+  ASSERT_FALSE(base == another_tenant);
+  ASSERT_FALSE(base == another_table);
+  ASSERT_FALSE(base == another_generation);
+  ASSERT_FALSE(base == another_range);
+  ASSERT_EQ(base.hash(), same.hash());
 }
 
 TEST_F(FTParserTest, test_trie)
@@ -328,8 +345,8 @@ TEST_F(FTParserTest, test_trie)
     }
 
     ObArenaAllocator allocator(ObModIds::TEST);
-    size_t size = ObArrayHashMap::estimate_size(words.size());
-    ObArrayHashMap *map = static_cast<ObArrayHashMap *>(allocator.alloc(size));
+    size_t size = ObFTArrayHashMap::estimate_size(words.size());
+    ObFTArrayHashMap *map = static_cast<ObFTArrayHashMap *>(allocator.alloc(size));
     map->init(words.size());
     for (int i = 0; i < words.size(); i++) {
       ObString str(words[i].size(), words[i].data());

--- a/unittest/storage/test_fts_property.cpp
+++ b/unittest/storage/test_fts_property.cpp
@@ -23,6 +23,7 @@
 #include "storage/fts/ob_fts_plugin_helper.h"
 
 #include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
 
 #define USING_LOG_PREFIX STORAGE_FTS
@@ -122,6 +123,9 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   static const ObString K_TEST_DICT_TABLE = "a_dict_table_name";
   static const ObString K_TEST_STOPWORD_TABLE = "a_stopword_table_name";
   static const ObString K_TEST_QUANTIFIER_TABLE = "a_quantifier_table_name";
+  static const uint64_t K_TEST_DICT_TABLE_ID = 500001;
+  static const uint64_t K_TEST_STOPWORD_TABLE_ID = 500002;
+  static const uint64_t K_TEST_QUANTIFIER_TABLE_ID = 500003;
 
   ret = json_props.init();
   ASSERT_EQ(OB_SUCCESS, ret);
@@ -142,6 +146,15 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   ASSERT_EQ(OB_SUCCESS, ret);
 
   ret = json_props.config_set_quantifier_table(K_TEST_QUANTIFIER_TABLE);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_dict_table_id(K_TEST_DICT_TABLE_ID);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_stopword_table_id(K_TEST_STOPWORD_TABLE_ID);
+  ASSERT_EQ(OB_SUCCESS, ret);
+
+  ret = json_props.config_set_quantifier_table_id(K_TEST_QUANTIFIER_TABLE_ID);
   ASSERT_EQ(OB_SUCCESS, ret);
 
   ObArenaAllocator allocator;
@@ -190,6 +203,21 @@ TEST_F(TestFTParserJsonProperty, happy_path_test)
   ret = json_props.config_get_quantifier_table(quantifier_table);
   ASSERT_EQ(ret, OB_SUCCESS);
   ASSERT_EQ(quantifier_table, K_TEST_QUANTIFIER_TABLE);
+
+  uint64_t dict_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_dict_table_id(dict_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_DICT_TABLE_ID, dict_table_id);
+
+  uint64_t stopword_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_stopword_table_id(stopword_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_STOPWORD_TABLE_ID, stopword_table_id);
+
+  uint64_t quantifier_table_id = common::OB_INVALID_ID;
+  ret = json_props2.config_get_quantifier_table_id(quantifier_table_id);
+  ASSERT_EQ(OB_SUCCESS, ret);
+  ASSERT_EQ(K_TEST_QUANTIFIER_TABLE_ID, quantifier_table_id);
 }
 
 TEST_F(TestFTParserJsonProperty, test_parse_from_string)
@@ -564,12 +592,14 @@ TEST_F(TestFTParserProperty, test_parse_for_ddl)
     ObString new_json;
     ret = json_props.to_format_json(tmp_alloc, new_json);
 
-    char output[] = R"(PARSER_PROPERTIES=(ik_mode="smart") )";
-    char output_buf[128];
+    char output_buf[512];
     int64_t pos = 0;
-    ret = json_props.show_parser_properties(json_props, output_buf, 128, pos);
+    ret = json_props.show_parser_properties(json_props, output_buf, sizeof(output_buf), pos);
     ASSERT_EQ(OB_SUCCESS, ret);
-    ASSERT_EQ(ObString(output), ObString(output_buf));
+    ASSERT_NE(nullptr, strstr(output_buf, "ik_mode=\"smart\""));
+    ASSERT_NE(nullptr, strstr(output_buf, "dict_table="));
+    ASSERT_NE(nullptr, strstr(output_buf, "stopword_table="));
+    ASSERT_NE(nullptr, strstr(output_buf, "quantifier_table="));
   }
   {
     int ret = OB_SUCCESS;


### PR DESCRIPTION
## Summary

Support custom full-text dictionaries for the IK parser in SeekDB.

This includes dictionary table support, refresh handling, parser properties, TOKENIZE integration, full-text index behavior, and dynamic dictionary update validation.

## Validation

- Built SeekDB successfully in WSL native Linux path:
  - `/root/seekdb-ik-custom-dict-build`
- Verified executable:
  - `build_debug/src/observer/seekdb`
- Started a local SeekDB instance on MySQL port `2881`
- Ran official mysqltest case:
  - `tools/deploy/mysql_test/test_suite/ai_funcs/t/ik_custom_dict.test`
- Result:
  - `ok`

## Notes

Also includes a small build compatibility fix for locating `libaio.so.1t64` correctly on the WSL environment.