### PR TITLE
[seekdb][deps] Switch al8 x86 SDKs to source submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/dependencies"]
+	path = deps/dependencies
+	url = ../seekdb-dependencies.git

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,20 @@ function echo_err() {
   echo -e "[build.sh][ERROR] $@" 1>&2
 }
 
+# Keep all native build tools and helper programs on the repository toolchain.
+# In particular, ICU and other source builds execute freshly-built host tools;
+# their runtime loader must see the matching libstdc++ from devtools as well.
+function setup_linux_toolchain_env()
+{
+    if [[ "$(uname -s)" != "Linux" || ! -d "$TOOLS_DIR/bin" ]]; then
+      return 0
+    fi
+    export PATH="$TOOLS_DIR/bin:$PATH"
+    if [[ -d "$TOOLS_DIR/lib64" ]]; then
+      export LD_LIBRARY_PATH="$TOOLS_DIR/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    fi
+}
+
 function usage
 {
     echo -e "Usage:"
@@ -184,13 +198,25 @@ function do_init
       exit 1
     fi
 
+    setup_linux_toolchain_env
+
     local source_cc="${CC:-}"
     local source_cxx="${CXX:-}"
     local source_cmake="${CMAKE_PATH:-}"
+    local source_ar="${AR:-}"
+    local source_ranlib="${RANLIB:-}"
+    local source_nm="${NM:-}"
+    local source_strip="${STRIP:-}"
+    local source_objcopy="${OBJCOPY:-}"
     if [[ "$(uname -s)" == "Linux" ]]; then
       source_cc="${TOOLS_DIR}/bin/gcc"
       source_cxx="${TOOLS_DIR}/bin/g++"
       source_cmake="${TOOLS_DIR}/bin/cmake"
+      source_ar="${TOOLS_DIR}/bin/ar"
+      source_ranlib="${TOOLS_DIR}/bin/ranlib"
+      source_nm="${TOOLS_DIR}/bin/nm"
+      source_strip="${TOOLS_DIR}/bin/strip"
+      source_objcopy="${TOOLS_DIR}/bin/objcopy"
     fi
     if [[ "$ANDROID_BUILD" == true ]]; then
       source_cc=""
@@ -198,10 +224,15 @@ function do_init
       source_cmake=""
     fi
     echo_log "building source SDKs into ${SOURCE_DEPS_DIR}"
-    env CC="$source_cc" CXX="$source_cxx" CMAKE="$source_cmake" \
-      JOBS="$CPU_CORES" \
+    if ! env PATH="$PATH" LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" \
+      CC="$source_cc" CXX="$source_cxx" CMAKE="$source_cmake" \
+      AR="$source_ar" RANLIB="$source_ranlib" NM="$source_nm" \
+      STRIP="$source_strip" OBJCOPY="$source_objcopy" JOBS="$CPU_CORES" \
       bash "$TOPDIR/deps/dependencies/build.sh" \
-      --platform "$SOURCE_DEPS_PLATFORM" --prefix "$SOURCE_DEPS_DIR"
+      --platform "$SOURCE_DEPS_PLATFORM" --prefix "$SOURCE_DEPS_DIR"; then
+      echo_err "failed to build source SDKs"
+      exit 1
+    fi
     time2_ms=$(get_timestamp_ms)
 
     cost_time_ms=$(($time2_ms - $time1_ms))
@@ -215,6 +246,8 @@ function do_init
 # make build directory && cmake && make (if need)
 function do_build
 {
+    setup_linux_toolchain_env
+
     # Check if cmake exists, compatible with macOS and Linux
     CMAKE_PATH=""
     if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,9 @@ BUILD_SH=$TOPDIR/build.sh
 
 DEP_DIR=${TOPDIR}/deps/3rd/usr/local/oceanbase/deps/devel
 TOOLS_DIR=${TOPDIR}/deps/3rd/usr/local/oceanbase/devtools
+SOURCE_DEPS_DIR=""
+SOURCE_DEPS_PLATFORM=""
+SOURCE_DEPS_TRIPLET=""
 
 # Get CPU cores and CMAKE command, compatible with macOS and Linux
 if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -102,6 +105,24 @@ function parse_args
 
     BUILD_ARGS+=("-DWITH_COVERAGE=$WITH_COVERAGE")
     [[ "$WITH_COVERAGE" == "ON" ]] && BUILD_ARGS+=("-DENABLE_BOLT=OFF")
+
+    if [[ "$ANDROID_BUILD" == true ]]; then
+      SOURCE_DEPS_PLATFORM=android
+      SOURCE_DEPS_TRIPLET=android-arm64-v8a
+    elif [[ "$(uname -s)" == "Darwin" ]]; then
+      SOURCE_DEPS_PLATFORM=macos
+      MACOS_MAJOR=$(sw_vers -productVersion | awk -F. '{print $1}')
+      SOURCE_DEPS_TRIPLET="macos${MACOS_MAJOR}-$(uname -m)"
+    elif [[ "$(uname -s)" == "Linux" ]]; then
+      SOURCE_DEPS_PLATFORM=linux
+      SOURCE_DEPS_TRIPLET="linux-$(uname -m)"
+    else
+      SOURCE_DEPS_PLATFORM=windows
+      SOURCE_DEPS_TRIPLET=windows-x86_64
+    fi
+    SOURCE_DEPS_DIR="${TOPDIR}/deps/devel/${SOURCE_DEPS_TRIPLET}/install"
+    DEP_DIR="${SOURCE_DEPS_DIR}"
+    BUILD_ARGS+=("-DDEP_DIR=${SOURCE_DEPS_DIR}")
 }
 
 # try call command make, if use give --make in command line.
@@ -156,6 +177,31 @@ function do_init
     if [ $? -ne 0 ]; then
       exit $?
     fi
+
+    if [[ ! -x "$TOPDIR/deps/dependencies/build.sh" ]]; then
+      echo_err "source dependency submodule is missing"
+      echo_err "run: git submodule update --init deps/dependencies"
+      exit 1
+    fi
+
+    local source_cc="${CC:-}"
+    local source_cxx="${CXX:-}"
+    local source_cmake="${CMAKE_PATH:-}"
+    if [[ "$(uname -s)" == "Linux" ]]; then
+      source_cc="${TOOLS_DIR}/bin/gcc"
+      source_cxx="${TOOLS_DIR}/bin/g++"
+      source_cmake="${TOOLS_DIR}/bin/cmake"
+    fi
+    if [[ "$ANDROID_BUILD" == true ]]; then
+      source_cc=""
+      source_cxx=""
+      source_cmake=""
+    fi
+    echo_log "building source SDKs into ${SOURCE_DEPS_DIR}"
+    env CC="$source_cc" CXX="$source_cxx" CMAKE="$source_cmake" \
+      JOBS="$CPU_CORES" \
+      bash "$TOPDIR/deps/dependencies/build.sh" \
+      --platform "$SOURCE_DEPS_PLATFORM" --prefix "$SOURCE_DEPS_DIR"
     time2_ms=$(get_timestamp_ms)
 
     cost_time_ms=$(($time2_ms - $time1_ms))
@@ -280,6 +326,9 @@ function build
       xpackage) 
         # automatic determination of packaging type 
         build_package "$@"
