### PR TITLE
Fixed seekdb macOS compilation bug

### DIFF
--- a/src/share/ob_telemetry.cpp
+++ b/src/share/ob_telemetry.cpp
@@ -21,11 +21,7 @@
 #include "share/config/ob_server_config.h"
 #include "share/ob_encryption_util.h"
 #include "common/ob_version_def.h"
-#ifdef __APPLE__
-#include <unistd.h>
-#else
 #include <curl/curl.h>
-#endif
 
 #define USING_LOG_PREFIX SHARE
 
@@ -203,26 +199,6 @@ int generate_telemetry_json(const char* reporter, const char* event_name, ObIAll
   return ret;
 }
 
-// macOS: Use system curl command to avoid libcurl ssl issues
-int send_telemetry_by_curl_cmd(const char *url)
-{
-  int ret = OB_SUCCESS;
-  // Use existing run/telemetry.json file which is already written by generate_telemetry_json()
-  char cmd[512];
-  snprintf(cmd, sizeof(cmd),
-           "curl -s -X POST -H \"Content-Type: application/json\" "
-           "-d @%s --connect-timeout 10 -m 15 \"%s\" >/dev/null 2>&1",
-           TELEMETRY_FILE_NAME, url);
-
-  int sys_ret = system(cmd);
-  if (sys_ret != 0) {
-    ret = OB_CURL_ERROR;
-    LOG_ERROR("Failed to execute curl command for telemetry", K(ret), K(sys_ret), K(url));
-  }
-  return ret;
-}
-// Linux: Use libcurl
-#ifndef __APPLE__
 static size_t discard(void* ptr, size_t size, size_t nmemb, void* userdata) {
   return size * nmemb;
 }
@@ -274,7 +250,6 @@ int send_telemetry_by_libcurl(const char *url, const ObString &json_str)
   }
   return ret;
 }
-#endif
 
 int send_telemetry(const char *url, const ObString &json_str)
 {
@@ -283,12 +258,7 @@ int send_telemetry(const char *url, const ObString &json_str)
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Invalid argument", K(ret), KP(url), K(json_str));
   } else {
-#ifdef __APPLE__
-    // macOS uses the telemetry file directly, json_str already written to TELEMETRY_FILE_NAME
-    ret = send_telemetry_by_curl_cmd(url);
-#else
     ret = send_telemetry_by_libcurl(url, json_str);
-#endif
   }
   return ret;
 }

--- a/src/share/ob_telemetry.cpp
+++ b/src/share/ob_telemetry.cpp
@@ -222,6 +222,7 @@ int send_telemetry_by_curl_cmd(const char *url)
   return ret;
 }
 // Linux: Use libcurl
+#ifndef __APPLE__
 static size_t discard(void* ptr, size_t size, size_t nmemb, void* userdata) {
   return size * nmemb;
 }
@@ -273,6 +274,7 @@ int send_telemetry_by_libcurl(const char *url, const ObString &json_str)
   }
   return ret;
 }
+#endif
 
 int send_telemetry(const char *url, const ObString &json_str)
 {
@@ -317,4 +319,3 @@ int report_telemetry(const char *reporter, const char *event_name)
 
 }
 }
-

--- a/src/storage/tx/ob_tx_api.cpp
+++ b/src/storage/tx/ob_tx_api.cpp
@@ -1387,7 +1387,7 @@ int ObTransService::rollback_savepoint_(ObTxDesc &tx,
                 TRANS_LOG(WARN, "retry blocking rollback", K(ret), K(tx_id), K(retry_cnt));
               }
               ++retry_cnt;
-              const int64_t retry_interval = std::min(10 * 1000 * retry_cnt, 50 * 1000L);
+              const int64_t retry_interval = std::min<int64_t>(10 * 1000 * retry_cnt, 50 * 1000);
               ob_usleep(retry_interval);
             }
           }


### PR DESCRIPTION
## Task Description
Fixed compilation errors on macOS related to `curl` and `long long` data types.

## Solution Description
On macOS, the build no longer uses `curl`. Additionally, unified the argument types for `std::min` calls to resolve type mismatch warnings/errors.

## Passed Regressions
core-test

## Upgrade Compatibility

## Other Information

## Release Note