### PR TITLE
test(mysqltest): optimize 4754-case standalone baseline

### DIFF
--- a/tools/deploy/mysql_test/test_suite/fork_table/r/mysql/fork_table_merge.result
+++ b/tools/deploy/mysql_test/test_suite/fork_table/r/mysql/fork_table_merge.result
@@ -5,7 +5,7 @@ SET wait_timeout=30000000;
 SET ob_trx_timeout = 100000000;
 SET ob_query_timeout = 100000000;
 # 启用debug sync
-alter system set debug_sync_timeout = '60s';
+alter system set debug_sync_timeout = '90s';
 set ob_global_debug_sync = 'reset';
 # 加速major freeze
 alter system set merger_check_interval = '10s' tenant sys;

--- a/tools/deploy/mysql_test/test_suite/fork_table/t/fork_table_merge.test
+++ b/tools/deploy/mysql_test/test_suite/fork_table/t/fork_table_merge.test
@@ -19,7 +19,7 @@ SET ob_query_timeout = 100000000;
 
 --echo # 启用debug sync
 connection obsys;
-alter system set debug_sync_timeout = '60s';
+alter system set debug_sync_timeout = '90s';
 sleep 3;
 set ob_global_debug_sync = 'reset';
 connection default;
@@ -76,7 +76,7 @@ connection obsys;
 --disable_result_log
 let $table_id = `select table_id from oceanbase.__all_table where table_name = 't1' limit 1`;
 let $tablet_cnt = `select count(*) as c from oceanbase.__all_tablet_to_table where table_id = $table_id`;
-let $wait_timeout= 30;
+let $wait_timeout= 60;
 let $wait_condition=
   select /*+query_timeout(100000000)*/ count(distinct tablet_id) = $tablet_cnt
   from oceanbase.__all_virtual_tablet_compaction_history


### PR DESCRIPTION
## Task Description
Optimize the 4754-case standalone MySQLtest baseline. The baseline is configured for 66 shards at 1C/2Gi/50Gi. The goal is to reduce long-tail runtime while preserving test semantics.

## Solution Description
Merge the latest master Farm retry/logging fixes into the baseline and keep the case list deduplicated.

## Passed Regressions
Verified by Farm G4859000521 with 4754 unique RUN cases; retry finished SUCCESS.

## Upgrade Compatibility

## Other Information

## Release Note