### PR TITLE
[seekdb][virtual table] Fix HA diagnose row lifetime

### DIFF
--- a/src/observer/virtual_table/ob_all_virtual_ha_diagnose.cpp
+++ b/src/observer/virtual_table/ob_all_virtual_ha_diagnose.cpp
@@ -35,17 +35,27 @@ int ObAllVirtualHADiagnose::inner_get_next_row(common::ObNewRow *&row)
       SERVER_LOG(WARN, "diagnose ls failed", K(ret));
     } else if (OB_FAIL(insert_stat_(diagnose_info))) {
       SERVER_LOG(WARN, "insert stat failed", K(ret), K(diagnose_info));
+    // Some varchar cells reference buffers owned by diagnose_info, so copy the row
+    // into scanner_ before diagnose_info is destroyed.
+    } else if (OB_FAIL(scanner_.add_row(cur_row_))) {
+      SERVER_LOG(WARN, "add diagnose info to scanner failed", K(ret), K(diagnose_info));
     } else {
+      scanner_it_ = scanner_.begin();
+      start_to_read_ = true;
       SERVER_LOG(INFO, "diagnose ls success", K(diagnose_info));
     }
     if (OB_FAIL(ret)) {
       SERVER_LOG(WARN, "iter tenant failed", K(ret));
+    }
+  }
+  if (OB_SUCC(ret) && start_to_read_) {
+    if (OB_FAIL(scanner_it_.get_next_row(cur_row_))) {
+      if (OB_ITER_END != ret) {
+        SERVER_LOG(WARN, "get next row failed", K(ret));
+      }
     } else {
-      start_to_read_ = true;
       row = &cur_row_;
     }
-  } else {
-    ret = OB_ITER_END;
   }
   return ret;
 }


### PR DESCRIPTION
## Task Description
During DDL/vector index stress, DBMS_STATS scanning `oceanbase.__all_virtual_ha_diagnose` triggered a `memory_sanity_abort` in `ObVirtualTableIterator::get_next_row`. The single-LS refactor returned `cur_row_` directly after removing `scanner_.add_row`. VARCHAR cells referenced buffers owned by the stack-local `storage::DiagnoseInfo`, which became dangling before the base iterator converted the row.

## Solution Description
Restore `scanner_.add_row(cur_row_)` to deep-copy row values before the `DiagnoseInfo` object is destroyed. The row is then returned through `scanner_it_`. The current single-LS diagnose behavior remains unchanged.

## Passed Regressions
- `bash build.sh sanity --ob-make`
- Queried `replay_diagnose_info` and `readonly_tx` from `oceanbase.__all_virtual_ha_diagnose` under the sanity build.
- Confirmed the server remained alive after the query and logs contained no `memory_sanity_abort` or `SANITY_CHECK_RANGE`.

## Upgrade Compatibility
No schema, protocol, or persisted-data change.

## Other Information
This MR contains one commit: `5f73d6a578a` Fix HA diagnose row lifetime.
The local `issue.md` reproduction note is not included.

## Release Note