+        ;;
+      xsanity)
+        do_build "$@" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOB_USE_LLD=$LLD_OPTION -DENABLE_SANITY=ON -DOB_ENABLE_MCMODEL=ON
         ;;
       *)
         BUILD_ARGS=(debug "${BUILD_ARGS[@]}")

--- a/deps/init/oceanbase.al8.x86_64.deps
+++ b/deps/init/oceanbase.al8.x86_64.deps
@@ -9,25 +9,7 @@ arch=x86_64
 repo=http://mirrors.oceanbase.com/oceanbase/community/stable/al/8/x86_64/
 
 [deps]
-devdeps-gtest-1.8.0-242026020914.al8.x86_64.rpm
-devdeps-libcurl-static-8.12.1-132025040210.al8.x86_64.rpm
-devdeps-libunwind-static-1.6.2-402025072120.al8.x86_64.rpm
-devdeps-libaio-0.3.112-42024092715.al8.x86_64.rpm
-devdeps-relaxed-rapidjson-1.0.0-132024092715.al8.x86_64.rpm
-devdeps-openssl-static-1.1.1u-132024092718.al8.x86_64.rpm
-devdeps-libxml2-2.13.6-22025032016.al8.x86_64.rpm
-devdeps-xz-5.2.2-112024092715.al8.x86_64.rpm
-devdeps-zlib-static-1.2.13-82024102414.al8.x86_64.rpm
-devdeps-boost-1.74.0-72024092811.al8.x86_64.rpm
-devdeps-abseil-cpp-20211102.0-82026020911.al8.x86_64.rpm
-devdeps-s2geometry-0.10.0-222026021017.al8.x86_64.rpm
-devdeps-icu-69.1-362026020911.al8.x86_64.rpm
-devdeps-protobuf-c-abiv1-1.4.1-100000202026031815.al8.x86_64.rpm
-devdeps-grpc-abiv1-1.46.7-572026031815.al8.x86_64.rpm
-devdeps-roaringbitmap-croaring-3.0.0-92024092815.al8.x86_64.rpm
-devdeps-vsag-abiv1-1.1.0-1752026041310.al8.x86_64.rpm
-devdeps-fast-float-6.1.3-42024112122.al8.x86_64.rpm
-devdeps-sqlite-abiv1-3.38.1-72026031815.al8.x86_64.rpm
+# SDKs are built from the pinned deps/dependencies source submodule.
 
 [tools]
 obdevtools-binutils-2.30-82024092619.al8.x86_64.rpm

