### PR TITLE
Set ObEmptyReadBucket capacity at fixed 16K buckets

### DIFF
--- a/src/storage/access/ob_empty_read_bucket.cpp
+++ b/src/storage/access/ob_empty_read_bucket.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "ob_empty_read_bucket.h"
-#include "share/config/ob_tenant_config_mgr.h"
 
 namespace oceanbase
 {
@@ -32,25 +31,17 @@ ObEmptyReadBucket::~ObEmptyReadBucket()
 {
 }
 
-int ObEmptyReadBucket::init(const int64_t lower_bound)
+int ObEmptyReadBucket::init()
 {
   int ret = OB_SUCCESS;
   char *buf = NULL;
-  //size must be 2^n, for fast mod
-  int64_t size = 1;
-  while (size <= lower_bound) {
-    size <<= 1;
-  }
-  STORAGE_LOG(DEBUG, "bucket number, ", K(size));
-  if (OB_UNLIKELY(size <= 0 || (size & (size - 1)))) {
-    ret = OB_INVALID_ARGUMENT;
-    STORAGE_LOG(WARN, "ObBloomFilterCache bucket size should be > 0 and 2^n ", K(size), K(ret));
-  } else if (OB_ISNULL(buf = static_cast<char*>(allocator_.alloc(sizeof(ObEmptyReadCell) * size)))) {
+  STORAGE_LOG(DEBUG, "bucket number", K(BUCKET_SIZE));
+  if (OB_ISNULL(buf = static_cast<char*>(allocator_.alloc(sizeof(ObEmptyReadCell) * BUCKET_SIZE)))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     STORAGE_LOG(WARN, "Fail to allocate memory, ", K(ret));
   } else {
-    buckets_ = new (buf) ObEmptyReadCell[size];
-    bucket_size_ = size;
+    buckets_ = new (buf) ObEmptyReadCell[BUCKET_SIZE];
+    bucket_size_ = BUCKET_SIZE;
   }
   return ret;
 }
@@ -58,15 +49,8 @@ int ObEmptyReadBucket::init(const int64_t lower_bound)
 int ObEmptyReadBucket::mtl_init(ObEmptyReadBucket *&bucket)
 {
   int ret = OB_SUCCESS;
-  int64_t global_mem_limit = GMEMCONF.get_server_memory_avail();
-  if (global_mem_limit <= 0) {
-    ret = OB_ERR_UNEXPECTED;
-    STORAGE_LOG(WARN, "Global memory should be greater than 0, ", K(global_mem_limit));
-  } else {
-    int64_t bucket_num_lower_bound = common::calculate_scaled_value_by_memory(BUCKET_SIZE_LOWER_LIMIT, BUCKET_SIZE_LIMIT);
-    if(OB_FAIL(bucket->init(bucket_num_lower_bound))) {
-      STORAGE_LOG(WARN, "failed to init EmptyReadBucket, ", K(ret));
-    }
+  if (OB_FAIL(bucket->init())) {
+    STORAGE_LOG(WARN, "failed to init EmptyReadBucket, ", K(ret));
   }
   return ret;
 }

--- a/src/storage/access/ob_empty_read_bucket.h
+++ b/src/storage/access/ob_empty_read_bucket.h
@@ -108,7 +108,7 @@ public:
   virtual ~ObEmptyReadBucket();
   static int mtl_init(ObEmptyReadBucket *&bucket);
   static void mtl_destroy(ObEmptyReadBucket *&bucket);
-  int init(const int64_t lower_bound);
+  int init();
   void destroy();
   OB_INLINE bool is_valid() const { return NULL != buckets_; }
   int get_cell(const uint64_t hashcode, ObEmptyReadCell *&cell);
@@ -118,8 +118,9 @@ public:
 private:
   OB_INLINE uint64_t get_bucket_size() const { return bucket_size_; }
   static const int64_t MIN_REBUILD_PERIOD_US = 1000 * 1000 * 120; //2min
-  static constexpr int64_t BUCKET_SIZE_LIMIT = 1<<20;//1048576
-  static constexpr int64_t BUCKET_SIZE_LOWER_LIMIT = 1<<14;//16384
+  static constexpr int64_t BUCKET_SIZE = 1 << 14; // 16384 buckets, about 640 KiB
+  static_assert(BUCKET_SIZE > 0 && 0 == (BUCKET_SIZE & (BUCKET_SIZE - 1)),
+                "bucket size must be a power of two");
   ObArenaAllocator allocator_;
   ObEmptyReadCell *buckets_;
   uint64_t bucket_size_;


### PR DESCRIPTION
## Task Description
Performance testing shows that the size of ObEmptyReadBucket has minimal impact on performance. Fix its capacity at 16,384 buckets, consuming approximately 640 KiB, instead of dynamically scaling the bucket count based on server memory.

## Solution Description

## Passed Regressions

## Upgrade Compatibility

## Other Information

## Release Note