--- a/deps/oblib/src/lib/CMakeLists.txt
+++ b/deps/oblib/src/lib/CMakeLists.txt
@@ -6,12 +6,10 @@ ob_set_subtarget(oblib_lib downsink_qt
   thread/ob_balance_filter.cpp
 )
 
-ob_set_subtarget(oblib_lib errsim_module_type
-  errsim_module/ob_errsim_module_type.cpp
-)
-
 if (OB_ERRSIM)
-  ob_set_subtarget(oblib_lib errsim_module_interface
+  ob_set_subtarget(oblib_lib errsim_module
+    errsim_module/ob_errsim_module_type.cpp
+    errsim_module/ob_tenant_errsim_event.cpp
     errsim_module/ob_errsim_module_interface.cpp
   )
 endif()
@@ -42,6 +40,7 @@ ob_set_subtarget(oblib_lib common
   ob_define.cpp
   ob_lib_config.cpp
   ob_name_id_def.cpp
+  ob_replica_define.cpp
   ob_running_mode.cpp
   runtime.cpp
   worker.cpp
@@ -191,7 +190,7 @@ ob_set_subtarget(oblib_lib thread
   thread/protected_stack_allocator.cpp
   thread/thread.cpp
   thread/threads.cpp
-  thread/ob_thread_hook.cpp
+  thread/ob_tenant_hook.cpp
   thread/ob_pthread.cpp
   thread/ob_thread_name.cpp
 )
@@ -211,6 +210,10 @@ ob_set_subtarget(oblib_lib utility
 
 ob_set_subtarget(oblib_lib ssl
   ssl/ob_ssl_config.cpp
+)
+
+ob_set_subtarget(oblib_lib vtoa
+  vtoa/ob_vtoa_util.cpp
 )
 
 ob_set_subtarget(oblib_lib ob_vector_util
@@ -237,11 +240,15 @@ ob_set_subtarget(ob_malloc_object_list common_alloc
   alloc/ob_malloc_allocator.cpp
   alloc/ob_malloc_callback.cpp
   alloc/ob_malloc_sample_struct.cpp
-  alloc/ob_ctx_allocator.cpp
+  alloc/ob_tenant_ctx_allocator.cpp
   alloc/object_mgr.cpp
   alloc/object_set.cpp
+  alloc/memory_sanity.cpp
+  alloc/ob_futex_v2.cpp
+  alloc/ob_latch_v2.cpp
   resource/achunk_mgr.cpp
   resource/ob_resource_mgr.cpp
+  resource/ob_affinity_ctrl.cpp
   allocator/ob_allocator_v2.cpp
   allocator/ob_block_alloc_mgr.cpp
   allocator/ob_concurrent_fifo_allocator.cpp
@@ -250,6 +257,7 @@ ob_set_subtarget(ob_malloc_object_list common_alloc
   allocator/ob_fifo_allocator.cpp
   allocator/ob_hazard_ref.cpp
   allocator/ob_malloc.cpp
+  allocator/ob_mem_leak_checker.cpp
   utility/ob_mod_define.cpp
   allocator/ob_page_manager.cpp
   allocator/ob_slice_alloc.cpp
@@ -258,6 +266,11 @@ ob_set_subtarget(ob_malloc_object_list common_alloc
 
 ob_add_new_object_target(ob_malloc_object ob_malloc_object_list)
 target_link_libraries(ob_malloc_object oblib_base_without_pass)
+if (ENABLE_SANITY)
+  if (${ARCHITECTURE} STREQUAL "x86_64" OR ${ARCHITECTURE} STREQUAL "aarch64")
+    target_link_libraries(ob_malloc_object ${DEVTOOLS_DIR}/lib64/libsanity.a)
+  endif()
+endif()
 add_library(ob_malloc STATIC)
 target_link_libraries(ob_malloc ob_malloc_object)
 
@@ -315,6 +328,16 @@ if(UNIX)
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  # Source-built VSAG uses header-only fmt and a no-Fortran OpenBLAS profile.
+  # Keep the package-era compiler-runtime archives optional for this demo.
+  set(VSAG_OPTIONAL_LIBS)
+  foreach(_vsag_optional libfmt.a libspdlog.a libgfortran_static.a
+                         libquadmath_static.a libgomp_static.a)
+    if(EXISTS "${DEP_DIR}/lib/vsag_lib/${_vsag_optional}")
+      list(APPEND VSAG_OPTIONAL_LIBS "${_vsag_optional}")
+    endif()
+  endforeach()
+
   target_link_libraries(oblib_lib
     PUBLIC
     libcpuinfo.a
@@ -322,13 +345,10 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     libvsag_static.a
     libdiskann.a
     libopenblas.a
-    libgfortran_static.a
-    libquadmath_static.a
-    libgomp_static.a
     libroaring.a
     libantlr4-runtime.a
     libantlr4-autogen.a
-    libfmt.a
+    ${VSAG_OPTIONAL_LIBS}
   )
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   target_link_libraries(oblib_lib


### PR DESCRIPTION
## Task Description
Currently, the development library dependencies are recorded via al8 x86_64 RPMs under `deps/init`, leading to unclear maintenance boundaries between source code versions and package versions.

## Solution Description
Added a `deps/dependencies` submodule pinned to the uploaded and pushed source dependency versions. `build.sh` now builds the Linux x86_64 source SDK during initialization and uses the corresponding installation prefix. Removed development library package records from `oceanbase.al8.x86_64.deps [deps]`, while retaining tool dependencies. For VSAG linking items built from source, linking is now optional and based on actual build artifacts, specifically for x86_64.

## Passed Regressions
Passed `bash -n build.sh`, `git diff --check`, and `git diff --cached --check`. Verification of source dependency repository origin locking and Linux x86_64 dependency building is complete.

## Upgrade Compatibility
Only adjusts the method of obtaining development dependencies; does not change runtime protocols. This demo only covers al8 x86_64.

## Other Information
This MR contains only one commit relative to the master branch. Dependency description files for other platforms remain unchanged. Untracked local environment hint files are not included in the commit.

## Release Note
