### PR TITLE
[seekdb][optimizer] Remove unused WorkerMap resource tracking

### DIFF
--- a/src/sql/code_generator/ob_static_engine_cg.cpp
+++ b/src/sql/code_generator/ob_static_engine_cg.cpp
@@ -46,6 +46,7 @@
 #include "sql/optimizer/ob_log_expand.h"
 #include "sql/engine/ob_operator_factory.h"
 #include "sql/engine/basic/ob_limit_op.h"
+#include "sql/engine/basic/ob_limit_vec_op.h"
 #include "sql/engine/basic/ob_values_op.h"
 #include "sql/engine/sort/ob_sort_op.h"
 #include "sql/engine/recursive_cte/ob_recursive_union_all_op.h"
@@ -57,20 +58,22 @@
 #include "sql/engine/set/ob_hash_except_op.h"
 #include "sql/engine/aggregate/ob_hash_distinct_op.h"
 #include "sql/engine/aggregate/ob_merge_distinct_op.h"
-#include "sql/engine/aggregate/ob_scalar_aggregate_op.h"
+#include "sql/engine/aggregate/ob_merge_distinct_vec_op.h"
 #include "sql/engine/basic/ob_expr_values_op.h"
 #include "sql/engine/basic/ob_monitoring_dump_op.h"
 #include "sql/engine/px/exchange/ob_px_ms_receive_op.h"
+#include "sql/engine/px/exchange/ob_px_ms_receive_vec_op.h"
 #include "sql/engine/px/exchange/ob_px_dist_transmit_op.h"
 #include "sql/engine/px/exchange/ob_px_repart_transmit_op.h"
 #include "sql/engine/px/exchange/ob_px_reduce_transmit_op.h"
 #include "sql/engine/px/exchange/ob_px_fifo_coord_op.h"
 #include "sql/engine/px/exchange/ob_px_ordered_coord_op.h"
 #include "sql/engine/px/exchange/ob_px_ms_coord_op.h"
+#include "sql/engine/px/exchange/ob_px_ms_coord_vec_op.h"
 #include "sql/engine/join/ob_hash_join_op.h"
+#include "sql/engine/join/hash_join/ob_hash_join_vec_op.h"
 #include "sql/engine/join/ob_nested_loop_join_op.h"
 #include "sql/engine/join/ob_join_filter_op.h"
-#include "sql/engine/window_function/ob_window_function_op.h"
 #include "sql/engine/subquery/ob_subplan_filter_op.h"
 #include "sql/engine/subquery/ob_subplan_scan_op.h"
 #include "sql/engine/expr/ob_expr_subquery_ref.h"
@@ -85,12 +88,15 @@
 #include "sql/engine/table/ob_table_row_store_op.h"
 #include "sql/engine/dml/ob_table_insert_up_op.h"
 #include "sql/engine/dml/ob_table_replace_op.h"
+#include "sql/engine/window_function/ob_window_function_vec_op.h"
 #include "sql/engine/table/ob_row_sample_scan_op.h"
 #include "sql/engine/table/ob_block_sample_scan_op.h"
 #include "sql/engine/table/ob_ddl_block_sample_scan_op.h"
 #include "sql/engine/table/ob_table_scan_with_index_back_op.h"
 #include "sql/engine/basic/ob_temp_table_access_op.h"
 #include "sql/engine/basic/ob_temp_table_insert_op.h"
+#include "sql/engine/basic/ob_temp_table_access_vec_op.h"
+#include "sql/engine/basic/ob_temp_table_insert_vec_op.h"
 #include "sql/engine/pdml/static/ob_px_multi_part_delete_op.h"
 #include "sql/engine/pdml/static/ob_px_multi_part_update_op.h"
 #include "sql/engine/pdml/static/ob_px_sstable_insert_op.h"
@@ -101,7 +107,21 @@
 #include "sql/engine/dml/ob_table_insert_op.h"
 #include "sql/engine/basic/ob_stat_collector_op.h"
 #include "sql/engine/opt_statistics/ob_optimizer_stats_gathering_op.h"
+#include "sql/engine/aggregate/ob_hash_distinct_vec_op.h"
+#include "sql/engine/aggregate/ob_scalar_aggregate_vec_op.h"
+#include "sql/engine/vector/expr_cmp_func.h"
+#include "sql/engine/sort/ob_sort_vec_op.h"
+#include "sql/engine/set/ob_hash_union_vec_op.h"
+#include "sql/engine/set/ob_hash_intersect_vec_op.h"
+#include "sql/engine/set/ob_hash_except_vec_op.h"
+#include "sql/engine/join/ob_merge_join_vec_op.h"
+#include "sql/engine/set/ob_merge_set_vec_op.h"
+#include "sql/engine/set/ob_merge_union_vec_op.h"
+#include "sql/engine/set/ob_merge_intersect_vec_op.h"
+#include "sql/engine/set/ob_merge_except_vec_op.h"
 #include "sql/engine/expand/ob_expand_vec_op.h"
+#include "sql/engine/join/ob_nested_loop_join_vec_op.h"
+#include "sql/engine/subquery/ob_subplan_filter_vec_op.h"
 #include "sql/optimizer/ob_log_values_table_access.h"
 #include "sql/engine/basic/ob_values_table_access_op.h"
 
@@ -230,7 +250,9 @@ int ObStaticEngineCG::postorder_generate_op(ObLogicalOperator &op,
              || OB_ISNULL(schema_guard = op.get_plan()->get_optimizer_context().get_sql_schema_guard())) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("invalid arguments", K(ret), K(op.get_plan()), K(schema_guard));
-  } else if (OB_FAIL(get_phy_op_type(op, type, in_root_job))) {
+  } else if (OB_FAIL(
+               get_phy_op_type(op, type, in_root_job,
+                               phy_plan_->is_vectorized() && phy_plan_->get_use_rich_format()))) {
     LOG_WARN("get phy op type failed", K(ret));
   } else if (type == PHY_INVALID || type >= PHY_END) {
     ret = OB_ERR_UNEXPECTED;
@@ -252,6 +274,9 @@ int ObStaticEngineCG::postorder_generate_op(ObLogicalOperator &op,
       }
     }
   }
+
+  // disable operator support rich format
+  OZ (disable_use_rich_format(op, *spec));
 
   // Generate operator spec.
   // Corresponding ObStaticEngineCG::generate_spec() will be called by
@@ -284,7 +309,7 @@ int ObStaticEngineCG::postorder_generate_op(ObLogicalOperator &op,
                                                phy_plan_->get_expr_frame_info().rt_exprs_);
       OV(NULL != partial_frame, OB_ALLOCATE_MEMORY_FAILED);
       OZ(ObStaticEngineExprCG::generate_partial_expr_frame(
-              *phy_plan_, *partial_frame, cur_op_exprs_));
+              *phy_plan_, *partial_frame, cur_op_exprs_, phy_plan_->get_use_rich_format()));
       OX(dml_spec->expr_frame_info_ = partial_frame);
     }
   }
@@ -303,7 +328,7 @@ int ObStaticEngineCG::postorder_generate_op(ObLogicalOperator &op,
                                                phy_plan_->get_expr_frame_info().rt_exprs_);
       OV(NULL != partial_frame, OB_ALLOCATE_MEMORY_FAILED);
       OZ(ObStaticEngineExprCG::generate_partial_expr_frame(
-              *phy_plan_, *partial_frame, *partial_frame_gen.dfo_raw_exprs_));
+              *phy_plan_, *partial_frame, *partial_frame_gen.dfo_raw_exprs_, phy_plan_->get_use_rich_format()));
       if (OB_SUCC(ret)) {
         static_cast<ObPxTransmitSpec *>(spec)->dfo_expr_frame_info_ = partial_frame;
       }
@@ -320,6 +345,35 @@ int ObStaticEngineCG::postorder_generate_op(ObLogicalOperator &op,
   }
   partial_frame_gen.px_coord_cnt_ -= is_px_coord ? 1 : 0;
   partial_frame_gen.dfo_raw_exprs_ = origin_dfo_raw_exprs;
+  return ret;
+}
+
+int ObStaticEngineCG::disable_use_rich_format(const ObLogicalOperator &op, ObOpSpec &spec)
+{
+  int ret = OB_SUCCESS;
+  bool use_rich_format = true;
+  if (!spec.use_rich_format_) {
+    // do nothing
+  } else if (log_op_def::LOG_TABLE_SCAN == op.get_type()) {
+    const ObLogTableScan &tsc = static_cast<const ObLogTableScan &>(op);
+    if (tsc.get_index_back()
+        || tsc.use_batch()
+        || is_virtual_table(tsc.get_ref_table_id())
+        || (NULL != spec.get_parent() && PHY_UPDATE == spec.get_parent()->type_)
+        || (NULL != spec.get_parent() && PHY_DELETE == spec.get_parent()->type_)
+        || (static_cast<ObTableScanSpec &>(spec)).tsc_ctdef_.scan_ctdef_.is_get_
+        || tsc.is_text_retrieval_scan()
+        || tsc.is_tsc_with_domain_id()
+        || tsc.has_func_lookup()) {
+      use_rich_format = false;
+      LOG_DEBUG("tsc disable use rich format", K(tsc.get_index_back()), K(tsc.use_batch()),
+                K(is_virtual_table(tsc.get_ref_table_id())));
+    }
+  }
+  if (!use_rich_format) {
+    spec.use_rich_format_ = false;
+  }
+
   return ret;
 }
 
@@ -824,7 +878,7 @@ int ObStaticEngineCG::generate_spec_final(ObLogicalOperator &op, ObOpSpec &spec)
   int ret = OB_SUCCESS;
 
   UNUSED(op);
-  if (PHY_SUBPLAN_FILTER == spec.type_) {
+  if (PHY_SUBPLAN_FILTER == spec.type_ || PHY_VEC_SUBPLAN_FILTER == spec.type_) {
     FOREACH_CNT_X(e, spec.calc_exprs_, OB_SUCC(ret)) {
       if (T_REF_QUERY == (*e)->type_) {
         ObExprSubQueryRef::Extra::get_info(**e).op_id_ = spec.id_;
@@ -858,7 +912,14 @@ int ObStaticEngineCG::generate_spec_final(ObLogicalOperator &op, ObOpSpec &spec)
   if (log_op_def::LOG_SET == op.get_type()
       && !static_cast<ObLogSet &>(op).is_recursive_union()
       && spec.is_vectorized()) {
-    ExprFixedArray *set_exprs = &static_cast<ObSetSpec&>(spec).set_exprs_;
+    ExprFixedArray *set_exprs = nullptr;
+    if (PHY_VEC_HASH_UNION == spec.type_
+        || PHY_VEC_HASH_INTERSECT == spec.type_
+        || PHY_VEC_HASH_EXCEPT == spec.type_) {
+      set_exprs = &static_cast<ObHashSetVecSpec&>(spec).set_exprs_;
+    } else {
+      set_exprs = &static_cast<ObSetSpec&>(spec).set_exprs_;
+    }
     for (int64_t i = 0; OB_SUCC(ret) && i < set_exprs->count(); ++i) {
       ObExpr *expr = set_exprs->at(i);
       if (!expr->is_batch_result()) {
@@ -871,6 +932,42 @@ int ObStaticEngineCG::generate_spec_final(ObLogicalOperator &op, ObOpSpec &spec)
 }
 
 int ObStaticEngineCG::generate_spec(ObLogLimit &op, ObLimitSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  spec.calc_found_rows_ = op.get_is_calc_found_rows();
+  spec.is_top_limit_ = op.is_top_limit();
+  spec.is_fetch_with_ties_ = op.is_fetch_with_ties();
+  if (NULL != op.get_limit_expr()) {
+    CK(op.get_limit_expr()->get_result_type().is_integer_type());
+    OZ(generate_rt_expr(*op.get_limit_expr(), spec.limit_expr_));
+    OZ(mark_expr_self_produced(op.get_limit_expr()));
+  }
+  if (NULL != op.get_offset_expr()) {
+    CK(op.get_offset_expr()->get_result_type().is_integer_type());
+    OZ(generate_rt_expr(*op.get_offset_expr(), spec.offset_expr_));
+    OZ(mark_expr_self_produced(op.get_offset_expr()));
+  }
+  if (NULL != op.get_percent_expr()) {
+    CK(op.get_percent_expr()->get_result_type().is_double());
+    OZ(generate_rt_expr(*op.get_percent_expr(), spec.percent_expr_));
+    OZ(mark_expr_self_produced(op.get_percent_expr()));
+  }
+  if (OB_SUCC(ret) && op.is_fetch_with_ties()) {
+    OZ(spec.sort_columns_.init(op.get_ties_ordering().count()));
+    FOREACH_CNT_X(it, op.get_ties_ordering(), OB_SUCC(ret)) {
+      CK(NULL != it->expr_);
+      ObExpr *e = NULL;
+      OZ(generate_rt_expr(*it->expr_, e));
+      OZ(mark_expr_self_produced(it->expr_));
+      OZ(spec.sort_columns_.push_back(e));
+    }
+  }
+
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogLimit &op, ObLimitVecSpec &spec, const bool in_root_job)
 {
   int ret = OB_SUCCESS;
   UNUSED(in_root_job);
@@ -954,6 +1051,12 @@ int ObStaticEngineCG::generate_spec(
   ObLogDistinct &op, ObMergeDistinctSpec &spec, const bool in_root_job)
 {
   return generate_merge_distinct_spec<ObMergeDistinctSpec> (op, spec, in_root_job);
+}
+
+int ObStaticEngineCG::generate_spec(
+  ObLogDistinct &op, ObMergeDistinctVecSpec &spec, const bool in_root_job)
+{
+  return generate_merge_distinct_spec<ObMergeDistinctVecSpec> (op, spec, in_root_job);
 }
 
 void ObStaticEngineCG::set_murmur_hash_func(
@@ -1078,11 +1181,170 @@ int ObStaticEngineCG::generate_spec(
   return ret;
 }
 
+int ObStaticEngineCG::generate_spec(ObLogDistinct &op, ObHashDistinctVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  spec.is_block_mode_ = op.get_block_mode();
+  spec.is_push_down_ = op.is_push_down();
+  int64_t init_count = op.get_distinct_exprs().count();
+  spec.by_pass_enabled_ = (op.is_push_down() && !op.force_push_down());
+  if (1 != op.get_num_of_child()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected child count of hash distinct", K(ret), K(op.get_num_of_child()));
+  } else if (OB_FAIL(spec.sort_collations_.init(init_count))) {
+    LOG_WARN("failed to init sort functions", K(ret));
+  } else if (OB_FAIL(spec.distinct_exprs_.init(op.get_distinct_exprs().count()
+                                               + op.get_child(0)->get_output_exprs().count()))) {
+    LOG_WARN("failed to init distinct exprs", K(ret));
+  } else {
+    ObArray<ObRawExpr *> additional_exprs;
+    ObExpr *expr = nullptr;
+    ARRAY_FOREACH(op.get_child(0)->get_output_exprs(), i) {
+      ObRawExpr* raw_expr = op.get_child(0)->get_output_exprs().at(i);
+      bool is_distinct_expr = has_exist_in_array(op.get_distinct_exprs(), raw_expr);
+      if (!is_distinct_expr) {
+        OZ (additional_exprs.push_back(raw_expr));
+      }
+    }
+    if (OB_SUCC(ret)) {
+      int64_t dist_cnt = 0;
+      ARRAY_FOREACH(op.get_distinct_exprs(), i) {
+        ObRawExpr* raw_expr = op.get_distinct_exprs().at(i);
+        if (OB_ISNULL(raw_expr)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_ERROR("null pointer", K(ret));
+        } else if (OB_UNLIKELY(ObCollectionSQLType == raw_expr->get_data_type())) {
+          ret = OB_ERR_INVALID_TYPE_FOR_OP;
+          LOG_WARN("select distinct array not allowed", K(ret));
+        } else if (raw_expr->is_const_expr()) {
+          // distinct const value, here we need to note: distinct 1 was skipped,
+          // But in ObMergeDistinct, if there is no distinct column, then all values are considered equal by default, which is exactly the expected semantics.
+          continue;
+        } else if (OB_FAIL(generate_rt_expr(*raw_expr, expr))) {
+          LOG_WARN("failed to generate rt expr", K(ret));
+        } else if (OB_FAIL(spec.distinct_exprs_.push_back(expr))) {
+          LOG_WARN("failed to push back expr", K(ret));
+        } else if (OB_ISNULL(expr->basic_funcs_)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("unexpected status: basic funcs is not init", K(ret));
+        } else if (expr->obj_meta_.is_ext()) {
+          // user-defined types without ORDER or MAP methods are not supported
+          ret = OB_ERR_NO_ORDER_MAP_SQL;
+          LOG_WARN("cannot ORDER objects without MAP or ORDER method", K(ret));
+        } else {
+          ObOrderDirection order_direction = default_asc_direction();
+          bool is_ascending = is_ascending_direction(order_direction);
+          ObSortFieldCollation field_collation(dist_cnt,
+            expr->datum_meta_.cs_type_,
+            is_ascending,
+            (is_null_first(order_direction) ^ is_ascending) ? NULL_LAST : NULL_FIRST);
+          if (OB_FAIL(spec.sort_collations_.push_back(field_collation))) {
+            LOG_WARN("failed to push back sort collation", K(ret));
+          } else {
+            ++dist_cnt;
+          }
+        }
+      }
+    }
+    // complete distinct exprs
+    if (OB_SUCC(ret) && 0 != additional_exprs.count()) {
+      ARRAY_FOREACH(additional_exprs, i) {
+        const ObRawExpr* raw_expr = additional_exprs.at(i);
+        if (OB_ISNULL(raw_expr)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_ERROR("null pointer", K(ret));
+        } else if (raw_expr->is_const_expr()) {
+            // distinct const value, here we need to note: distinct 1 was skipped,
+            // But in ObMergeDistinct, if there is no distinct column, then all values are considered equal by default, which is exactly the expected semantics.
+            continue;
+        } else if (OB_FAIL(generate_rt_expr(*raw_expr, expr))) {
+          LOG_WARN("failed to generate rt expr", K(ret));
+        } else if (OB_FAIL(spec.distinct_exprs_.push_back(expr))) {
+          LOG_WARN("failed to push back expr", K(ret));
+        }
+      }
+    }
+  }
+  return ret;
+}
+
 /*
  * Material operator does not have any other extra runtime variables to process, so during Codegen, no processing is needed
  * All of this is handled by common methods like basic, so here no implementation is needed, everything is UNUSED
  */
 int ObStaticEngineCG::generate_spec(ObLogMaterial &op, ObMaterialSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(op);
+  UNUSED(spec);
+  UNUSED(in_root_job);
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogMaterial &op, ObMaterialVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(op);
+  UNUSED(spec);
+  UNUSED(in_root_job);
+  return ret;
+}
+int ObStaticEngineCG::generate_spec(ObLogTempTableInsert &op, ObTempTableInsertVecOpSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  ObLogicalOperator *parent = NULL;
+  bool is_distributed = false;
+  if (OB_ISNULL(parent = op.get_parent())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null", K(ret));
+  } else if (log_op_def::LOG_EXCHANGE == parent->get_type()) {
+    is_distributed = true;
+  }
+  spec.set_distributed(is_distributed);
+  spec.set_temp_table_id(op.get_temp_table_id());
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogTempTableAccess &op, ObTempTableAccessVecOpSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  ObIArray<ObRawExpr*> &access_exprs = op.get_access_exprs();
+  bool is_distributed = false;
+  if (OB_FAIL(spec.init_output_index(access_exprs.count()))) {
+    LOG_WARN("failed to init output index.", K(ret));
+  } else if (OB_FAIL(spec.init_access_exprs(access_exprs.count()))) {
+    LOG_WARN("failed to init access exprs.", K(ret));
+  } else if (OB_FAIL(get_is_distributed(op, is_distributed))) {
+    LOG_WARN("failed get is distributed.", K(ret));
+  } else {
+    phy_plan_->set_use_temp_table(true);
+    spec.set_distributed(is_distributed);
+    spec.set_temp_table_id(op.get_temp_table_id());
+    ARRAY_FOREACH(access_exprs, i) {
+      if (OB_ISNULL(access_exprs.at(i)) || !access_exprs.at(i)->is_column_ref_expr()) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_ERROR("expected basic column expr", K(ret));
+      } else {
+        ObColumnRefRawExpr* col_expr = static_cast<ObColumnRefRawExpr *>(access_exprs.at(i));
+        int64_t index = col_expr->get_column_id() - OB_APP_MIN_COLUMN_ID;
+        ObExpr *expr = NULL;
+        if (OB_FAIL(spec.add_output_index(index))) {
+          LOG_WARN("failed to add output index", K(ret), K(index));
+        } else if (OB_FAIL(generate_rt_expr(*access_exprs.at(i), expr))) {
+          LOG_WARN("failed to generate rt expr", K(ret));
+        } else if (OB_FAIL(spec.add_access_expr(expr))) {
+          LOG_WARN("failed to add output index", K(ret), K(*col_expr));
+        } else if (OB_FAIL(mark_expr_self_produced(col_expr))) { // temp table access need to set IS_COLUMNLIZED flag
+          LOG_WARN("mark expr self produced failed", K(ret));
+        } else { /*do nothing.*/ }
+      }
+    } // end for
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogTempTableTransformation &op, ObTempTableTransformationVecOpSpec &spec, const bool in_root_job)
 {
   int ret = OB_SUCCESS;
   UNUSED(op);
@@ -1174,6 +1436,92 @@ int ObStaticEngineCG::generate_spec(ObLogSet &op, ObHashExceptSpec &spec, const 
   UNUSED(in_root_job);
   if (OB_FAIL(generate_hash_set_spec(op, spec))) {
     LOG_WARN("failed to generate spec set", K(ret));
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogSet &op, ObHashUnionVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  if (OB_FAIL(generate_hash_set_spec(op, spec))) {
+    LOG_WARN("failed to generate spec set", K(ret));
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogSet &op, ObHashIntersectVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  if (OB_FAIL(generate_hash_set_spec(op, spec))) {
+    LOG_WARN("failed to generate spec set", K(ret));
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogSet &op, ObHashExceptVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  if (OB_FAIL(generate_hash_set_spec(op, spec))) {
+    LOG_WARN("failed to generate spec set", K(ret));
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_hash_set_spec(ObLogSet &op, ObHashSetVecSpec &spec)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<ObRawExpr *, 4> out_raw_exprs;
+  if (OB_FAIL(op.get_pure_set_exprs(out_raw_exprs))) {
+    LOG_WARN("failed to get output exprs", K(ret));
+  } else if (OB_FAIL(mark_expr_self_produced(out_raw_exprs))) { // set expr
+    LOG_WARN("fail to mark exprs self produced", K(ret));
+  } else if (OB_FAIL(spec.set_exprs_.init(out_raw_exprs.count()))) {
+    LOG_WARN("failed to init set exprs", K(ret));
+  } else if (OB_FAIL(generate_rt_exprs(out_raw_exprs, spec.set_exprs_))) {
+    LOG_WARN("failed to generate rt exprs", K(ret));
+  } else if (OB_FAIL(spec.sort_collations_.init(spec.set_exprs_.count()))) {
+    LOG_WARN("failed to init sort collations", K(ret));
+  } else {
+    for (int64_t i = 0; i < spec.set_exprs_.count() && OB_SUCC(ret); ++i) {
+      ObRawExpr *raw_expr = out_raw_exprs.at(i);
+      ObExpr *expr = spec.set_exprs_.at(i);
+      ObOrderDirection order_direction = default_asc_direction();
+      bool is_ascending = is_ascending_direction(order_direction);
+      ObSortFieldCollation field_collation(i,
+          expr->datum_meta_.cs_type_,
+          is_ascending,
+          (is_null_first(order_direction) ^ is_ascending) ? NULL_LAST : NULL_FIRST);
+      if (raw_expr->get_expr_type() != expr->type_ ||
+          !(T_OP_SET < expr->type_ && expr->type_ <= T_OP_EXCEPT)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected status: expr type is not match",
+          K(raw_expr->get_expr_type()), K(expr->type_));
+      } else if (OB_ISNULL(expr->basic_funcs_)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected status: basic funcs is not init", K(ret));
+      } else if (ob_is_user_defined_pl_type(expr->datum_meta_.type_)) {
+        // user-defined types without ORDER or MAP methods are not supported
+        ret = OB_ERR_NO_ORDER_MAP_SQL;
+        LOG_WARN("cannot ORDER objects without MAP or ORDER method", K(ret));
+      } else if (OB_FAIL(spec.sort_collations_.push_back(field_collation))) {
+        LOG_WARN("failed to push back sort collation", K(ret));
+      }
+    }
+  }
+  if (OB_SUCC(ret)) {
+    ObOpSpec *left = nullptr;
+    ObOpSpec *right = nullptr;
+    if (OB_UNLIKELY(spec.get_child_cnt() != 2)
+      || OB_ISNULL(left = spec.get_child(0))
+      || OB_ISNULL(right = spec.get_child(1))
+      || OB_UNLIKELY(left->get_output_count() != spec.set_exprs_.count())
+      || OB_UNLIKELY(right->get_output_count() != spec.set_exprs_.count())) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("cg check failed", K(ret), K(spec.get_child_cnt()), K(spec.set_exprs_.count()));
+    }
   }
   return ret;
 }
@@ -1278,6 +1626,104 @@ int ObStaticEngineCG::generate_spec(ObLogSet &op, ObMergeExceptSpec &spec, const
   if (OB_FAIL(generate_merge_set_spec(op, spec))) {
     LOG_WARN("failed to generate spec set", K(ret));
   }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogSet &op, ObMergeUnionVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  if (OB_FAIL(generate_merge_set_spec(op, spec))) {
+    LOG_WARN("failed to generate spec set", K(ret));
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(
+  ObLogSet &op, ObMergeIntersectVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  if (OB_FAIL(generate_merge_set_spec(op, spec))) {
+    LOG_WARN("failed to generate spec set", K(ret));
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(
+  ObLogSet &op, ObMergeExceptVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  if (OB_FAIL(generate_merge_set_spec(op, spec))) {
+    LOG_WARN("failed to generate spec set", K(ret));
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_merge_set_spec(ObLogSet &op, ObMergeSetVecSpec &spec)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<ObRawExpr *, 4> out_raw_exprs;
+  if (OB_FAIL(op.get_pure_set_exprs(out_raw_exprs))) {
+    LOG_WARN("failed to get output exprs", K(ret));
+  } else if (OB_FAIL(mark_expr_self_produced(out_raw_exprs))) { // set expr
+    LOG_WARN("fail to mark exprs self produced", K(ret));
+  } else if (OB_FAIL(spec.set_exprs_.init(out_raw_exprs.count()))) {
+    LOG_WARN("failed to init set exprs", K(ret));
+  } else if (OB_FAIL(generate_rt_exprs(out_raw_exprs, spec.set_exprs_))) {
+    LOG_WARN("failed to generate rt exprs", K(ret));
+  } else if (op.is_set_distinct()
+      && (spec.set_exprs_.count() != op.get_map_array().count() && 0 != op.get_map_array().count())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("output exprs is not match map array", K(ret), K(op.get_map_array().count()),
+      K(spec.set_exprs_.count()));
+  } else if (!op.is_set_distinct()) {
+  } else if (OB_FAIL(spec.sort_collations_.init(spec.set_exprs_.count()))) {
+    LOG_WARN("failed to init sort collations", K(ret));
+  } else if (OB_FAIL(spec.sort_cmp_funs_.init(spec.set_exprs_.count()))) {
+    LOG_WARN("failed to compare function", K(ret));
+  } else {
+    for (int64_t i = 0; i < spec.set_exprs_.count() && OB_SUCC(ret); ++i) {
+      int64_t idx = (0 == op.get_map_array().count()) ? i : op.get_map_array().at(i);
+      if (idx >= spec.set_exprs_.count()) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected status: invalid idx", K(idx), K(spec.set_exprs_.count()));
+      } else {
+        ObExpr *expr = spec.set_exprs_.at(idx);
+        ObOrderDirection order_direction = op.get_set_directions().at(i);
+        bool is_ascending = is_ascending_direction(order_direction);
+        ObSortFieldCollation field_collation(idx,
+            expr->datum_meta_.cs_type_,
+            is_ascending,
+            (is_null_first(order_direction) ^ is_ascending) ? NULL_LAST : NULL_FIRST);
+        if (OB_FAIL(spec.sort_collations_.push_back(field_collation))) {
+          LOG_WARN("failed to push back sort collation", K(ret));
+        } else if (ob_is_user_defined_pl_type(expr->datum_meta_.type_)) {
+          // user-defined types without ORDER or MAP methods are not supported
+          ret = OB_ERR_NO_ORDER_MAP_SQL;
+          LOG_WARN("cannot ORDER objects without MAP or ORDER method", K(ret));
+        } else {
+          ObSortCmpFunc cmp_func;
+          cmp_func.cmp_func_ = ObDatumFuncs::get_nullsafe_cmp_func(expr->datum_meta_.type_,
+                                                                  expr->datum_meta_.type_,
+                                                                  field_collation.null_pos_,
+                                                                  field_collation.cs_type_,
+                                                                  expr->datum_meta_.scale_,
+                                                                  expr->obj_meta_.has_lob_header(),
+                                                                  expr->datum_meta_.precision_,
+                                                                  expr->datum_meta_.precision_);
+          if (OB_ISNULL(cmp_func.cmp_func_)) {
+            ret = OB_ERR_UNEXPECTED;
+            LOG_WARN("cmp_func is null, check datatype is valid", K(cmp_func.cmp_func_), K(ret));
+          } else if (OB_FAIL(spec.sort_cmp_funs_.push_back(cmp_func))) {
+            LOG_WARN("failed to push back sort function", K(ret));
+          }
+        }
+      }
+    }
+  }
+  spec.is_distinct_ = op.is_set_distinct();
   return ret;
 }
 
@@ -1565,7 +2011,7 @@ int ObStaticEngineCG::generate_spec(ObLogSort &op, ObSortSpec &spec, const bool 
         LOG_WARN("topn must be int", K(ret), K(*spec.topn_expr_));
       }
       if (OB_SUCC(ret) && op.enable_pd_topn_filter()) {
-        if (OB_FAIL(prepare_topn_runtime_filter_info(op, spec))) {
+        if (OB_FAIL(prepare_topn_runtime_filter_info<false>(op, spec))) {
           LOG_WARN("failed to prepare topn runtime_filter info");
         }
       }
@@ -1712,6 +2158,76 @@ int ObStaticEngineCG::append_child_output_no_dup(const bool is_store_sortkey_sep
   return ret;
 }
 
+int ObStaticEngineCG::generate_encode_sort_exprs(const bool is_store_sortkey_separately,
+                                                 ObLogSort &op, ObSortVecSpec &spec,
+                                                 ObIArray<OrderItem> &sk_keys,
+                                                 ObIArray<OrderItem> &addon_keys)
+{
+  int ret = OB_SUCCESS;
+  int64_t prefix_pos = op.get_prefix_pos();
+  int64_t part_cnt = op.get_part_cnt();
+  if (op.get_part_cnt() > 0 && OB_FAIL(sk_keys.push_back(op.get_hash_sortkey()))) {
+    LOG_WARN("failed to push back hash sortkey", K(ret));
+  }
+  for (int64_t i = 0; OB_SUCC(ret) && i < op.get_sort_keys().count(); i++) {
+    if (!is_store_sortkey_separately || (i < prefix_pos || i < part_cnt)) {
+      if (OB_FAIL(sk_keys.push_back(op.get_sort_keys().at(i)))) {
+        LOG_WARN("failed to push back sortkey", K(ret));
+      }
+    } else {
+      if (OB_FAIL(addon_keys.push_back(op.get_sort_keys().at(i)))) {
+        LOG_WARN("failed to push back sortkey", K(ret));
+      }
+    }
+  }
+  if (OB_SUCC(ret)) {
+    ObExpr *encode_expr = nullptr;
+    OrderItem order_item = op.get_encode_sortkeys().at(op.get_encode_sortkeys().count() - 1);
+    if (is_store_sortkey_separately) {
+      if (OB_FAIL(spec.sk_exprs_.init(sk_keys.count() + 1))) {
+        LOG_WARN("failed to init sort key exprs", K(ret));
+      } else if (OB_FAIL(spec.addon_exprs_.init(addon_keys.count()
+                                                + spec.get_child()->output_.count()))) {
+        LOG_WARN("failed to init addon exprs", K(ret));
+      }
+    } else {
+      if (OB_FAIL(spec.sk_exprs_.init(sk_keys.count() + spec.get_child()->output_.count() + 1))) {
+        LOG_WARN("failed to init sort key exprs", K(ret));
+      }
+    }
+    if (OB_FAIL(ret)) {
+    } else if (OB_FAIL(generate_rt_expr(*order_item.expr_, encode_expr))) {
+      LOG_WARN("failed to generate rt expr", K(ret));
+    } else if (OB_FAIL(spec.sk_exprs_.push_back(encode_expr))) {
+      LOG_WARN("failed to push back expr", K(ret));
+    }
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_sort_exprs(const bool is_store_sortkey_separately, ObLogSort &op,
+                                          ObSortVecSpec &spec, ObIArray<OrderItem> &sk_keys)
+{
+  int ret = OB_SUCCESS;
+  if (op.get_part_cnt() > 0 && OB_FAIL(sk_keys.push_back(op.get_hash_sortkey()))) {
+    LOG_WARN("failed to push back hash sortkey", K(ret));
+  } else if (OB_FAIL(append(sk_keys, op.get_sort_keys()))) {
+    LOG_WARN("failed to append sortkeys", K(ret));
+  } else if (is_store_sortkey_separately) {
+    if (OB_FAIL(spec.sk_exprs_.init(sk_keys.count()))) {
+      LOG_WARN("failed to init all exprs", K(ret));
+    } else if (OB_FAIL(spec.addon_exprs_.init(spec.get_child()->output_.count()))) {
+      LOG_WARN("failed to init addon exprs", K(ret));
+    }
+  } else {
+    if (OB_FAIL(spec.sk_exprs_.init(sk_keys.count() + spec.get_child()->output_.count()))) {
+      LOG_WARN("failed to init all exprs", K(ret));
+    }
+  }
+  return ret;
+}
+
+template<bool USE_RICH_FORMAT>
 int ObStaticEngineCG::prepare_topn_runtime_filter_info(ObLogSort &op, ObOpSpec &spec)
 {
   int ret = OB_SUCCESS;
@@ -1735,23 +2251,23 @@ int ObStaticEngineCG::prepare_topn_runtime_filter_info(ObLogSort &op, ObOpSpec &
     ObSEArray<ObTopNFilterCmpMeta, 4> cmp_metas;
     ObTopNFilterCmpMeta cmp_meta;
     for (int64_t i = 0; i < effective_sk_cnt && OB_SUCC(ret); ++i) {
-      const bool is_null_first = op.get_sort_keys().at(i).is_null_first();
+      bool is_null_first = op.get_sort_keys().at(i).is_null_first();
       const ObExpr *sort_key = pd_topn_filter_rt_expr->args_[i];
       const sql::ObDatumMeta &meta = sort_key->datum_meta_;
-      cmp_meta.cmp_func_ = ObDatumFuncs::get_nullsafe_cmp_func(
-          meta.type_, meta.type_, is_null_first ? NULL_FIRST : NULL_LAST,
-          meta.cs_type_, meta.scale_, sort_key->obj_meta_.has_lob_header(),
-          meta.precision_, meta.precision_);
+      NullSafeRowCmpFunc null_first_cmp = nullptr, null_last_cmp = nullptr;
+      VectorCmpExprFuncsHelper::get_cmp_set(meta, meta, null_first_cmp, null_last_cmp);
+      cmp_meta.cmp_func_ = is_null_first ? null_first_cmp : null_last_cmp;
       cmp_meta.obj_meta_ = sort_key->obj_meta_;
-      if (OB_ISNULL(cmp_meta.cmp_func_)) {
-        ret = OB_ERR_UNEXPECTED;
-        LOG_WARN("failed to get topn filter compare function", K(ret), K(meta), K(is_null_first));
-      } else if (OB_FAIL(cmp_metas.push_back(cmp_meta))) {
+      if (OB_FAIL(cmp_metas.push_back(cmp_meta))) {
         LOG_WARN("failed to push back cmp meta");
       }
     }
-    ObPushDownTopNFilterInfo *topn_filter_info =
-        &static_cast<ObSortSpec &>(spec).pd_topn_filter_info_;
+    ObPushDownTopNFilterInfo *topn_filter_info = nullptr;
+    if (USE_RICH_FORMAT) {
+      topn_filter_info = &static_cast<ObSortVecSpec &>(spec).pd_topn_filter_info_;
+    } else {
+      topn_filter_info = &static_cast<ObSortSpec &>(spec).pd_topn_filter_info_;
+    }
     if (OB_FAIL(ret)) {
     } else if (OB_FAIL(topn_filter_info->init(
                    op.get_p2p_sequence_id(), effective_sk_cnt, total_sk_cnt, cmp_metas,
@@ -1759,6 +2275,110 @@ int ObStaticEngineCG::prepare_topn_runtime_filter_info(ObLogSort &op, ObOpSpec &
                    is_shared_pd_topn_filter, is_shuffle_pd_topn_filter, max_batch_size,
                    adaptive_filter_ratio))) {
       LOG_WARN("failed to init topn_filter_info");
+    }
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogSort &op, ObSortVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  ObSEArray<ObExpr *, 4> output_exprs;
+  UNUSED(in_root_job);
+  if (OB_FAIL(generate_rt_exprs(op.get_output_exprs(), output_exprs))) {
+    LOG_WARN("failed to generate rt exprs", K(ret));
+  } else {
+    if (OB_NOT_NULL(op.get_topn_expr())) {
+      spec.is_fetch_with_ties_ = op.is_fetch_with_ties();
+      OZ(generate_rt_expr(*op.get_topn_expr(), spec.topn_expr_));
+      if (OB_NOT_NULL(spec.topn_expr_) && !ob_is_integer_type(spec.topn_expr_->datum_meta_.type_)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("topn must be int", K(ret), K(*spec.topn_expr_));
+      }
+      if (OB_SUCC(ret) && op.enable_pd_topn_filter()) {
+        if (OB_FAIL(prepare_topn_runtime_filter_info<true>(op, spec))) {
+          LOG_WARN("failed to prepare topn runtime_filter info");
+        }
+      }
+    }
+    if (OB_NOT_NULL(op.get_topk_limit_expr())) {
+      OZ(generate_rt_expr(*op.get_topk_limit_expr(), spec.topk_limit_expr_));
+      if (OB_NOT_NULL(op.get_topk_offset_expr())) {
+        OZ(generate_rt_expr(*op.get_topk_offset_expr(), spec.topk_offset_expr_));
+        if (OB_NOT_NULL(spec.topk_offset_expr_)
+            && !ob_is_integer_type(spec.topk_offset_expr_->datum_meta_.type_)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("topn must be int", K(ret), K(*spec.topk_offset_expr_));
+        }
+      }
+      spec.minimum_row_count_ = op.get_minimum_row_count();
+      spec.topk_precision_ = op.get_topk_precision();
+    }
+    if (OB_SUCC(ret)) {
+      bool is_store_sortkey_separately = false;
+      if (std::ceil(op.get_width() / op.get_sort_key_width())
+          > ObSortVecOp::SORTKEY_STORE_SEPARATELY_THRESHOLD) {
+        is_store_sortkey_separately = true;
+      }
+      int tmp_ret = OB_E(EventTable::EN_DISABLE_SORTKEY_SEPARATELY) OB_SUCCESS;
+      if (OB_SUCCESS != tmp_ret) {
+        is_store_sortkey_separately = false;
+      }
+      ObSEArray<OrderItem, 1> sk_keys;
+      ObSEArray<OrderItem, 1> addon_keys;
+      bool enable_encode_sortkey_opt = op.enable_encode_sortkey_opt();
+      if (op.get_part_cnt() > 0 || nullptr != op.get_topn_expr()
+          || nullptr != op.get_topk_limit_expr()) {
+        enable_encode_sortkey_opt = false;
+      }
+      if (OB_ISNULL(spec.get_child())) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("child is null", K(ret));
+      } else if (enable_encode_sortkey_opt) {
+        if (OB_FAIL(generate_encode_sort_exprs(is_store_sortkey_separately, op, spec, sk_keys,
+                                               addon_keys))) {
+          LOG_WARN("failed to generate encode sort exprs", K(ret));
+        }
+      } else if (OB_FAIL(generate_sort_exprs(is_store_sortkey_separately, op, spec, sk_keys))) {
+        LOG_WARN("failed to generate sort exprs", K(ret));
+      }
+      if (OB_FAIL(ret)) {
+        // do nothing
+      } else if (OB_FAIL(fill_sort_info(sk_keys, spec.sk_collations_, spec.sk_exprs_))) {
+        LOG_WARN("failed to sort info", K(ret));
+      } else if (OB_FAIL(fill_sort_info(addon_keys, spec.addon_collations_, spec.addon_exprs_))) {
+        LOG_WARN("failed to sort info", K(ret));
+      } else if (OB_FAIL(append_child_output_no_dup(is_store_sortkey_separately,
+                                                    spec.get_child()->output_, spec.sk_exprs_,
+                                                    spec.addon_exprs_))) {
+        LOG_WARN("failed to append array no dup", K(ret));
+      } else if (opt_ctx_->is_online_ddl() && OB_FAIL(fill_compress_type(op, spec.compress_type_))) {
+        LOG_WARN("fail to gt compress_type", K(ret));
+      } else {
+        spec.prefix_pos_ = op.get_prefix_pos();
+        spec.is_local_merge_sort_ = op.is_local_merge_sort();
+        if (op.get_plan()->get_optimizer_context().is_online_ddl()) {
+          spec.prescan_enabled_ = true;
+        }
+        spec.has_addon_ = (spec.addon_exprs_.count() != 0);
+        spec.enable_encode_sortkey_opt_ = enable_encode_sortkey_opt;
+        spec.part_cnt_ = op.get_part_cnt();
+        spec.enable_single_col_compare_opt_ = false;
+        LOG_TRACE("trace order by", K(spec.sk_exprs_.count()), K(spec.addon_exprs_.count()),
+                  K(spec.sk_exprs_), K(spec.addon_exprs_),
+                  K(spec.sk_collations_), K(spec.addon_collations_), K(spec.enable_single_col_compare_opt_));
+      }
+      if (OB_SUCC(ret)) {
+        if (spec.part_cnt_ > 0 && spec.part_cnt_ >= spec.sk_collations_.count()) {
+          ret = OB_INVALID_ARGUMENT;
+          LOG_WARN("part cnt or sort size not meet the expection", K(ret),
+                   K(OB_NOT_NULL(op.get_topn_expr())), K(OB_NOT_NULL(op.get_topk_limit_expr())),
+                   K(spec.enable_encode_sortkey_opt_), K(spec.prefix_pos_),
+                   K(spec.is_local_merge_sort_), K(spec.part_cnt_),
+                   K(spec.sk_collations_.count()),
+                   K(spec.addon_collations_.count()));
+        }
+      }
     }
   }
   return ret;
@@ -2777,6 +3397,85 @@ int ObStaticEngineCG::generate_spec(ObLogMonitoringDump &op, ObMonitoringDumpSpe
   return ret;
 }
 
+int ObStaticEngineCG::prepare_runtime_filter_cmp_info(ObLogJoinFilter &join_filter_create, ObJoinFilterSpec &spec)
+{
+  int ret = OB_SUCCESS;
+  ObLogJoinFilter *join_filter_use = static_cast<ObLogJoinFilter *>(join_filter_create.get_paired_join_filter());
+  common::ObIArray<ObRawExpr *> &join_use_exprs = join_filter_use->get_join_exprs();
+  common::ObIArray<ObRawExpr *> &join_create_exprs = join_filter_create.get_join_exprs();
+  if (OB_UNLIKELY(join_use_exprs.count() != join_create_exprs.count())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("join_use_exprs's size doesn't match join_create_exprs's size",
+        K(join_use_exprs.count()), K(join_create_exprs.count()));
+  } else if (OB_FAIL(spec.rf_build_cmp_infos_.init(join_use_exprs.count()))) {
+    LOG_WARN("failed to init rf_build_cmp_infos_");
+  } else if (OB_FAIL(spec.rf_probe_cmp_infos_.init(join_use_exprs.count()))) {
+    LOG_WARN("failed to init rf_probe_cmp_infos_");
+  }
+  for (int i = 0; i < join_use_exprs.count() && OB_SUCC(ret); ++i) {
+    ObExpr *join_use_rt_expr =
+        static_cast<ObExpr *>(ObStaticEngineExprCG::get_left_value_rt_expr(*join_use_exprs.at(i)));
+    ObExpr *join_create_rt_expr =
+        static_cast<ObExpr *>(ObStaticEngineExprCG::get_left_value_rt_expr(*join_create_exprs.at(i)));
+    CK(OB_NOT_NULL(join_use_rt_expr) && OB_NOT_NULL(join_create_rt_expr));
+
+    sql::ObDatumMeta use_dataum_meta = join_use_rt_expr->datum_meta_;
+    sql::ObDatumMeta create_datum_meta = join_create_rt_expr->datum_meta_;
+
+    if (OB_SUCC(ret) && (ob_is_string_or_lob_type(use_dataum_meta.get_type())
+        || ob_is_string_or_lob_type(create_datum_meta.get_type()))) {
+      if (OB_UNLIKELY(use_dataum_meta.cs_type_ != create_datum_meta.cs_type_)) {
+        if (ob_is_null(use_dataum_meta.get_type())) {
+          // use create's cs_type
+          use_dataum_meta.cs_type_ = create_datum_meta.cs_type_;
+        } else if (ob_is_null(create_datum_meta.get_type())) {
+          // use use's cs_type
+          create_datum_meta.cs_type_ = use_dataum_meta.cs_type_;
+        } else {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("collation type not match", K(use_dataum_meta.get_type()),
+                   K(create_datum_meta.get_type()));
+        }
+      }
+    }
+
+    if (OB_SUCC(ret)) {
+      NullSafeRowCmpFunc null_first_cmp = nullptr, null_last_cmp = nullptr;
+      ObObjMeta obj_meta;
+      // for create op insert data into rf
+      VectorCmpExprFuncsHelper::get_cmp_set(create_datum_meta, create_datum_meta, null_first_cmp,
+                                            null_last_cmp);
+      if (OB_ISNULL(null_first_cmp) || OB_ISNULL(null_last_cmp)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("cmp_func is null");
+      } else {
+        ObRFCmpInfo rf_cmp_info;
+        rf_cmp_info.obj_meta_.set_meta(join_create_rt_expr->obj_meta_);
+        rf_cmp_info.cmp_func_ = null_first_cmp;
+        if (OB_FAIL(spec.rf_build_cmp_infos_.push_back(rf_cmp_info))) {
+          LOG_WARN("failed to push back");
+        }
+      }
+      // for probe data
+      VectorCmpExprFuncsHelper::get_cmp_set(use_dataum_meta, create_datum_meta, null_first_cmp,
+                                            null_last_cmp);
+      if (OB_FAIL(ret)) {
+      } else if (OB_ISNULL(null_first_cmp) || OB_ISNULL(null_last_cmp)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("cmp_func is null");
+      } else {
+        ObRFCmpInfo rf_cmp_info;
+        rf_cmp_info.obj_meta_.set_meta(join_use_rt_expr->obj_meta_);
+        rf_cmp_info.cmp_func_ = null_first_cmp;
+        if (OB_FAIL(spec.rf_probe_cmp_infos_.push_back(rf_cmp_info))) {
+          LOG_WARN("failed to push back");
+        }
+      }
+    }
+  }
+  return ret;
+}
+
 int ObStaticEngineCG::generate_spec(ObLogJoinFilter &op, ObJoinFilterSpec &spec, const bool in_root_job)
 {
   int ret = OB_SUCCESS;
@@ -2786,12 +3485,61 @@ int ObStaticEngineCG::generate_spec(ObLogJoinFilter &op, ObJoinFilterSpec &spec,
   spec.set_filter_length(op.get_filter_length());
   spec.set_shared_filter_type(op.get_filter_type());
   spec.is_shuffle_ = op.is_use_filter_shuffle();
+  bool enable_rich_format = spec.use_rich_format_;
+  if (enable_rich_format) {
+    spec.jf_material_control_info_ = op.get_jf_material_control_info();
+  }
+
+  spec.use_ndv_runtime_bloom_filter_size_ = GCONF._ndv_runtime_bloom_filter_size;
   spec.bloom_filter_ratio_ = GCONF._bloom_filter_ratio;
   if (OB_ISNULL(opt_ctx_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("opt_ctx_ is null", K(ret));
   } else if (OB_FAIL(opt_ctx_->get_global_hint().opt_params_.get_integer_opt_param(ObOptParamHint::BLOOM_FILTER_RATIO, spec.bloom_filter_ratio_))) {
     LOG_WARN("failed to get opt param bloom filter ratio", K(ret));
+  }
+
+  if (spec.jf_material_control_info_.is_controller_) {
+    // for the join filter at top, it is the controller, it need to do calulate the hash value of
+    // hash join and do material
+    if (log_op_def::LOG_JOIN != op.get_parent()->get_type()) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("the parent of the top join filter must be hash join");
+    } else {
+      ObLogJoin &join_op = static_cast<ObLogJoin &>(*op.get_parent());
+      const common::ObIArray<ObRawExpr *> &equal_join_conditions =
+          join_op.get_equal_join_conditions();
+      const common::ObIArray<ObRawExpr *> &all_join_key_left_exprs =
+          op.get_all_join_key_left_exprs();
+      if (equal_join_conditions.count() != all_join_key_left_exprs.count()) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unmatched expr count", K(equal_join_conditions.count()),
+                 K(all_join_key_left_exprs.count()), K(spec.get_id()));
+      } else if (OB_FAIL(spec.full_hash_join_keys_.prepare_allocate(equal_join_conditions.count()))) {
+        LOG_WARN("failed to prepare_allocate full_hash_join_keys", K(ret));
+      } else if (OB_FAIL(spec.hash_join_is_ns_equal_cond_.prepare_allocate(
+                     equal_join_conditions.count()))) {
+        LOG_WARN("failed to prepare_allocate hash_join_is_ns_equal_cond_", K(ret));
+      }
+
+      for (int64_t i = 0; OB_SUCC(ret) && i < all_join_key_left_exprs.count(); ++i) {
+        ObRawExpr *left_raw_expr = all_join_key_left_exprs.at(i);
+        ObExpr *left_expr = nullptr;
+        if (OB_FAIL(generate_rt_expr(*left_raw_expr, left_expr))) {
+          LOG_WARN("failed to generate_rt_expr");
+        } else if (OB_ISNULL(left_expr)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("unexprected null left_expr");
+        } else {
+          spec.full_hash_join_keys_.at(i) = left_expr;
+          if (T_OP_NSEQ == equal_join_conditions.at(i)->get_expr_type()) {
+            spec.hash_join_is_ns_equal_cond_.at(i) = true;
+          } else {
+            spec.hash_join_is_ns_equal_cond_.at(i) = false;
+          }
+        }
+      }
+    }
   }
 
   if (OB_FAIL(ret)) {
@@ -2837,6 +3585,14 @@ int ObStaticEngineCG::generate_spec(ObLogJoinFilter &op, ObJoinFilterSpec &spec,
             LOG_WARN("failed to push back hash func", K(ret));
           } else if (OB_FAIL(spec.cmp_funcs_.push_back(null_first_cmp))) {
             LOG_WARN("failed to push back null first cmp func", K(ret));
+          }
+        }
+        if (OB_SUCC(ret) && enable_rich_format) {
+          // for vectorize 2.0, both the cmp funcs of build table and probe table are stored in join filter create op.
+          // when open join filter create op, the runtime filter msg will be allocated and then the cmp func will be passed
+          // to the runtime filter msg.
+          if (OB_FAIL(prepare_runtime_filter_cmp_info(op, spec))) {
+            LOG_WARN("failed to prepare_runtime_filter_cmp_info");
           }
         }
       } else {
@@ -2887,6 +3643,9 @@ int ObStaticEngineCG::generate_spec(ObLogJoinFilter &op, ObJoinFilterSpec &spec,
       rf_info.p2p_datahub_id_ = p2p_sequence_ids.at(i);
       rf_info.filter_shared_type_ = op.get_filter_type();
       rf_info.dh_msg_type_ = static_cast<ObP2PDatahubMsgBase::ObP2PDatahubMsgType>(rf_types.at(i));
+      if (enable_rich_format) {
+        ObP2PDatahubMsgBase::transform_vec_p2p_msg_type(rf_info.dh_msg_type_, rf_info.dh_msg_type_);
+      }
       if (!op.is_create_filter()) {
         const common::ObIArray<ObRawExpr *> &join_filter_exprs =
             op.get_join_filter_exprs();
@@ -3097,8 +3856,10 @@ int ObStaticEngineCG::generate_basic_transmit_spec(
     spec.is_wf_hybrid_ = op.is_wf_hybrid();
     spec.sample_type_ = op.get_sample_type();
     spec.repartition_table_id_ = op.get_repartition_table_id();
+    spec.use_rich_format_ &= op.support_rich_format_vectorize();
     LOG_TRACE("CG transmit", K(op.get_dfo_id()), K(op.get_op_id()),
-              K(op.get_dist_method()), K(op.get_unmatch_row_dist_method()));
+              K(op.get_dist_method()), K(op.get_unmatch_row_dist_method()),
+              K(op.support_rich_format_vectorize()));
   }
   // Process PDML partition_id pseudo column
   if (OB_SUCC(ret)) {
@@ -3139,6 +3900,7 @@ int ObStaticEngineCG::generate_basic_transmit_spec(
   return ret;
 }
 
+ERRSIM_POINT_DEF(ERRSIM_EXCHANGE_VEC_DOP1);
 int ObStaticEngineCG::generate_basic_receive_spec(ObLogExchange &op, ObPxReceiveSpec &spec, const bool in_root_job)
 {
   int ret = OB_SUCCESS;
@@ -3151,6 +3913,16 @@ int ObStaticEngineCG::generate_basic_receive_spec(ObLogExchange &op, ObPxReceive
     LOG_WARN("child spec is null", K(ret));
   } else {
     spec.repartition_table_id_ = op.get_repartition_table_id();
+    // all receive op support rich_format, while some types of transmit not support rich format.
+    // so make use_rich_format_ of receive same as use_rich_format_ of transmit.
+    spec.use_rich_format_ &= (op.support_rich_format_vectorize());
+    if (OB_UNLIKELY(ERRSIM_EXCHANGE_VEC_DOP1 != OB_SUCCESS) &&
+        op.get_plan()->get_optimizer_context().get_max_parallel() == 1) {
+      spec.use_rich_format_ = false;
+    }
+    if (!spec.use_rich_format_) {
+      const_cast<ObOpSpec *> (spec.get_left())->use_rich_format_ = false;
+    }
     if (OB_FAIL(spec.child_exprs_.init(spec.get_child()->output_.count()))) {
       LOG_WARN("failed to init child exprs", K(ret));
     } else if (OB_FAIL(spec.bloom_filter_id_array_.assign(op.get_bloom_filter_ids()))) {
@@ -3231,11 +4003,54 @@ int ObStaticEngineCG::generate_spec(ObLogExchange &op, ObPxMSCoordSpec &spec, co
     LOG_WARN("failed to sort funcs", K(ret));
   } else if (OB_FAIL(append_array_no_dup(spec.all_exprs_, spec.child_exprs_))) {
     LOG_WARN("failed to append array no dup", K(ret));
+  } else {
+    const_cast<ObOpSpec *> (spec.get_left())->use_rich_format_ = false;
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogExchange &op, ObPxMSCoordVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(generate_basic_receive_spec(op, spec, in_root_job))) {
+    LOG_WARN("failed to generate basic receive spec", K(ret));
+  } else if (OB_FAIL(spec.all_exprs_.init(op.get_sort_keys().count() + spec.child_exprs_.count()))) {
+    LOG_WARN("failed to init all exprs", K(ret));
+  } else if (OB_FAIL(fill_sort_info(op.get_sort_keys(),
+      spec.sort_collations_, spec.all_exprs_))) {
+    LOG_WARN("failed to sort info", K(ret));
+  } else if (OB_FAIL(fill_sort_funcs(
+      spec.sort_collations_, spec.sort_cmp_funs_, spec.all_exprs_))) {
+    LOG_WARN("failed to sort funcs", K(ret));
+  } else if (OB_FAIL(append_array_no_dup(spec.all_exprs_, spec.child_exprs_))) {
+    LOG_WARN("failed to append array no dup", K(ret));
   }
   return ret;
 }
 
 int ObStaticEngineCG::generate_spec(ObLogExchange &op, ObPxMSReceiveSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(generate_basic_receive_spec(op, spec, in_root_job))) {
+    LOG_WARN("failed to generate basic receive spec", K(ret));
+  } else if (OB_FAIL(spec.all_exprs_.init(op.get_sort_keys().count() + spec.child_exprs_.count()))) {
+    LOG_WARN("failed to init all exprs", K(ret));
+  } else if (OB_FAIL(fill_sort_info(op.get_sort_keys(),
+      spec.sort_collations_, spec.all_exprs_))) {
+    LOG_WARN("failed to sort info", K(ret));
+  } else if (OB_FAIL(fill_sort_funcs(
+      spec.sort_collations_, spec.sort_cmp_funs_, spec.all_exprs_))) {
+    LOG_WARN("failed to sort funcs", K(ret));
+  } else if (OB_FAIL(append_array_no_dup(spec.all_exprs_, spec.child_exprs_))) {
+    LOG_WARN("failed to append array no dup", K(ret));
+  } else {
+    spec.local_order_ = op.is_sort_local_order();
+    const_cast<ObOpSpec *> (spec.get_left())->use_rich_format_ = false;
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogExchange &op, ObPxMSReceiveVecSpec &spec, const bool in_root_job)
 {
   int ret = OB_SUCCESS;
   if (OB_FAIL(generate_basic_receive_spec(op, spec, in_root_job))) {
@@ -3690,6 +4505,24 @@ int ObStaticEngineCG::generate_spec(ObLogGroupBy &op, ObScalarAggregateSpec &spe
   return ret;
 }
 
+int ObStaticEngineCG::generate_spec(ObLogGroupBy &op, ObScalarAggregateVecSpec &spec,
+                                    const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(generate_spec(op, dynamic_cast<ObScalarAggregateSpec &>(spec), in_root_job))) {
+    LOG_WARN("generate spec failed", K(ret));
+  } else if (op.is_pushdown_scalar_aggr()){
+    spec.set_cant_return_empty_set();
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogGroupBy &op, ObMergeGroupByVecSpec &spec,
+                                    const bool in_root_job)
+{
+  return generate_spec(op, reinterpret_cast<ObMergeGroupBySpec &>(spec), in_root_job);
+}
+
 int ObStaticEngineCG::generate_spec(ObLogGroupBy &op, ObMergeGroupBySpec &spec,
     const bool in_root_job)
 {
@@ -3966,6 +4799,11 @@ int ObStaticEngineCG::generate_spec(ObLogGroupBy &op, ObHashGroupBySpec &spec,
   return ret;
 }
 
+int ObStaticEngineCG::generate_spec(ObLogGroupBy &op, ObHashGroupByVecSpec &spec, const bool in_root_job)
+{
+  return generate_spec(op, reinterpret_cast<ObHashGroupBySpec &> (spec), in_root_job);
+}
+
 // copy from ObCodeGeneratorImpl::convert_normal_table_scan
 int ObStaticEngineCG::generate_normal_tsc(ObLogTableScan &op, ObTableScanSpec &spec)
 {
@@ -4037,6 +4875,9 @@ int ObStaticEngineCG::generate_normal_tsc(ObLogTableScan &op, ObTableScanSpec &s
   if (OB_SUCC(ret)) {
     if (OB_FAIL(tsc_cg_service_.generate_tsc_ctdef(op, spec.tsc_ctdef_))) {
       LOG_WARN("generate tsc ctdef failed", K(ret));
+    } else if (FALSE_IT(spec.tsc_ctdef_.scan_flags_.enable_rich_format_
+                        = spec.use_rich_format_)) {
+      // do nothing
     }
     LOG_TRACE("CG index table scan",
               K(spec.tsc_ctdef_.scan_ctdef_.ref_table_id_),
@@ -4044,7 +4885,8 @@ int ObStaticEngineCG::generate_normal_tsc(ObLogTableScan &op, ObTableScanSpec &s
               K(spec.ref_table_id_),
               K(op.get_ref_table_id()),
               K(op.get_index_table_id()),
-              K(tbl_name), K(index_name));
+              K(tbl_name), K(index_name),
+              K(spec.use_rich_format_));
   }
 
   if (OB_SUCC(ret)) {
@@ -4266,6 +5108,136 @@ int ObStaticEngineCG::generate_tsc_flags(ObLogTableScan &op, ObTableScanSpec &sp
   return ret;
 }
 
+int ObStaticEngineCG::generate_spec(ObLogJoin &op,
+                                    ObMergeJoinVecSpec &spec,
+                                    const bool in_root_job)
+{
+  UNUSED(in_root_job);
+  int ret = OB_SUCCESS;
+  if (op.is_partition_wise()) {
+    phy_plan_->set_is_wise_join(op.is_partition_wise()); // set is_wise_join
+  }
+  // 1. add other join conditions
+  const ObIArray<ObRawExpr*> &other_join_conds = op.get_other_join_conditions();
+
+  OZ(spec.other_join_conds_.init(other_join_conds.count()));
+
+  ARRAY_FOREACH(other_join_conds, i) {
+    ObRawExpr *raw_expr = other_join_conds.at(i);
+    ObExpr *expr = NULL;
+    if (OB_ISNULL(raw_expr)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_ERROR("null pointer", K(ret));
+    } else if (OB_FAIL(generate_rt_expr(*raw_expr, expr))) {
+      LOG_WARN("fail to generate rt expr", K(ret), K(*raw_expr));
+    } else if (OB_FAIL(spec.other_join_conds_.push_back(expr))) {
+      LOG_WARN("failed to add sql expr", K(ret), K(*expr));
+    } else {
+      LOG_DEBUG("equijoin condition", K(*raw_expr), K(*expr));
+    }
+  } // end for
+  spec.join_type_ = op.get_join_type();
+  // 2. add equal conditions and populate all exprs for left/right child
+  const ObIArray<ObRawExpr*> &equal_join_conds = op.get_equal_join_conditions();
+  OZ(spec.equal_cond_infos_.init(equal_join_conds.count()));
+  if (OB_ISNULL(spec.get_left())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("left is null", K(ret));
+  } else if (OB_ISNULL(spec.get_right())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("right is null", K(ret));
+  } else if (OB_FAIL(spec.left_child_fetcher_all_exprs_.init(
+                spec.get_left()->output_.count() +
+                equal_join_conds.count()))) {
+    LOG_WARN("failed to init left fetcher all exprs", K(ret));
+  } else if (OB_FAIL(spec.right_child_fetcher_all_exprs_.init(
+                spec.get_right()->output_.count() +
+                equal_join_conds.count()))) {
+    LOG_WARN("failed to init right fetcher all exprs", K(ret));
+  } else if (OB_FAIL(
+                append_array_no_dup(spec.left_child_fetcher_all_exprs_,
+                                      spec.get_left()->output_))) {
+    LOG_WARN("fail to append array no dup for left child", K(ret), K(op));
+  } else if (OB_FAIL(
+                append_array_no_dup(spec.right_child_fetcher_all_exprs_,
+                                      spec.get_right()->output_))) {
+    LOG_WARN("fail to append array no dup for right child", K(ret), K(op));
+  } else if (OB_FAIL(spec.init_equal_keys(equal_join_conds.count()))) {
+    LOG_WARN("fail to init equal key arrays", K(ret), K(op));
+  }
+  ARRAY_FOREACH(equal_join_conds, i) {
+    ObMergeJoinVecSpec::EqualConditionInfo equal_cond_info;
+    ObRawExpr *raw_expr = equal_join_conds.at(i);
+    CK(OB_NOT_NULL(raw_expr));
+    CK(T_OP_EQ == raw_expr->get_expr_type() || T_OP_NSEQ == raw_expr->get_expr_type());
+    OZ(generate_rt_expr(*raw_expr, equal_cond_info.expr_));
+    CK(OB_NOT_NULL(equal_cond_info.expr_));
+    CK(equal_cond_info.expr_->arg_cnt_ == 2)
+    CK(OB_NOT_NULL(equal_cond_info.expr_->args_));
+    CK(OB_NOT_NULL(equal_cond_info.expr_->args_[0]));
+    CK(OB_NOT_NULL(equal_cond_info.expr_->args_[1]));
+    if (OB_SUCC(ret)){
+      if (OB_SUCC(ret)) {
+        OZ(calc_equal_cond_opposite(op, *raw_expr, equal_cond_info.is_opposite_));
+        if (OB_SUCC(ret)) {
+          sql::NullSafeRowCmpFunc null_first_cmp = nullptr;
+          sql::NullSafeRowCmpFunc null_last_cmp = nullptr;
+          const sql::ObDatumMeta &l_meta = !equal_cond_info.is_opposite_ ? equal_cond_info.expr_->args_[0]->datum_meta_
+                                          : equal_cond_info.expr_->args_[1]->datum_meta_;
+          const sql::ObDatumMeta &r_meta = !equal_cond_info.is_opposite_ ? equal_cond_info.expr_->args_[1]->datum_meta_
+                                          : equal_cond_info.expr_->args_[0]->datum_meta_;
+          VectorCmpExprFuncsHelper::get_cmp_set(l_meta, r_meta, null_first_cmp, null_last_cmp);
+          CK(OB_NOT_NULL(null_first_cmp));
+          CK(OB_NOT_NULL(null_last_cmp));
+          if (OB_SUCC(ret)) {
+            equal_cond_info.ns_cmp_func_ = null_first_cmp;
+          }
+        }
+        OZ(spec.equal_cond_infos_.push_back(equal_cond_info));
+        int64_t l_idx = 0;
+        int64_t r_idx = 0;
+        if (OB_FAIL(ret)) {
+        } else if (OB_FAIL(add_var_to_array_no_dup(spec.left_child_fetcher_all_exprs_,
+            !equal_cond_info.is_opposite_ ? equal_cond_info.expr_->args_[0]
+                                          : equal_cond_info.expr_->args_[1],
+            &l_idx))) {
+          OB_LOG(WARN, "fail to add_var_to_array_no_dup",  K(ret));
+        } else if (OB_FAIL(add_var_to_array_no_dup(spec.right_child_fetcher_all_exprs_,
+            !equal_cond_info.is_opposite_ ? equal_cond_info.expr_->args_[1]
+                                          : equal_cond_info.expr_->args_[0],
+            &r_idx))) {
+          OB_LOG(WARN, "fail to add_var_to_array_no_dup", K(ret));
+        } else if (OB_FAIL(spec.left_child_fetcher_equal_keys_.push_back(
+            !equal_cond_info.is_opposite_ ? equal_cond_info.expr_->args_[0]
+                                          : equal_cond_info.expr_->args_[1]))) {
+          OB_LOG(WARN, "fail to push back equal key into left child", K(ret));
+        } else if (OB_FAIL(spec.right_child_fetcher_equal_keys_.push_back(
+            !equal_cond_info.is_opposite_ ? equal_cond_info.expr_->args_[1]
+                                          : equal_cond_info.expr_->args_[0]))) {
+          OB_LOG(WARN, "fail to push back equal key into right child", K(ret));
+        } else if (OB_FAIL(spec.left_child_fetcher_equal_keys_idx_.push_back(l_idx))) {
+          OB_LOG(WARN, "fail to push back equal key idx into right child", K(ret));
+        } else if (OB_FAIL(spec.right_child_fetcher_equal_keys_idx_.push_back(r_idx))) {
+          OB_LOG(WARN, "fail to push back equal key idx into right child", K(ret));
+        }
+        LOG_DEBUG("equijoin condition", K(*raw_expr), K(equal_cond_info),
+                  K(equal_cond_info.is_opposite_),
+                  K(equal_cond_info.ns_cmp_func_),
+                  KPC(equal_cond_info.expr_->args_[0]),
+                  KPC(equal_cond_info.expr_->args_[1]));
+      }
+    }
+  } // end for
+  // 3. add merge directions
+  if (OB_SUCC(ret)) {
+    const ObIArray<ObOrderDirection> &merge_directions = op.get_merge_directions();
+    if (OB_FAIL(spec.set_merge_directions(merge_directions))) {
+      LOG_WARN("fail to set merge directions", K(ret));
+    }
+  }
+  return ret;
+}
+
 int ObStaticEngineCG::generate_param_spec(
   const common::ObIArray<ObExecParamRawExpr *> &param_raw_exprs,
   ObFixedArray<ObDynamicParamSetter, ObIAllocator> &param_setter)
@@ -4294,6 +5266,23 @@ int ObStaticEngineCG::generate_spec(ObLogJoin &op, ObHashJoinSpec &spec, const b
   int ret = OB_SUCCESS;
   UNUSED(in_root_job);
 
+  if (op.get_jf_material_control_info().enable_material_) {
+    // join filter material feature need hash join with vectorized 2.0
+    // if hash join is vectorized 1.0, disable join filter material
+    ObOpSpec *cur_spec = &spec;
+    while (cur_spec->get_child(0) != nullptr) {
+      cur_spec = cur_spec->get_child(0);
+      if (!cur_spec->use_rich_format_) {
+        break;
+      } else if (cur_spec->get_type() != PHY_JOIN_FILTER) {
+        break;
+      } else {
+        ObJoinFilterSpec *join_filter_spec = static_cast<ObJoinFilterSpec *>(cur_spec);
+        join_filter_spec->jf_material_control_info_.enable_material_ = false;
+      }
+    }
+  }
+
   CK (nullptr != op.get_join_path());
   if (OB_SUCC(ret) && op.get_join_path()->is_naaj_) {
     CK (LEFT_ANTI_JOIN == op.get_join_type() || RIGHT_ANTI_JOIN == op.get_join_type());
@@ -4306,12 +5295,248 @@ int ObStaticEngineCG::generate_spec(ObLogJoin &op, ObHashJoinSpec &spec, const b
   return ret;
 }
 
+int ObStaticEngineCG::generate_spec(ObLogJoin &op, ObHashJoinVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  CK (nullptr != op.get_join_path());
+  if (OB_SUCC(ret) && op.get_join_path()->is_naaj_) {
+    CK (LEFT_ANTI_JOIN == op.get_join_type() || RIGHT_ANTI_JOIN == op.get_join_type());
+    OX (spec.is_naaj_ = op.get_join_path()->is_naaj_);
+    OX (spec.is_sna_ = op.get_join_path()->is_sna_);
+  }
+  spec.is_shared_ht_ = DIST_BC2HOST_NONE == op.get_join_distributed_method();
+  if (op.is_partition_wise()) {
+    phy_plan_->set_is_wise_join(op.is_partition_wise()); // set is_wise_join
+  }
+
+  spec.jf_material_control_info_ = op.get_jf_material_control_info();
+
+  // 1. add other join conditions
+  const ObIArray<ObRawExpr*> &other_join_conds = op.get_other_join_conditions();
+  OZ(spec.other_join_conds_.init(other_join_conds.count()));
+  ARRAY_FOREACH(other_join_conds, i) {
+    ObRawExpr *raw_expr = other_join_conds.at(i);
+    ObExpr *expr = NULL;
+    if (OB_ISNULL(raw_expr)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_ERROR("null pointer", K(ret));
+    } else if (OB_FAIL(generate_rt_expr(*raw_expr, expr))) {
+      LOG_WARN("fail to generate rt expr", K(ret), K(*raw_expr));
+    } else if (OB_FAIL(spec.other_join_conds_.push_back(expr))) {
+      LOG_WARN("failed to add sql expr", K(ret), K(*expr));
+    } else {
+      LOG_DEBUG("equijoin condition", K(*raw_expr), K(*expr));
+    }
+  } // end for
+
+  spec.join_type_ = op.get_join_type();
+  if (OB_SUCC(ret)) {
+    ObHashJoinVecSpec &hj_spec = spec;
+    CK (OB_NOT_NULL(hj_spec.get_left()));
+    CK (OB_NOT_NULL(hj_spec.get_right()));
+    ObSEArray<ObExpr *, 4> equal_join_conds;
+    OZ (generate_rt_exprs(op.get_equal_join_conditions(), equal_join_conds));
+    OZ (hj_spec.join_conds_.init(op.get_equal_join_conditions().count()
+                                 + op.get_other_join_conditions().count()));
+    for (int64_t i = 0; OB_SUCC(ret) && i < equal_join_conds.count(); i++) {
+      OZ (hj_spec.join_conds_.push_back(equal_join_conds.at(i)));
+    }
+    for (int64_t i = 0; OB_SUCC(ret) && i < hj_spec.other_join_conds_.count(); i++) {
+      OZ (hj_spec.join_conds_.push_back(hj_spec.other_join_conds_.at(i)));
+    }
+    OZ (hj_spec.build_key_proj_.init(equal_join_conds.count()));
+    OZ (hj_spec.probe_key_proj_.init(equal_join_conds.count()));
+    OZ (hj_spec.build_keys_.init(equal_join_conds.count()));
+    OZ (hj_spec.probe_keys_.init(equal_join_conds.count()));
+    OZ (hj_spec.build_rows_output_.init(hj_spec.get_left()->output_.count() + equal_join_conds.count()));
+    if (OB_SUCC(ret)) {
+      for (int64_t i = 0; OB_SUCC(ret) && i < hj_spec.get_left()->output_.count(); i++) {
+        OZ (hj_spec.build_rows_output_.push_back(hj_spec.get_left()->output_.at(i)));
+      }
+    }
+    if (OB_SUCC(ret)) {
+      hj_spec.can_prob_opt_ = true;
+      int64_t build_key_not_in_output_idx = hj_spec.get_left()->output_.count();
+      int64_t probe_key_not_in_output_idx = hj_spec.get_right()->output_.count();
+      for (int64_t i = 0; i < equal_join_conds.count() && OB_SUCC(ret); ++i) {
+        ObExpr *expr = equal_join_conds.at(i);
+        ObHashFunc left_hash_func;
+        ObHashFunc right_hash_func;
+        ObExpr *left_expr = nullptr;
+        ObExpr *right_expr = nullptr;
+        bool is_opposite = false;
+        if (2 != expr->arg_cnt_) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("unexpected status: join keys must have 2 arguments", K(ret), K(*expr));
+        } else if (OB_FAIL(calc_equal_cond_opposite(
+            op, *op.get_equal_join_conditions().at(i), is_opposite))) {
+          LOG_WARN("failed to calc equal condition opposite", K(ret));
+        } else {
+          if (is_opposite) {
+            left_expr = expr->args_[1];
+            right_expr = expr->args_[0];
+          } else {
+            left_expr = expr->args_[0];
+            right_expr = expr->args_[1];
+          }
+          if (T_REF_COLUMN != left_expr->type_
+              || T_REF_COLUMN != right_expr->type_
+              || left_expr->datum_meta_.type_ != right_expr->datum_meta_.type_
+              || T_OP_NSEQ == expr->type_
+              || !has_exist_in_array(hj_spec.get_left()->output_, left_expr)
+              || !has_exist_in_array(hj_spec.get_right()->output_, right_expr)) {
+            hj_spec.can_prob_opt_ = false;
+          }
+          int64_t idx = 0;
+          if (has_exist_in_array(hj_spec.get_left()->output_, left_expr, &idx)) {
+            OZ (hj_spec.build_key_proj_.push_back(idx));
+          } else {
+            OZ (hj_spec.build_rows_output_.push_back(left_expr));
+            OZ (hj_spec.build_key_proj_.push_back(build_key_not_in_output_idx++));
+          }
+          if (OB_FAIL(ret)) {
+          } else if (has_exist_in_array(hj_spec.get_right()->output_, right_expr, &idx)) {
+            OZ (hj_spec.probe_key_proj_.push_back(idx));
+          } else {
+            OZ (hj_spec.probe_key_proj_.push_back(probe_key_not_in_output_idx++));
+          }
+          OZ (hj_spec.build_keys_.push_back(left_expr));
+          OZ (hj_spec.probe_keys_.push_back(right_expr));
+        }
+      } // for end
+      if (hj_spec.can_prob_opt_) {
+        //TODO shengle other join type can use probe opt
+        if (INNER_JOIN != op.get_join_type() || op.get_other_join_conditions().count() > 0) {
+          hj_spec.can_prob_opt_ = false;
+        }
+      }
+      if (OB_SUCC(ret)) {
+        if (OB_FAIL(hj_spec.is_ns_equal_cond_.init(equal_join_conds.count()))) {
+          LOG_WARN("failed to init ns equal array", K(ret));
+        } else {
+          // for null safe equal, we can not skip null value during executing
+          for (int64_t i = 0; OB_SUCC(ret) && i < equal_join_conds.count(); ++i) {
+            ObExpr *equal_expr = equal_join_conds.at(i);
+            if (OB_ISNULL(equal_expr)) {
+              ret = OB_ERR_UNEXPECTED;
+              LOG_WARN("got null join equal expr", K(ret), K(i));
+            } else if (T_OP_NSEQ == equal_expr->type_) {
+              OZ (hj_spec.is_ns_equal_cond_.push_back(true));
+            } else {
+              OZ (hj_spec.is_ns_equal_cond_.push_back(false));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
 int ObStaticEngineCG::generate_spec(ObLogJoin &op,
                                     ObNestedLoopJoinSpec &spec,
                                     const bool in_root_job)
 {
   UNUSED(in_root_job);
   return generate_join_spec(op, spec);
+}
+
+int ObStaticEngineCG::generate_spec(ObLogJoin &op,
+                                    ObNestedLoopJoinVecSpec &spec,
+                                    const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  UNUSED(in_root_job);
+  bool is_late_mat = (phy_plan_->get_is_late_materialized() || op.is_late_mat());
+  phy_plan_->set_is_late_materialized(is_late_mat);
+  if (op.is_partition_wise()) {
+    phy_plan_->set_is_wise_join(op.is_partition_wise()); // set is_wise_join
+  }
+  // 1. add other join conditions
+  const ObIArray<ObRawExpr*> &other_join_conds = op.get_other_join_conditions();
+  if (OB_FAIL(spec.other_join_conds_.init(other_join_conds.count()))) {
+    LOG_WARN("failed to init other join conditions", K(ret));
+  } else {
+    ARRAY_FOREACH(other_join_conds, i) {
+      ObRawExpr *raw_expr = other_join_conds.at(i);
+      ObExpr *expr = NULL;
+      if (OB_ISNULL(raw_expr)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_ERROR("null pointer", K(ret));
+      } else if (OB_FAIL(generate_rt_expr(*raw_expr, expr))) {
+        LOG_WARN("fail to generate rt expr", K(ret), K(*raw_expr));
+      } else if (OB_FAIL(spec.other_join_conds_.push_back(expr))) {
+        LOG_WARN("failed to add sql expr", K(ret), K(*expr));
+      } else {
+        LOG_DEBUG("equijoin condition", K(*raw_expr), K(*expr));
+      }
+    } // end for
+  }
+
+  spec.join_type_ = op.get_join_type();
+  if (OB_FAIL(ret)) {
+    // do nothing
+  } else if (NESTED_LOOP_JOIN ==  op.get_join_algo()) {
+    if (0 != op.get_equal_join_conditions().count()) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("equal join conditions' count should equal 0", K(ret));
+    } else {
+      spec.enable_gi_partition_pruning_ = op.is_enable_gi_partition_pruning();
+      if (spec.enable_gi_partition_pruning_ && OB_FAIL(do_gi_partition_pruning(op, spec))) {
+        LOG_WARN("fail do gi partition pruning", K(ret));
+      } else if (OB_FAIL(generate_param_spec(op.get_nl_params(), spec.rescan_params_))) {
+        LOG_WARN("fail to generate param spec", K(ret));
+      } else {
+        spec.enable_px_batch_rescan_ = false;
+        if (OB_SUCC(ret) && PHY_VEC_NESTED_LOOP_JOIN == spec.type_) {
+          bool use_batch_nlj = op.can_use_batch_nlj();
+          if (use_batch_nlj) {
+            spec.group_rescan_ = use_batch_nlj;
+          }
+
+          if (spec.is_vectorized()) {
+            // populate other cond join info
+            const ObIArray<ObExpr *> &conds = spec.other_join_conds_;
+            if (OB_FAIL(spec.left_expr_ids_in_other_cond_.prepare_allocate(conds.count()))) {
+              ret = OB_ERR_UNEXPECTED;
+              LOG_WARN("Failed to prepare_allocate left_expr_ids_in_other_cond_", K(ret));
+            } else {
+              ARRAY_FOREACH(conds, i) {
+                ObExpr *cond = conds.at(i);
+                ObSEArray<int, 1> left_expr_ids;
+                for (int64_t l_output_idx = 0;
+                     OB_SUCC(ret) && l_output_idx < spec.get_left()->output_.count();
+                     l_output_idx++) {
+                  // check if left child expr appears in other_condition
+                  bool appears_in_cond = false;
+                  if (OB_FAIL(cond->contain_expr(
+                          spec.get_left()->output_.at(l_output_idx), appears_in_cond))) {
+                    LOG_WARN("other expr contain calculate failed", K(ret), KPC(cond),
+                             K(l_output_idx),
+                             KPC(spec.get_left()->output_.at(l_output_idx)));
+                  } else {
+                    if (appears_in_cond) {
+                      if (OB_FAIL(left_expr_ids.push_back(l_output_idx))) {
+                        LOG_WARN("other expr contain", K(ret));
+                      }
+                    }
+                  }
+                }
+                // Note: no need to call init explicitly as init() is invoked inside assign()
+                OZ(spec.left_expr_ids_in_other_cond_.at(i).assign(left_expr_ids));
+              }
+            }
+          }
+        }
+      }
+    }
+  } else {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid join algorithm to generate NLJ spec", K(ret), K(op.get_join_algo()));
+  }
+  return ret;
 }
 
 int ObStaticEngineCG::generate_spec(ObLogJoin &op,
@@ -4626,6 +5851,14 @@ int ObStaticEngineCG::do_gi_partition_pruning(
   return ret;
 }
 
+int ObStaticEngineCG::do_gi_partition_pruning(
+    ObLogJoin &op,
+    ObNestedLoopJoinVecSpec &spec)
+{
+  int ret = OB_SUCCESS;
+  OZ(generate_rt_expr(*op.get_partition_id_expr(), spec.gi_partition_id_expr_));
+  return ret;
+}
 int ObStaticEngineCG::calc_equal_cond_opposite(const ObLogJoin &op,
                                                const ObRawExpr &raw_expr,
                                                bool &is_opposite)
@@ -4930,7 +6163,7 @@ int ObStaticEngineCG::generate_spec(
         }
       }
       if (OB_SUCC(ret) && is_all_subquery_deterministic) {
-        spec.enable_subquery_result_cache_ = true;
+        spec.exec_param_idxs_inited_ = true;
       }
     }
   }
@@ -4960,6 +6193,18 @@ int ObStaticEngineCG::generate_spec(
   }
   if (OB_SUCC(ret)) {
     spec.enable_das_group_rescan_ = op.enable_das_group_rescan();
+  }
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(
+    ObLogSubPlanFilter &op, ObSubPlanFilterVecSpec &spec, const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  spec.use_rich_format_ = true;
+  ObSubPlanFilterSpec &base_spec = spec;
+  if (OB_FAIL(generate_spec(op, base_spec, in_root_job))) {
+    LOG_WARN("failed to generate spec for subplan filter operator", K(ret));
   }
   return ret;
 }
@@ -5170,6 +6415,11 @@ int ObStaticEngineCG::generate_spec(ObLogInsert &op, ObPxMultiPartSSTableInsertS
   return ret;
 }
 
+int ObStaticEngineCG::generate_spec(ObLogInsert &op, ObPxMultiPartSSTableInsertVecSpec &spec, const bool in_root_job)
+{
+  return generate_spec(op, static_cast<ObPxMultiPartSSTableInsertSpec &>(spec), in_root_job);
+}
+
 int ObStaticEngineCG::generate_spec(ObLogUpdate &op,
                                     ObPxMultiPartUpdateSpec &spec,
                                     const bool in_root_job)
@@ -5317,7 +6567,7 @@ int ObStaticEngineCG::fill_aggr_infos(ObLogGroupBy &op,
   spec.support_fast_single_row_agg_ = true;
   for (int64_t i = 0; OB_SUCC(ret) && i < all_aggr_exprs.count(); ++i) {
     ObAggrInfo &aggr_info = spec.aggr_infos_.at(i);
-    if (!is_simple_aggr_expr(aggr_exprs.at(i)->get_expr_type())) {
+    if (!is_simple_aggr_expr(aggr_exprs.at(i)->get_expr_type(), spec.use_rich_format_)) {
       spec.support_fast_single_row_agg_ = false;
     }
     if (OB_FAIL(fill_aggr_info(*static_cast<ObAggFunRawExpr *>(aggr_exprs.at(i)),
@@ -5345,7 +6595,9 @@ int ObStaticEngineCG::fill_aggr_infos(ObLogGroupBy &op,
     bool find_first_spec = false;
     while (!find_first_spec && child_spec->get_children() != NULL
             && child_spec->get_child_cnt() > 0) {
-      if ((child_spec->type_ == PHY_HASH_GROUP_BY ||
+      if ((child_spec->type_ == PHY_VEC_HASH_GROUP_BY ||
+           child_spec->type_ == PHY_HASH_GROUP_BY ||
+           child_spec->type_ == PHY_VEC_MERGE_GROUP_BY ||
            child_spec->type_ == PHY_MERGE_GROUP_BY) &&
            ((ObGroupBySpec*)child_spec)->aggr_stage_ == ObThreeStageAggrStage::FIRST_STAGE) {
         find_first_spec = true;
@@ -5824,6 +7076,57 @@ int ObStaticEngineCG::generate_spec(ObLogWindowFunction &op, ObWindowFunctionSpe
   }
 
   LOG_DEBUG("finish generate_spec", K(spec), K(ret));
+  return ret;
+}
+
+int ObStaticEngineCG::generate_spec(ObLogWindowFunction &op, ObWindowFunctionVecSpec &spec,
+    const bool in_root_job)
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(generate_spec(op, static_cast<ObWindowFunctionSpec &>(spec), in_root_job))) {
+    LOG_WARN("generate window function spec failed", K(ret));
+  } else {
+    NullSafeRowCmpFunc null_first_cmp = nullptr, null_last_cmp = nullptr;
+    for (int i = 0; OB_SUCC(ret) && i < spec.wf_infos_.count(); i++) {
+      WinFuncInfo &wf_info = spec.wf_infos_.at(i);
+      for (int j = 0; OB_SUCC(ret) && j < wf_info.sort_exprs_.count(); j++) {
+        ObExpr *sort_expr = wf_info.sort_exprs_.at(j);
+        VectorCmpExprFuncsHelper::get_cmp_set(sort_expr->datum_meta_, sort_expr->datum_meta_,
+                                              null_first_cmp, null_last_cmp);
+        if (OB_ISNULL(null_first_cmp) || OB_ISNULL(null_last_cmp)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("unexpected null cmp funcs", K(ret), K(null_first_cmp), K(null_last_cmp));
+        } else if (wf_info.sort_collations_.at(j).null_pos_ == NULL_FIRST) {
+          wf_info.sort_cmp_funcs_.at(j).row_cmp_func_ = null_first_cmp;
+        } else {
+          wf_info.sort_cmp_funcs_.at(j).row_cmp_func_ = null_last_cmp;
+        }
+      } // end inner for
+    } // end outter for
+  }
+  if (OB_FAIL(ret)) {
+  } else if (op.is_range_dist_parallel()) {
+    // change sort cmp functions in rd_sort_cmp_funcs_
+    for (int i = 0; OB_SUCC(ret) && i < spec.rd_sort_collations_.count(); i++) {
+      ObExpr *rd_expr = spec.rd_coord_exprs_.at(i);
+      if (OB_ISNULL(rd_expr) || i >= spec.rd_sort_cmp_funcs_.count()) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected null rd expr", K(ret), K(i));
+      } else {
+        NullSafeRowCmpFunc null_first_cmp = nullptr, null_last_cmp = nullptr;
+        VectorCmpExprFuncsHelper::get_cmp_set(
+          rd_expr->datum_meta_, rd_expr->datum_meta_, null_first_cmp, null_last_cmp);
+        if (OB_ISNULL(null_first_cmp) || OB_ISNULL(null_last_cmp)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("unexpected null cmp funcs", K(ret), K(null_first_cmp), K(null_last_cmp));
+        } else if (spec.rd_sort_collations_.at(i).null_pos_ == NULL_FIRST) {
+          spec.rd_sort_cmp_funcs_.at(i).row_cmp_func_ = null_first_cmp;
+        } else {
+          spec.rd_sort_cmp_funcs_.at(i).row_cmp_func_ = null_last_cmp;
+        }
+      }
+    }
+  }
   return ret;
 }
 
@@ -6486,10 +7789,7 @@ int ObStaticEngineCG::set_properties_post(const ObLogPlan &log_plan, ObPhysicalP
   if (OB_SUCC(ret)) {
     //set other params
     //set user var assignment property
-    // Keep the recursive assignment flag captured before query transformations.
-    // The root statement may no longer expose assignments that remain in a child
-    // query, but scalar execution still has to eagerly evaluate their outputs.
-    phy_plan.set_contains_assignment(log_plan.get_optimizer_context().has_var_assign());
+    phy_plan.set_contains_assignment(log_plan.get_stmt()->is_contains_assignment());
     phy_plan.set_require_local_execution(!log_plan.get_optimizer_context().get_exchange_allocated());
     phy_plan.set_plan_type(log_plan.get_optimizer_context().get_phy_plan_type());
     phy_plan.set_location_type(log_plan.get_optimizer_context().get_location_type());
@@ -6723,34 +8023,93 @@ int ObStaticEngineCG::set_properties_post(const ObLogPlan &log_plan, ObPhysicalP
 // FIXME bin.lb: We should split the big switch case into logical operator class.
 int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
                                          ObPhyOperatorType &type,
-                                         const bool in_root_job)
+                                         const bool in_root_job,
+                                         const bool use_rich_format)
 {
   int ret = OB_SUCCESS;
   type = PHY_INVALID;
+  int err_switch = OB_E(EventTable::EN_DISK_ERROR) OB_SUCCESS;
   switch(log_op.get_type()) {
     case log_op_def::LOG_LIMIT: {
       type = PHY_LIMIT;
+      if (use_rich_format) {
+        type = PHY_VEC_LIMIT;
+      } else {
+        type = PHY_LIMIT;
+      }
       break;
     }
     case log_op_def::LOG_GROUP_BY: {
       auto &op = static_cast<ObLogGroupBy&>(log_op);
       switch (op.get_algo()) {
-        case MERGE_AGGREGATE:
+      case MERGE_AGGREGATE: {
+        int tmp_ret = OB_SUCCESS;
+        tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_SCALAR_GROUP_BY) OB_SUCCESS;
+        bool use_vec2_merge_gby =
+          ((OB_SUCCESS == OB_E(EventTable::EN_DISABLE_VEC_MERGE_GBY) OB_SUCCESS));
+        if (op.is_pushdown_scalar_aggr() && OB_SUCC(tmp_ret) && use_rich_format
+            && aggregate::Processor::all_supported_aggregate_functions(
+              static_cast<ObLogGroupBy *>(&log_op)->get_aggr_funcs())) {
+          type = PHY_VEC_SCALAR_AGGREGATE;
+        } else if (use_rich_format && use_vec2_merge_gby
+                   && aggregate::Processor::all_supported_aggregate_functions(
+                     static_cast<ObLogGroupBy *>(&log_op)->get_aggr_funcs(),
+                     static_cast<ObLogGroupBy *>(&log_op)->get_hash_rollup_info() != nullptr,
+                     static_cast<ObLogGroupBy *>(&log_op)->has_rollup())) {
+          type = PHY_VEC_MERGE_GROUP_BY;
+        } else {
           type = PHY_MERGE_GROUP_BY;
-          break;
-        case HASH_AGGREGATE:
+        }
+        break;
+      }
+        case HASH_AGGREGATE: {
           type = PHY_HASH_GROUP_BY;
+          int tmp_ret = OB_SUCCESS;
+          tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_HASH_GROUP_BY) OB_SUCCESS;
+          if (OB_SUCCESS == tmp_ret
+              && use_rich_format
+              && aggregate::Processor::all_supported_aggregate_functions(
+                static_cast<ObLogGroupBy *>(&log_op)->get_aggr_funcs(),
+                static_cast<ObLogGroupBy *>(&log_op)->get_hash_rollup_info() != nullptr,
+                static_cast<ObLogGroupBy *>(&log_op)->has_rollup())) {
+            type = PHY_VEC_HASH_GROUP_BY;
+          }
           break;
-        case SCALAR_AGGREGATE:
-          type = PHY_SCALAR_AGGREGATE;
+        }
+        case SCALAR_AGGREGATE: {
+          int tmp_ret = OB_SUCCESS;
+          tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_SCALAR_GROUP_BY) OB_SUCCESS;
+          if (use_rich_format && OB_SUCC(tmp_ret)
+              && aggregate::Processor::all_supported_aggregate_functions(
+                   static_cast<ObLogGroupBy *>(&log_op)->get_aggr_funcs(), true,
+                   static_cast<ObLogGroupBy *>(&log_op)->has_rollup())) {
+            type = PHY_VEC_SCALAR_AGGREGATE;
+          } else {
+            type = PHY_SCALAR_AGGREGATE;
+          }
           break;
+        }
         default:
           break;
       }
       break;
     }
     case log_op_def::LOG_SORT: {
-      type = PHY_SORT;
+      int tmp_ret = OB_SUCCESS;
+      bool use_vec_sort = true;
+      const ObLogSort &sort_op = static_cast<const ObLogSort &>(log_op);
+      if ((1 == sort_op.get_sort_keys().count() && !sort_op.enable_pd_topn_filter())
+          || (NULL != sort_op.get_topn_expr() && sort_op.get_part_cnt() > 0)) {
+        use_vec_sort = false;
+      }
+      tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_SORT) OB_SUCCESS;
+      if (OB_SUCCESS != tmp_ret) {
+        type = PHY_SORT;
+      } else if (use_vec_sort && use_rich_format) {
+        type = PHY_VEC_SORT;
+      } else {
+        type = PHY_SORT;
+      }
       break;
     }
     case log_op_def::LOG_TABLE_SCAN: {
@@ -6775,17 +8134,38 @@ int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
     case log_op_def::LOG_JOIN: {
       auto &op = static_cast<ObLogJoin&>(log_op);
       switch(op.get_join_algo()) {
-        case NESTED_LOOP_JOIN:
+        case NESTED_LOOP_JOIN: {
           type = PHY_NESTED_LOOP_JOIN;
+          if (type == PHY_NESTED_LOOP_JOIN && use_rich_format &&
+              op.get_plan()->get_optimizer_context().get_session_info()->is_nlj_spf_use_rich_format_enabled() &&
+              !op.enable_px_batch_rescan()) {
+            type = PHY_VEC_NESTED_LOOP_JOIN;
+          }
           break;
-        case MERGE_JOIN:
-          type = PHY_MERGE_JOIN;
+        }
+        case MERGE_JOIN: {
+          int tmp_ret = OB_SUCCESS;
+          tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_MERGE_JOIN) OB_SUCCESS;
+          if (OB_SUCCESS == tmp_ret && use_rich_format) {
+            type = PHY_VEC_MERGE_JOIN;
+          } else {
+            type = PHY_MERGE_JOIN;
+          }
           break;
-        case HASH_JOIN:
-          type = PHY_HASH_JOIN;
+        }
+        case HASH_JOIN: {
+          int tmp_ret = OB_SUCCESS;
+          tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_HASH_JOIN) OB_SUCCESS;
+          if (OB_SUCCESS == tmp_ret && use_rich_format) {
+            type = PHY_VEC_HASH_JOIN;
+          } else {
+            type = PHY_HASH_JOIN;
+          }
           break;
-        default:
+        }
+        default: {
           break;
+        }
       }
       break;
     }
@@ -6819,7 +8199,10 @@ int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
           if (op.is_task_order()) {
             type = PHY_PX_ORDERED_COORD;
           } else if (op.is_merge_sort()) {
-            type = PHY_PX_MERGE_SORT_COORD;
+            type = (use_rich_format && op.support_rich_format_vectorize()
+                    && op.get_plan()->get_optimizer_context().get_max_parallel() > 1) ?
+                       PHY_VEC_PX_MERGE_SORT_COORD :
+                       PHY_PX_MERGE_SORT_COORD;
           } else {
             type = PHY_PX_FIFO_COORD;
           }
@@ -6830,7 +8213,10 @@ int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
                          "with local order in root job", K(ret));
           }
         } else if (op.is_merge_sort()) {
-          type = PHY_PX_MERGE_SORT_RECEIVE;
+          type = (use_rich_format && op.support_rich_format_vectorize()
+                  && op.get_plan()->get_optimizer_context().get_max_parallel() > 1) ?
+                     PHY_VEC_PX_MERGE_SORT_RECEIVE :
+                     PHY_PX_MERGE_SORT_RECEIVE;
         } else {
           type = PHY_PX_FIFO_RECEIVE;
         }
@@ -6840,9 +8226,25 @@ int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
     case log_op_def::LOG_DISTINCT: {
       auto &op = static_cast<ObLogDistinct&>(log_op);
       if (MERGE_AGGREGATE == op.get_algo()) {
-        type = PHY_MERGE_DISTINCT;
+        int tmp_ret = OB_SUCCESS;
+        tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_MERGE_DISTINCT) OB_SUCCESS;
+        if (OB_SUCCESS != tmp_ret) {
+          type = PHY_MERGE_DISTINCT;
+        } else if (use_rich_format) {
+          type = PHY_VEC_MERGE_DISTINCT;
+        } else {
+          type = PHY_MERGE_DISTINCT;
+        }
       } else if (HASH_AGGREGATE == op.get_algo()) {
-        type = PHY_HASH_DISTINCT;
+        int tmp_ret = OB_SUCCESS;
+        tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_HASH_DISTINCT) OB_SUCCESS;
+        if (OB_SUCCESS != tmp_ret) {
+          type = PHY_HASH_DISTINCT;
+        } else if (use_rich_format) {
+          type = PHY_VEC_HASH_DISTINCT;
+        } else {
+          type = PHY_HASH_DISTINCT;
+        }
       }
       break;
     }
@@ -6901,15 +8303,44 @@ int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
       auto &op = static_cast<ObLogSet&>(log_op);
       switch (op.get_set_op()) {
         case ObSelectStmt::UNION:
-          type = op.is_recursive_union()
-                   ? PHY_RECURSIVE_UNION_ALL
-                   : (MERGE_SET == op.get_algo() ? PHY_MERGE_UNION : PHY_HASH_UNION);
+          if (op.is_recursive_union()) {
+            type = PHY_RECURSIVE_UNION_ALL;
+          } else {
+            if (use_rich_format) {
+              bool use_vec = (EVENT_CALL(EventTable::EN_TEST_FOR_HASH_UNION) == OB_SUCCESS);
+              if (use_vec) {
+                type = (MERGE_SET == op.get_algo() ? PHY_VEC_MERGE_UNION : PHY_VEC_HASH_UNION);
+              } else {
+                type = (MERGE_SET == op.get_algo() ? PHY_MERGE_UNION : PHY_HASH_UNION);
+              }
+            } else {
+              type = (MERGE_SET == op.get_algo() ? PHY_MERGE_UNION : PHY_HASH_UNION);
+            }
+          }
           break;
         case ObSelectStmt::INTERSECT:
-          type = (MERGE_SET == op.get_algo() ? PHY_MERGE_INTERSECT : PHY_HASH_INTERSECT);
+          if (use_rich_format) {
+            bool use_vec = (EVENT_CALL(EventTable::EN_TEST_FOR_HASH_UNION) == OB_SUCCESS);
+            if (use_vec) {
+              type = (MERGE_SET == op.get_algo() ? PHY_VEC_MERGE_INTERSECT : PHY_VEC_HASH_INTERSECT);
+            } else {
+              type = (MERGE_SET == op.get_algo() ? PHY_MERGE_INTERSECT : PHY_HASH_INTERSECT);
+            }
+          } else {
+            type = (MERGE_SET == op.get_algo() ? PHY_MERGE_INTERSECT : PHY_HASH_INTERSECT);
+          }
           break;
         case ObSelectStmt::EXCEPT:
-          type = (MERGE_SET == op.get_algo() ? PHY_MERGE_EXCEPT : PHY_HASH_EXCEPT);
+          if (use_rich_format) {
+            bool use_vec = (EVENT_CALL(EventTable::EN_TEST_FOR_HASH_UNION) == OB_SUCCESS);
+            if (use_vec) {
+              type = (MERGE_SET == op.get_algo() ? PHY_VEC_MERGE_EXCEPT : PHY_VEC_HASH_EXCEPT);
+            } else {
+              type = (MERGE_SET == op.get_algo() ? PHY_MERGE_EXCEPT : PHY_HASH_EXCEPT);
+            }
+          } else {
+            type = (MERGE_SET == op.get_algo() ? PHY_MERGE_EXCEPT : PHY_HASH_EXCEPT);
+          }
           break;
         default:
           break;
@@ -6917,7 +8348,15 @@ int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
       break;
     }
     case log_op_def::LOG_SUBPLAN_FILTER: {
+      auto &op = static_cast<ObLogSubPlanFilter &>(log_op);
       type = PHY_SUBPLAN_FILTER;
+      if (!op.is_update_set() && use_rich_format &&
+          op.get_plan()->get_optimizer_context().get_session_info()->is_nlj_spf_use_rich_format_enabled() &&
+          !op.is_px_batch_rescan_enabled()) {
+        type = PHY_VEC_SUBPLAN_FILTER;
+      } else {
+        type = PHY_SUBPLAN_FILTER;
+      }
       break;
     }
     case log_op_def::LOG_SUBPLAN_SCAN: {
@@ -6925,11 +8364,24 @@ int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
       break;
     }
     case log_op_def::LOG_MATERIAL: {
-      type = PHY_MATERIAL;
+      if (use_rich_format) {
+        type = PHY_VEC_MATERIAL;
+      } else {
+        type = PHY_MATERIAL;
+      }
       break;
     }
     case log_op_def::LOG_WINDOW_FUNCTION: {
-      type = PHY_WINDOW_FUNCTION;
+      int tmp_ret = OB_SUCCESS;
+      tmp_ret = OB_E(EventTable::EN_DISABLE_VEC_WINDOW_FUNCTION) OB_SUCCESS;
+      if (OB_FAIL(ret)) {
+      } else if (use_rich_format && tmp_ret == OB_SUCCESS
+          && ObWindowFunctionVecOp::all_supported_winfuncs(
+            static_cast<ObLogWindowFunction *>(&log_op)->get_window_exprs())) {
+        type = PHY_VEC_WINDOW_FUNCTION;
+      } else {
+        type = PHY_WINDOW_FUNCTION;
+      }
       break;
     }
     case log_op_def::LOG_SELECT_INTO: {
@@ -6957,15 +8409,27 @@ int ObStaticEngineCG::get_phy_op_type(ObLogicalOperator &log_op,
       break;
     }
     case log_op_def::LOG_TEMP_TABLE_INSERT: {
-      type = PHY_TEMP_TABLE_INSERT;
+      if (use_rich_format) {
+        type = PHY_VEC_TEMP_TABLE_INSERT;
+      } else {
+        type = PHY_TEMP_TABLE_INSERT;
+      }
       break;
     }
     case log_op_def::LOG_TEMP_TABLE_ACCESS: {
-      type = PHY_TEMP_TABLE_ACCESS;
+      if (use_rich_format) {
+        type = PHY_VEC_TEMP_TABLE_ACCESS;
+      } else {
+        type = PHY_TEMP_TABLE_ACCESS;
+      }
       break;
     }
     case log_op_def::LOG_TEMP_TABLE_TRANSFORMATION: {
-      type = PHY_TEMP_TABLE_TRANSFORMATION;
+      if (use_rich_format) {
+        type = PHY_VEC_TEMP_TABLE_TRANSFORMATION;
+      } else {
+        type = PHY_TEMP_TABLE_TRANSFORMATION;
+      }
       break;
     }
     case log_op_def::LOG_STAT_COLLECTOR: {
@@ -7069,7 +8533,8 @@ int ObStaticEngineCG::add_output_datum_check_flag(ObOpSpec &spec)
   // whitelist not to check output datum
   if (!spec.is_vectorized() ||
       IS_PX_TRANSMIT(spec.get_type()) ||
-      PHY_MATERIAL == spec.get_type()) {
+      PHY_MATERIAL == spec.get_type() ||
+      PHY_VEC_MATERIAL == spec.get_type()) {
     // do nothing
   } else {
     spec.need_check_output_datum_ = true;

--- a/src/sql/engine/ob_physical_plan.cpp
+++ b/src/sql/engine/ob_physical_plan.cpp
@@ -102,6 +102,7 @@ ObPhysicalPlan::ObPhysicalPlan(MemoryContext &mem_context /* = CURRENT_CONTEXT *
     has_instead_of_trigger_(false),
     need_record_plan_info_(false),
     logical_plan_(),
+    use_rich_format_(false),
     subschema_ctx_(allocator_),
     das_dop_(0),
     disable_auto_memory_mgr_(false),
@@ -112,6 +113,7 @@ ObPhysicalPlan::ObPhysicalPlan(MemoryContext &mem_context /* = CURRENT_CONTEXT *
     can_set_feedback_info_(true),
     need_switch_to_table_lock_worker_(false),
     data_complement_gen_doc_id_(false),
+    direct_load_need_sort_(false),
     insertup_can_do_gts_opt_(false),
     px_worker_share_plan_enabled_(false)
 {
@@ -184,6 +186,7 @@ void ObPhysicalPlan::reset()
   contain_pl_udf_or_trigger_ = false;
   is_packed_ = false;
   has_instead_of_trigger_ = false;
+  use_rich_format_ = false;
   need_record_plan_info_ = false;
   logical_plan_.reset();
   subschema_ctx_.reset();
@@ -196,6 +199,7 @@ void ObPhysicalPlan::reset()
   can_set_feedback_info_.store(true);
   need_switch_to_table_lock_worker_ = false;
   data_complement_gen_doc_id_ = false;
+  direct_load_need_sort_ = false;
   insertup_can_do_gts_opt_ = false;
   px_worker_share_plan_enabled_ = false;
 }
@@ -669,6 +673,7 @@ OB_SERIALIZE_MEMBER(ObPhysicalPlan,
                     vars_,
                     px_dop_,
                     has_nested_sql_,
+                    stat_.enable_early_lock_release_,
                     use_pdml_,
                     is_new_engine_,
                     use_temp_table_,
@@ -687,6 +692,7 @@ OB_SERIALIZE_MEMBER(ObPhysicalPlan,
                     stat_.plan_id_,
                     need_record_plan_info_,
                     subschema_ctx_,
+                    use_rich_format_,
                     disable_auto_memory_mgr_,
                     udf_has_dml_stmt_,
                     stat_.format_sql_id_,
@@ -889,7 +895,10 @@ int ObPhysicalPlan::alloc_op_spec(const ObPhyOperatorType type,
     op->id_ = tmp_op_id;
     op->plan_ = this;
     op->max_batch_size_ = (ObOperatorFactory::is_vectorized(type)) ? batch_size_ : 0;
-    LOG_TRACE("alloc op spec", K(op->max_batch_size_), K(*op));
+    op->use_rich_format_ = use_rich_format_
+                           && op->is_vectorized()
+                           && ObOperatorFactory::support_rich_format(type);
+    LOG_TRACE("alloc op spec", K(use_rich_format_), K(op->max_batch_size_), K(op->use_rich_format_), K(*op));
   }
   return ret;
 }
@@ -906,9 +915,11 @@ int ObPhysicalPlan::alloc_op_spec_for_cg(ObLogicalOperator *op, ObSqlSchemaGuard
     LOG_WARN("check op vectorization failed", K(ret));
   } else if (disable_vectorize) {
     spec->max_batch_size_ = 0;
+    spec->use_rich_format_ = false;
   }
   if (OB_SUCC(ret)) {
-    LOG_TRACE("alloc op spec for cg", K(disable_vectorize), K(spec->max_batch_size_), K(*spec));
+    LOG_TRACE("alloc op spec for cg", K(disable_vectorize), K(spec->max_batch_size_),
+              K(spec->use_rich_format_), K(*spec));
   }
   return ret;
 }

--- a/src/sql/engine/ob_physical_plan.h
+++ b/src/sql/engine/ob_physical_plan.h
@@ -176,6 +176,7 @@ public:
   uint64_t get_signature() const { return signature_; }
   void set_plan_hash_value(uint64_t v) { stat_.plan_hash_value_ = v; }
   int32_t *alloc_projector(int64_t projector_size);
+  int add_table_location(const ObPhyTableLocation &table_location);
   ObExprOperatorFactory &get_expr_op_factory() { return expr_op_factory_; }
   const ObExprOperatorFactory &get_expr_op_factory() const { return expr_op_factory_; }
 
@@ -287,6 +288,8 @@ public:
   inline int64_t get_ddl_execution_id() const { return ddl_execution_id_; }
   inline void set_ddl_task_id(const int64_t ddl_task_id) { ddl_task_id_ = ddl_task_id; }
   inline int64_t get_ddl_task_id() const { return ddl_task_id_; }
+  inline void set_use_rich_format(const bool v) { use_rich_format_ = v; }
+  inline bool get_use_rich_format() const { return use_rich_format_; }
   void set_record_plan_info(bool v) { need_record_plan_info_ = v; }
   bool need_record_plan_info() const { return need_record_plan_info_; }
   bool try_record_plan_info();
@@ -378,6 +381,11 @@ public:
   const ObSubSchemaCtx &get_subschema_ctx() const { return subschema_ctx_; }
   int set_all_local_session_vars(ObIArray<ObLocalSessionVar> *all_local_session_vars);
   ObIArray<ObLocalSessionVar> & get_all_local_session_vars() { return all_local_session_vars_; }
+  void set_direct_load_need_sort(const bool direct_load_need_sort)
+  {
+    direct_load_need_sort_ = direct_load_need_sort;
+  }
+  bool get_direct_load_need_sort() const { return direct_load_need_sort_; }
   inline bool get_insertup_can_do_gts_opt() const {return insertup_can_do_gts_opt_; }
   inline void set_insertup_can_do_gts_opt(bool v) { insertup_can_do_gts_opt_ = v; }
   void set_is_use_auto_dop(bool use_auto_dop)  { stat_.is_use_auto_dop_ = use_auto_dop; }
@@ -528,6 +536,8 @@ public:
   bool has_instead_of_trigger_; // mask if has instead of trigger on view
   bool need_record_plan_info_;
   ObLogicalPlanRawData logical_plan_;
+  // for detector manager
+  bool use_rich_format_;
   ObSubSchemaCtx subschema_ctx_;
   int64_t das_dop_;
   bool disable_auto_memory_mgr_;
@@ -542,6 +552,7 @@ private:
   bool need_switch_to_table_lock_worker_; // for table lock switch worker thread
   bool data_complement_gen_doc_id_;
 private:
+  bool direct_load_need_sort_;
   bool insertup_can_do_gts_opt_;
   int64_t px_worker_share_plan_enabled_;
 };

--- a/src/sql/optimizer/ob_log_exchange.cpp
+++ b/src/sql/optimizer/ob_log_exchange.cpp
@@ -379,7 +379,7 @@ int ObLogExchange::compute_op_ordering()
   return ret;
 }
 
-int ObLogExchange::compute_op_parallel_info()
+int ObLogExchange::compute_op_parallel_and_server_info()
 {
   int ret = OB_SUCCESS;
   ObLogicalOperator* child = NULL;
@@ -387,16 +387,38 @@ int ObLogExchange::compute_op_parallel_info()
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("get unexpected null", K(ret), K(get_plan()), K(child));
   } else if (is_producer()) {
-    if (OB_FAIL(ObLogicalOperator::compute_op_parallel_info())) {
+    if (OB_FAIL(ObLogicalOperator::compute_op_parallel_and_server_info())) {
       LOG_WARN("failed to compute sharding info for producer exchange", K(ret));
     } else { /*do nothing*/ }
   } else if (is_pq_local()) {
     set_parallel(ObGlobalHint::DEFAULT_PARALLEL);
     set_available_parallel(child->get_available_parallel());
+    set_server_cnt(1);
+    static_cast<ObLogExchange*>(child)->set_in_server_cnt(1);
+    get_server_list().reuse();
+    if (OB_FAIL(get_server_list().push_back(get_plan()->get_optimizer_context().get_local_server_addr()))) {
+      LOG_WARN("failed to push back server list", K(ret));
+    }
   } else {
-    // set_exchange_info may leave the consumer DOP unset; inherit the local
-    // worker parallelism from the child in that case.
-    if (ObGlobalHint::DEFAULT_PARALLEL > get_parallel()) {
+    // set_exchange_info not set these info, use child parallel and server info.
+    if (OB_FAIL(ret)) {
+    } else if ((is_pq_hash_dist() && !is_slave_mapping()) || is_pq_random()) {
+      server_list_.reuse();
+      common::ObAddr all_server_list;
+      all_server_list.set_max(); // a special ALL server list indicating hash data distribution
+      if (OB_FAIL(server_list_.push_back(all_server_list))) {
+        LOG_WARN("failed to assign all server list", K(ret));
+      }
+    } else if (get_server_list().empty() && OB_FAIL(get_server_list().assign(child->get_server_list()))) {
+      LOG_WARN("failed to assign server list", K(ret));
+    }
+    if (OB_FAIL(ret)) {
+    } else if (0 == get_server_cnt()) {
+      set_server_cnt(child->get_server_cnt());
+    } else {
+      static_cast<ObLogExchange*>(child)->set_in_server_cnt(get_server_cnt());
+    }
+    if (OB_SUCC(ret) && ObGlobalHint::DEFAULT_PARALLEL > get_parallel()) {
       if (child->is_single()) {
         set_parallel(child->get_available_parallel());
         set_available_parallel(child->get_available_parallel());
@@ -469,7 +491,8 @@ int ObLogExchange::inner_est_cost(int64_t parallel, double child_card, double &o
     ObExchOutCostInfo est_cost_info(child_card,
                                     child->get_width(),
                                     dist_method_,
-                                    parallel);
+                                    parallel,
+                                    get_in_server_cnt());
     if (OB_FAIL(ObOptEstCost::cost_exchange_out(est_cost_info,
                                                 op_cost,
                                                 opt_ctx))) {
@@ -481,6 +504,7 @@ int ObLogExchange::inner_est_cost(int64_t parallel, double child_card, double &o
                                    child->get_width(),
                                    dist_method_,
                                    parallel,
+                                   get_server_cnt(),
                                    is_local_order_,
                                    sort_keys_);
     if (OB_FAIL(ObOptEstCost::cost_exchange_in(est_cost_info,
@@ -540,6 +564,7 @@ int ObLogExchange::set_exchange_info(const ObExchangeInfo &exch_info)
   null_row_dist_method_ = exch_info.null_row_dist_method_;
   slave_mapping_type_ = exch_info.slave_mapping_type_;
   if (is_producer()) {
+    in_server_cnt_ = exch_info.server_cnt_;
     slice_count_ = exch_info.slice_count_;
     repartition_type_ = exch_info.repartition_type_;
     repartition_ref_table_id_ = exch_info.repartition_ref_table_id_;
@@ -581,6 +606,8 @@ int ObLogExchange::set_exchange_info(const ObExchangeInfo &exch_info)
       LOG_WARN("failed to assign sort keys", K(ret));
     } else if (OB_FAIL(weak_sharding_.assign(exch_info.weak_sharding_))) {
       LOG_WARN("failed to assign weak sharding", K(ret));
+    } else if (OB_FAIL(server_list_.assign(exch_info.server_list_))) {
+      LOG_WARN("failed to assign server list", K(ret));
     } else {
       if (exch_info.is_wf_hybrid_) {
         strong_sharding_ = get_plan()->get_optimizer_context().get_distributed_sharding();
@@ -588,6 +615,7 @@ int ObLogExchange::set_exchange_info(const ObExchangeInfo &exch_info)
         strong_sharding_ = exch_info.strong_sharding_;
       }
       parallel_ = exch_info.parallel_;
+      server_cnt_ = exch_info.server_cnt_;
       is_task_order_ = exch_info.is_task_order_;
       is_merge_sort_ = exch_info.is_merge_sort_;
       is_sort_local_order_ = exch_info.is_sort_local_order_;
@@ -1012,6 +1040,18 @@ int ObLogExchange::is_my_fixed_expr(const ObRawExpr *expr, bool &is_fixed)
     }
   }
   return OB_SUCCESS;
+}
+
+bool ObLogExchange::support_rich_format_vectorize() const {
+  bool res = !(dist_method_ == ObPQDistributeMethod::SM_BROADCAST);
+  int tmp_ret = abs(OB_E(EventTable::EN_OFS_IO_SUBMIT) OB_SUCCESS);
+  if (tmp_ret & (1 << dist_method_)) {
+    res = false;
+  }
+  // ordered: 16
+  // ms: 17
+  LOG_TRACE("[VEC2.0 PX] support_rich_format_vectorize", K(res), K(dist_method_), K(tmp_ret));
+  return res;
 }
 
 int ObLogExchange::open_px_resource_analyze(OPEN_PX_RESOURCE_ANALYZE_DECLARE_ARG)

--- a/src/sql/optimizer/ob_log_plan.cpp
+++ b/src/sql/optimizer/ob_log_plan.cpp
@@ -2685,6 +2685,8 @@ int ObLogPlan::allocate_access_path(AccessPath *ap,
       LOG_WARN("failed to set query ranges", K(ret));
     } else if (OB_FAIL(scan->set_range_columns(ap->get_cost_table_scan_info().range_columns_))) {
       LOG_WARN("failed to set range column", K(ret));
+    } else if (OB_FAIL(append(scan->get_server_list(), ap->get_server_list()))) {
+      LOG_WARN("failed to assign server list", K(ret));
     } else { // set table name and index name
       scan->set_table_name(table_item->get_table_name());
       scan->set_diverse_path_count(ap->parent_->get_diverse_path_count());
@@ -3004,12 +3006,17 @@ int ObLogPlan::compute_join_exchange_info(JoinPath &join_path,
   SlaveMappingType sm_type = get_slave_mapping_type(join_path.join_dist_algo_);
   left_exch_info.dist_method_ = ObPQDistributeMethod::NONE;
   left_exch_info.parallel_ = join_path.parallel_;
+  left_exch_info.server_cnt_ = join_path.server_cnt_;
   right_exch_info.dist_method_ = ObPQDistributeMethod::NONE;
   right_exch_info.parallel_ = join_path.parallel_;
+  right_exch_info.server_cnt_ = join_path.server_cnt_;
   if (OB_ISNULL(join_path.left_path_) || OB_ISNULL(join_path.left_path_->parent_) ||
       OB_ISNULL(join_path.right_path_) || OB_ISNULL(join_path.right_path_->parent_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("get unexpected null", K(join_path.left_path_), K(join_path.right_path_), K(ret));
+  } else if (OB_FAIL(left_exch_info.server_list_.assign(join_path.server_list_))
+             || OB_FAIL(right_exch_info.server_list_.assign(join_path.server_list_))) {
+    LOG_WARN("failed to assign server list", K(ret));
   } else if (OB_FAIL(append(equal_sets, join_path.left_path_->parent_->get_output_equal_sets())) ||
              OB_FAIL(append(equal_sets, join_path.right_path_->parent_->get_output_equal_sets()))) {
     LOG_WARN("failed to append equal sets", K(ret));
@@ -5042,7 +5049,7 @@ int ObLogPlan::get_distribute_group_by_method(ObLogicalOperator *top,
                                                                        is_partition_wise))) {
       LOG_WARN("failed to check if sharding compatible with distinct expr", K(ret));
     } else if (is_partition_wise &&
-               (top->is_parallel_more_than_part_cnt(SLAVE_MAPPING_DOP_TO_PARTITION_RATIO) || force_slave_mapping ||
+               (top->is_parallel_more_than_part_cnt(2) || force_slave_mapping ||
                 DistAlgo::DIST_HASH_HASH_LOCAL == group_dist_methods)) {
       group_dist_methods = DistAlgo::DIST_HASH_HASH_LOCAL;
       OPT_TRACE("group operator will use hash local method and prune other method");
@@ -5438,6 +5445,7 @@ int ObLogPlan::compute_groupby_dop_by_auto_dop(const ObIArray<ObRawExpr*> &group
   int ret = OB_SUCCESS;
   dop = ObGlobalHint::UNSET_PARALLEL;
   bool need_calc_dop = false;
+  int64_t server_cnt = 0;
   int64_t calc_dop = ObGlobalHint::UNSET_PARALLEL;
   int64_t max_child_dop = ObGlobalHint::UNSET_PARALLEL;
   if (!groupby_helper.can_three_stage_pushdown_ || !rollup_exprs.empty()) {
@@ -5452,10 +5460,11 @@ int ObLogPlan::compute_groupby_dop_by_auto_dop(const ObIArray<ObRawExpr*> &group
     LOG_WARN("failed to check candi plan need calc dop", K(ret));
   } else if (!need_calc_dop) {
     /* do nothing */
-  } else if (OB_FAIL(get_parallel_info_from_candidate_plans(max_child_dop))) {
+  } else if (OB_FAIL(get_parallel_info_from_candidate_plans(server_cnt, max_child_dop))) {
     LOG_WARN("failed to get parallel info from candidate plans", K(ret));
   } else if (OB_FAIL(inner_compute_three_stage_groupby_dop_by_auto_dop(group_exprs,
                                                                        groupby_helper,
+                                                                       server_cnt,
                                                                        calc_dop))) {
     LOG_WARN("failed to inner compute group by dop by auto dop", K(ret));
   } else if (max_child_dop < calc_dop) {
@@ -5466,6 +5475,7 @@ int ObLogPlan::compute_groupby_dop_by_auto_dop(const ObIArray<ObRawExpr*> &group
 
 int ObLogPlan::inner_compute_three_stage_groupby_dop_by_auto_dop(const ObIArray<ObRawExpr*> &group_exprs,
                                                                  const GroupingOpHelper &groupby_helper,
+                                                                 const int64_t server_cnt,
                                                                  int64_t &dop) const
 {
   int ret = OB_SUCCESS;
@@ -5486,7 +5496,7 @@ int ObLogPlan::inner_compute_three_stage_groupby_dop_by_auto_dop(const ObIArray<
   } else {
     const ObOptimizerContext &opt_ctx = get_optimizer_context();
     const double cost_threshold_us = 1000.0 * std::max(static_cast<int64_t>(10), opt_ctx.get_parallel_min_scan_time_threshold());
-    const int64_t calc_dop_limit = opt_ctx.get_parallel_degree_limit();
+    const int64_t calc_dop_limit = opt_ctx.get_parallel_degree_limit(server_cnt);
     const double op_cost = ObOptEstCost::cost_hash_group(child->get_card() * number_of_copies,
                                                          0, // do not consider grouop by result
                                                          child->get_width(),
@@ -5532,9 +5542,10 @@ int ObLogPlan::get_three_stage_groupby_number_of_copies(const ObIArray<ObAggFunR
   return ret;
 }
 
-int ObLogPlan::get_parallel_info_from_candidate_plans(int64_t &dop) const
+int ObLogPlan::get_parallel_info_from_candidate_plans(int64_t &server_cnt, int64_t &dop) const
 {
   int ret = OB_SUCCESS;
+  server_cnt = 1;
   dop = get_optimizer_context().get_parallel();
   ObLogicalOperator *op = NULL;
   int64_t child_parallel = ObGlobalHint::UNSET_PARALLEL;
@@ -5549,9 +5560,10 @@ int ObLogPlan::get_parallel_info_from_candidate_plans(int64_t &dop) const
     } else {
       child_parallel = op->is_single() ? op->get_available_parallel() : op->get_parallel();
       dop = std::max(dop, child_parallel);
+      server_cnt = std::max(server_cnt, op->get_server_cnt());
     }
   }
-  LOG_DEBUG("finish get parallel info from candidate plans", K(dop));
+  LOG_DEBUG("finish get parallel info from candidate plans", K(server_cnt), K(dop));
   return ret;
 }
 
@@ -9526,7 +9538,31 @@ int ObLogPlan::prune_and_keep_best_plans(ObIArray<CandidatePlan> &all_candidate_
 int ObLogPlan::remove_match_all_fake_cte_plan(ObIArray<CandidatePlan> &all_candidate_plans,
                                               ObIArray<CandidatePlan> &candidate_plans)
 {
-  return candidate_plans.assign(all_candidate_plans);
+  int ret = OB_SUCCESS;
+  candidate_plans.reuse();
+  for (int64_t i = 0; OB_SUCC(ret) && i < all_candidate_plans.count(); i++) {
+    CandidatePlan &candi_plan = all_candidate_plans.at(i);
+    if (OB_ISNULL(candi_plan.plan_tree_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("get unexpected null", K(ret));
+    } else if (candi_plan.plan_tree_->get_type() == LOG_SET &&
+               static_cast<ObLogSet*>(candi_plan.plan_tree_)->is_recursive_union()) {
+      ObLogicalOperator* right_child = candi_plan.plan_tree_->get_child(ObLogicalOperator::second_child);
+      if (OB_ISNULL(right_child)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("get unexpected null", K(ret));
+      } else if (right_child->get_contains_match_all_fake_cte()) {
+        OPT_TRACE("contain match all fake cte, will not add plan");
+      } else if (OB_FAIL(candidate_plans.push_back(candi_plan))) {
+        LOG_WARN("failed to push back", K(ret));
+      }
+    } else if (candi_plan.plan_tree_->get_contains_match_all_fake_cte()) {
+      OPT_TRACE("contain match all fake cte, will not add plan");
+    } else if (OB_FAIL(candidate_plans.push_back(candi_plan))) {
+      LOG_WARN("failed to push back", K(ret));
+    }
+  }
+  return ret;
 }
 
 int ObLogPlan::add_candidate_plan(ObIArray<CandidatePlan> &current_plans,
@@ -10282,7 +10318,10 @@ int ObLogPlan::check_location_need_multi_partition_dml(ObLogicalOperator &top,
   } else if (OB_ISNULL(source_sharding) || OB_ISNULL(source_table_part)) {
     is_multi_part_dml = true;
     is_result_local = true;
-  } else if (FALSE_IT(source_loc_type = source_table_part->get_location_type())) {
+  } else if (OB_FAIL(source_table_part->get_location_type(
+                                          get_optimizer_context().get_local_server_addr(),
+                                          source_loc_type))) {
+    LOG_WARN("failed get location type", K(ret));
   } else if (source_sharding->is_match_all() || OB_TBL_LOCATION_ALL == source_loc_type) {
     is_multi_part_dml = true;
     is_result_local = true;
@@ -12673,8 +12712,11 @@ int ObLogPlan::compute_subplan_filter_repartition_distribution_info(ObLogicalOpe
                                                      *right_child,
                                                      exch_info))) {
       LOG_WARN("failed to compute repartition distribution info", K(ret));
+    } else if (OB_FAIL(exch_info.server_list_.assign(max_parallel_child->get_server_list()))) {
+      LOG_WARN("failed to assign server list", K(ret));
     } else {
       exch_info.parallel_ = max_parallel_child->get_parallel();
+      exch_info.server_cnt_ = max_parallel_child->get_server_cnt();
       exch_info.unmatch_row_dist_method_ = ObPQDistributeMethod::DROP;
       LOG_TRACE("succeed to compute repartition distribution info", K(exch_info));
     }
@@ -14552,6 +14594,19 @@ int ObLogPlan::remove_duplicate_constraints()
         LOG_WARN("failed to remove a element from array", K(ret));
       }
     }
+  }
+  return ret;
+}
+
+int ObLogPlan::get_enable_rich_vector_format(bool &enable)
+{
+  int ret = OB_SUCCESS;
+  ObSQLSessionInfo *session_info = nullptr;
+  if (OB_ISNULL(session_info = get_optimizer_context().get_session_info())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("session is null", K(ret));
+  } else {
+    enable = session_info->use_rich_format();
   }
   return ret;
 }

--- a/src/sql/optimizer/ob_logical_operator.cpp
+++ b/src/sql/optimizer/ob_logical_operator.cpp
@@ -167,6 +167,8 @@ int ObExchangeInfo::assign(const ObExchangeInfo &other)
     LOG_WARN("failed to assign hybrid phy exprs cnt array", K(ret));
   } else if (OB_FAIL(repart_all_tablet_ids_.assign(other.repart_all_tablet_ids_))) {
     LOG_WARN("failed to assign partition ids", K(ret));
+  } else if (OB_FAIL(server_list_.assign(other.server_list_))) {
+    LOG_WARN("failed to assign server list", K(ret));
   } else {
     is_task_order_ = other.is_task_order_;
     is_merge_sort_ = other.is_merge_sort_;
@@ -188,6 +190,7 @@ int ObExchangeInfo::assign(const ObExchangeInfo &other)
     may_add_interval_part_ = other.may_add_interval_part_;
     sample_type_ = other.sample_type_;
     parallel_ = other.parallel_;
+    server_cnt_ = other.server_cnt_;
   }
   return ret;
 }
@@ -399,6 +402,7 @@ ObLogicalOperator::ObLogicalOperator(ObLogPlan &plan)
     contain_fake_cte_(false),
     contain_pw_merge_op_(false),
     contain_das_op_(false),
+    contain_match_all_fake_cte_(false),
     strong_sharding_(NULL),
     weak_sharding_(),
     is_pipelined_plan_(false),
@@ -414,6 +418,7 @@ ObLogicalOperator::ObLogicalOperator(ObLogPlan &plan)
     parallel_(ObGlobalHint::UNSET_PARALLEL),
     op_parallel_rule_(OpParallelRule::OP_DOP_RULE_MAX),
     available_parallel_(ObGlobalHint::DEFAULT_PARALLEL),
+    server_cnt_(1),
     need_late_materialization_(false),
     op_exprs_(),
     inherit_sharding_index_(-1),
@@ -476,6 +481,11 @@ double FilterCompare::get_selectivity(ObRawExpr *expr)
 {
   bool found = false;
   double selectivity = 1;
+  if (OB_NOT_NULL(expr) && T_FUN_LABEL_SE_LABEL_VALUE_CMP_LE == expr->get_expr_type()) {
+    // security filter should be calc firstly
+    found = true;
+    selectivity = -1.0;
+  }
   for (int64_t i = 0; !found && i < predicate_selectivities_.count(); i++) {
     if (predicate_selectivities_.at(i).expr_ == expr) {
       found = true;
@@ -688,7 +698,7 @@ int ObLogicalOperator::compute_op_interesting_order_info()
   return ret;
 }
 
-int ObLogicalOperator::compute_op_parallel_info()
+int ObLogicalOperator::compute_op_parallel_and_server_info()
 {
   int ret = OB_SUCCESS;
   ObLogicalOperator* child = NULL;
@@ -700,19 +710,23 @@ int ObLogicalOperator::compute_op_parallel_info()
   } else if (OB_ISNULL(child = get_child(first_child))) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpect null child", K(ret), K(child));
+  } else if (OB_FAIL(get_server_list().assign(child->get_server_list()))) {
+    LOG_WARN("failed to assign server list", K(ret));
   } else {
     set_parallel(child->get_parallel());
     set_available_parallel(child->get_available_parallel());
+    set_server_cnt(child->get_server_cnt());
   }
   return ret;
 }
 
 
-int ObLogicalOperator::compute_normal_multi_child_parallel_info()
+int ObLogicalOperator::compute_normal_multi_child_parallel_and_server_info()
 {
   int ret = OB_SUCCESS;
   const ObLogicalOperator *max_parallel_child = NULL;
   bool max_parallel_from_exch = false;
+  ObPQDistributeMethod::Type child_distribute_method_type = ObPQDistributeMethod::NONE;
   int64_t max_available_parallel = ObGlobalHint::DEFAULT_PARALLEL;
   const ObLogicalOperator *child = NULL;
   for (int64_t i = 0; OB_SUCC(ret) && i < get_num_of_child(); ++i) {
@@ -739,19 +753,31 @@ int ObLogicalOperator::compute_normal_multi_child_parallel_info()
   } else if (OB_ISNULL(max_parallel_child)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected null ", K(ret), K(max_parallel_child));
+  } else if (OB_FAIL(get_server_list().assign(max_parallel_child->get_server_list()))) {
+    LOG_WARN("failed to assign server list", K(ret));
   } else {
     set_parallel(max_parallel_child->get_parallel());
     set_available_parallel(max_available_parallel);
+    set_server_cnt(max_parallel_child->get_server_cnt());
   }
   return ret;
 }
 
-int ObLogicalOperator::set_parallel_info_for_match_all()
+int ObLogicalOperator::set_parallel_and_server_info_for_match_all()
 {
   int ret = OB_SUCCESS;
-  set_parallel(ObGlobalHint::DEFAULT_PARALLEL);
-  set_available_parallel(ObGlobalHint::DEFAULT_PARALLEL);
-  set_op_parallel_rule(OpParallelRule::OP_DAS_DOP);
+  get_server_list().reuse();
+  if (OB_ISNULL(get_plan())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("get unexpected null", K(ret), K(get_plan()));
+  } else if (OB_FAIL(get_server_list().push_back(get_plan()->get_optimizer_context().get_local_server_addr()))) {
+    LOG_WARN("failed to push back server list", K(ret));
+  } else {
+    set_parallel(ObGlobalHint::DEFAULT_PARALLEL);
+    set_available_parallel(ObGlobalHint::DEFAULT_PARALLEL);
+    set_op_parallel_rule(OpParallelRule::OP_DAS_DOP);
+    set_server_cnt(1);
+  }
   return ret;
 }
 
@@ -900,6 +926,23 @@ int ObLogicalOperator::compute_op_other_info()
       }
     }
 
+    // compute contains fake cte match all sharding
+    if (OB_SUCC(ret)) {
+      if (get_type() == log_op_def::ObLogOpType::LOG_SET &&
+          static_cast<ObLogSet*>(this)->is_recursive_union()) {
+        /*do nothing*/
+      } else {
+        for (int64_t i = 0; OB_SUCC(ret) && !contain_match_all_fake_cte_ && i < get_num_of_child(); i++) {
+          if (OB_ISNULL(get_child(i))) {
+            ret = OB_ERR_UNEXPECTED;
+            LOG_WARN("get unexpected null", K(ret));
+          } else {
+            contain_match_all_fake_cte_ |= get_child(i)->get_contains_match_all_fake_cte();
+          }
+        }
+      }
+    }
+
     // compute contains merge style op
     if (OB_SUCC(ret)) {
       for (int64_t i = 0; OB_SUCC(ret) && !contain_pw_merge_op_ && i < get_num_of_child(); i++) {
@@ -999,6 +1042,7 @@ int ObLogicalOperator::compute_property(Path *path)
     set_location_type(path->location_type_);
     set_contains_fake_cte(path->contain_fake_cte_);
     set_contains_pw_merge_op(path->contain_pw_merge_op_);
+    set_contains_match_all_fake_cte(path->contain_match_all_fake_cte_);
     set_contains_das_op(path->contain_das_op_);
     is_pipelined_plan_ = path->is_pipelined_path();
     is_nl_style_pipelined_plan_ = path->is_nl_style_pipelined_path();
@@ -1013,9 +1057,12 @@ int ObLogicalOperator::compute_property(Path *path)
     set_is_range_order(path->is_range_order_);
     set_parallel(path->parallel_);
     set_op_parallel_rule(path->op_parallel_rule_);
-    set_available_parallel(path->available_parallel_);
+    set_available_parallel(path->available_parallel_),
+    set_server_cnt(path->server_cnt_);
     set_inherit_sharding_index(path->inherit_sharding_index_);
-    if (OB_FAIL(ambient_card_.assign(path->parent_->get_ambient_card()))) {
+    if (OB_FAIL(server_list_.assign(path->server_list_))) {
+      LOG_WARN("failed to assign path's server list to op", K(ret));
+    } else if (OB_FAIL(ambient_card_.assign(path->parent_->get_ambient_card()))) {
       LOG_WARN("failed to assign ambient cards", K(ret));
     } else if (OB_FAIL(check_property_valid())) {
       LOG_WARN("failed to check property valid", K(ret), KPC(path));
@@ -1234,8 +1281,8 @@ int ObLogicalOperator::compute_property()
     LOG_WARN("failed to compute op ordering", K(ret));
   } else if (OB_FAIL(compute_op_interesting_order_info())) {
     LOG_WARN("failed to compute op ordering match info", K(ret));
-  } else if (OB_FAIL(compute_op_parallel_info())) {
-    LOG_WARN("failed to compute op parallel info", K(ret));
+  } else if (OB_FAIL(compute_op_parallel_and_server_info())) {
+    LOG_WARN("failed to compute op server info", K(ret));
   } else if (OB_FAIL(est_width())) {
     LOG_WARN("failed to compute width", K(ret));
   } else if (OB_FAIL(est_cost())) {
@@ -1307,9 +1354,11 @@ int ObLogicalOperator::inner_est_ambient_card_by_child(int64_t child_idx)
 int ObLogicalOperator::check_property_valid() const
 {
   int ret = OB_SUCCESS;
-  if (OB_UNLIKELY(ObGlobalHint::DEFAULT_PARALLEL > get_parallel())) {
+  if (OB_UNLIKELY(ObGlobalHint::DEFAULT_PARALLEL > get_parallel()
+                  || get_server_cnt() < 1)) {
     ret = OB_ERR_UNEXPECTED;
-    LOG_WARN("has invalid parallel info", K(ret), K(get_parallel()));
+    LOG_WARN("has invalid parallel or server info", K(ret), K(get_parallel()),
+                                                    K(get_server_list()), K(get_server_cnt()));
   }
   return ret;
 }
@@ -3661,7 +3710,7 @@ int ObLogicalOperator::explain_print_partitions(ObTablePartitionInfo &table_part
     ObLogicalOperator::PartInfo part_info;
     const ObOptTabletLoc &part_loc = partitions.at(i).get_partition_location();
     if (is_virtual_table(ref_table_id)) {
-      if (EMPTY_VIRTUAL_TABLE_TABLET_ID == part_loc.get_partition_id()) {
+      if (VirtualSvrPair::EMPTY_VIRTUAL_TABLE_TABLET_ID == part_loc.get_partition_id()) {
 
       } else {
         part_info.part_id_ = part_loc.get_partition_id();
@@ -6333,6 +6382,33 @@ int ObLogicalOperator::check_op_orderding_used_by_parent(bool &used)
     } else {
       child = parent;
       parent = parent->get_parent();
+    }
+  }
+  return ret;
+}
+
+int ObLogicalOperator::check_contain_dist_das(const ObIArray<ObAddr> &exec_server_list,
+                                              bool &contain_dist_das) const
+{
+  int ret = OB_SUCCESS;
+  contain_dist_das = false;
+  if (!get_contains_das_op()) {
+    contain_dist_das = false;
+  } else if (LOG_TABLE_SCAN == get_type() && static_cast<const ObLogTableScan*>(this)->use_das()) {
+    if (1 != exec_server_list.count()
+        || 1 != get_server_list().count()
+        || exec_server_list.at(0) != get_server_list().at(0)) {
+      contain_dist_das = true;
+    }
+  } else {
+    ObLogicalOperator *child = NULL;
+    for (int64_t i = 0; !contain_dist_das && OB_SUCC(ret) && i < get_num_of_child(); ++i) {
+      if (OB_ISNULL(child = get_child(i))) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("child is null", K(ret), K(i));
+      } else if (OB_FAIL(SMART_CALL(child->check_contain_dist_das(exec_server_list, contain_dist_das)))) {
+        LOG_WARN("failed to smart call check contain dist das", K(ret));
+      }
     }
   }
   return ret;

--- a/src/sql/optimizer/ob_logical_operator.h
+++ b/src/sql/optimizer/ob_logical_operator.h
@@ -41,8 +41,6 @@ namespace oceanbase
 {
 namespace sql
 {
-static constexpr int64_t SLAVE_MAPPING_DOP_TO_PARTITION_RATIO = 2;
-
 struct JoinFilterInfo;
 struct EstimateCostInfo;
 struct ObSqlPlanItem;
@@ -473,7 +471,9 @@ struct ObExchangeInfo
     wf_hybrid_pby_exprs_cnt_array_(),
     may_add_interval_part_(MayAddIntervalPart::NO),
     sample_type_(NOT_INIT_SAMPLE_TYPE),
-    parallel_(ObGlobalHint::UNSET_PARALLEL)
+    parallel_(ObGlobalHint::UNSET_PARALLEL),
+    server_cnt_(0),
+    server_list_()
   {
     repartition_table_id_ = 0;
   }
@@ -532,6 +532,8 @@ struct ObExchangeInfo
   // sample type for range distribution or partition range distribution
   ObPxSampleType sample_type_;
   int64_t parallel_;
+  int64_t server_cnt_;
+  common::ObSEArray<common::ObAddr, 4> server_list_;
 
   TO_STRING_KV(K_(is_task_order),
                K_(is_merge_sort),
@@ -554,7 +556,9 @@ struct ObExchangeInfo
                K_(wf_hybrid_pby_exprs_cnt_array),
                K_(may_add_interval_part),
                K_(sample_type),
-               K_(parallel));
+               K_(parallel),
+               K_(server_cnt),
+               K_(server_list));
 private:
   DISALLOW_COPY_AND_ASSIGN(ObExchangeInfo);
 };
@@ -1093,6 +1097,15 @@ public:
     return op_ordering_;
   }
 
+  inline common::ObIArray<common::ObAddr> &get_server_list()
+  {
+    return server_list_;
+  }
+  inline const common::ObIArray<common::ObAddr> &get_server_list() const
+  {
+    return server_list_;
+  }
+
   inline const ObFdItemSet& get_fd_item_set() const
   {
     return NULL == fd_item_set_ ? empty_fd_item_set_ : *fd_item_set_;
@@ -1271,7 +1284,7 @@ public:
 
   virtual int compute_op_interesting_order_info();
 
-  virtual int compute_op_parallel_info();
+  virtual int compute_op_parallel_and_server_info();
 
   virtual int compute_table_set();
 
@@ -1312,8 +1325,8 @@ public:
   virtual int compute_property();
 
   int check_property_valid() const;
-  int compute_normal_multi_child_parallel_info();
-  int set_parallel_info_for_match_all();
+  int compute_normal_multi_child_parallel_and_server_info();
+  int set_parallel_and_server_info_for_match_all();
   int get_limit_offset_value(ObRawExpr *percent_expr,
                              ObRawExpr *limit_expr,
                              ObRawExpr *offset_expr,
@@ -1491,6 +1504,11 @@ public:
   {
     contain_pw_merge_op_ = contain_pw_merge_op;
   }
+  inline bool get_contains_match_all_fake_cte() const { return contain_match_all_fake_cte_; }
+  inline void set_contains_match_all_fake_cte(bool contain_match_all_fake_cte)
+  {
+    contain_match_all_fake_cte_ = contain_match_all_fake_cte;
+  }
   inline bool get_contains_das_op() const { return contain_das_op_; }
   inline void set_contains_das_op(bool contain_das_op)
   {
@@ -1593,6 +1611,9 @@ public:
   inline OpParallelRule get_op_parallel_rule() const { return op_parallel_rule_; }
   inline int64_t get_available_parallel() const { return available_parallel_; }
   inline void set_available_parallel(int64_t available_parallel) { available_parallel_ = available_parallel; }
+  inline void set_server_cnt(int64_t count) { server_cnt_ = count; }
+  inline int64_t get_server_cnt() const { return server_cnt_; }
+
   void set_late_materialization(bool need_mater) { need_late_materialization_ = need_mater; }
   bool need_late_materialization() const { return need_late_materialization_; }
   /**
@@ -1664,8 +1685,8 @@ public:
   // 2. If this operator is single-child and block, then open and close its child.
   // 3. If this operator has multiple children, open all children by default and
   //    operators should override this function according to their unique execution logic.
-  // update_max = false means a parent is comparing alternative child branches
-  // for the largest running thread/group count without updating the plan-wide peaks.
+  // update_max = false means it is searching for the child with the largest
+  // running thread/group count and should not update the plan-wide peak.
   virtual int open_px_resource_analyze(OPEN_PX_RESOURCE_ANALYZE_DECLARE_ARG);
   // Make the operator in state that all data has been outputted already.
   virtual int close_px_resource_analyze(CLOSE_PX_RESOURCE_ANALYZE_DECLARE_ARG);
@@ -1676,6 +1697,9 @@ public:
   int pre_check_can_px_batch_rescan(bool &find_nested_rescan,
                                     bool &find_rescan_px,
                                     bool nested) const;
+  int check_contain_dist_das(const ObIArray<ObAddr> &exec_server_list,
+                             bool &contain_dist_das) const;
+
   inline bool can_re_parallel() { return !is_distributed() && !is_match_all() && 1 < get_available_parallel() && !get_is_at_most_one_row(); }
   int check_op_orderding_used_by_parent(bool &used);
 
@@ -1900,6 +1924,7 @@ protected:
   bool contain_fake_cte_;
   bool contain_pw_merge_op_;
   bool contain_das_op_;
+  bool contain_match_all_fake_cte_;
   ObShardingInfo *strong_sharding_;
   common::ObSEArray<ObShardingInfo*, 8, common::ModulePageAllocator, true> weak_sharding_;
   bool is_pipelined_plan_;
@@ -1915,6 +1940,8 @@ protected:
   int64_t parallel_;
   OpParallelRule op_parallel_rule_;
   int64_t available_parallel_;  // parallel degree used by serial op to enable parallel again
+  int64_t server_cnt_;
+  ObSEArray<common::ObAddr, 8, common::ModulePageAllocator, true> server_list_;
   bool need_late_materialization_;
   // all non_const exprs for this op, generated by allocate_expr_pre and used by project pruning
   ObSEArray<ObRawExpr*, 8, common::ModulePageAllocator, true> op_exprs_;

--- a/src/sql/optimizer/ob_optimizer_context.h
+++ b/src/sql/optimizer/ob_optimizer_context.h
@@ -110,14 +110,14 @@ struct AutoDOPParams {
       parallel_min_scan_time_threshold_(1000)
     { }
 
-  int64_t get_parallel_degree_limit() const {
+  int64_t get_parallel_degree_limit(const int64_t server_cnt) const {
     int64_t limit = 0;
     if (0 < parallel_degree_limit_) {
       limit = parallel_degree_limit_;
-    } else if (0 >= parallel_servers_target_ || 0 >= min_cpu_) {
-      limit = std::max(parallel_servers_target_, min_cpu_);
+    } else if (0 >= parallel_servers_target_ || 0 >= min_cpu_ || 0 >= server_cnt) {
+      limit = std::max(parallel_servers_target_, server_cnt * min_cpu_);
     } else {
-      limit = std::min(parallel_servers_target_, min_cpu_);
+      limit = std::min(parallel_servers_target_, server_cnt * min_cpu_);
     }
     return std::max(limit, static_cast<int64_t>(1));
   }
@@ -290,6 +290,7 @@ ObOptimizerContext(ObSQLSessionInfo *session_info,
     partition_wise_plan_enabled_(true),
     enable_px_ordered_coord_(false),
     enable_opt_row_goal_(ObEnableOptRowGoal::MAX),
+    enable_distributed_das_scan_(true),
     enable_topn_runtime_filter_(true)
   { }
   inline common::ObOptStatManager *get_opt_stat_manager() { return opt_stat_manager_; }
@@ -375,7 +376,7 @@ ObOptimizerContext(ObSQLSessionInfo *session_info,
   void set_das_keep_order_enabled(bool das_keep_order_enabled) { das_keep_order_enabled_ = das_keep_order_enabled; }
   inline int64_t get_parallel() const { return parallel_; }
   inline int64_t get_max_parallel() const { return max_parallel_; }
-  inline int64_t get_parallel_degree_limit() const { return auto_dop_params_.get_parallel_degree_limit(); }
+  inline int64_t get_parallel_degree_limit(const int64_t server_cnt) const { return auto_dop_params_.get_parallel_degree_limit(server_cnt); }
   inline int64_t get_session_parallel_degree_limit() const { return auto_dop_params_.parallel_degree_limit_; }
   inline int64_t get_parallel_min_scan_time_threshold() const { return auto_dop_params_.parallel_min_scan_time_threshold_; }
   inline bool force_disable_parallel() const  { return px_parallel_rule_ >= PL_UDF_DAS_FORCE_SERIALIZE
@@ -458,6 +459,7 @@ ObOptimizerContext(ObSQLSessionInfo *session_info,
   static const int BATCH_RESCAN_BIT_NON_BASIC_SCAN = 9;
   static const int BATCH_RESCAN_BIT_STARTUP_FILTER = 10;
  
+  // Whether a batch rescan scenario is enabled is controlled by its configuration bit.
   void init_batch_rescan_flags(const bool enable_batch_nlj,
                                const bool enable_batch_spf,
                                const int64_t batch_rescan_flag)
@@ -727,6 +729,8 @@ ObOptimizerContext(ObSQLSessionInfo *session_info,
   inline void set_push_join_pred_into_view_enabled(bool enabled) { push_join_pred_into_view_enabled_ = enabled; }
   inline void set_enable_opt_row_goal(int64_t type) { enable_opt_row_goal_ = static_cast<ObEnableOptRowGoal>(type); }
   inline ObEnableOptRowGoal get_enable_opt_row_goal() const { return enable_opt_row_goal_; }
+  inline bool is_enable_distributed_das_scan() const { return enable_distributed_das_scan_; }
+  inline void set_enable_distributed_das_scan(bool enabled) { enable_distributed_das_scan_ = enabled; }
   inline bool enable_topn_runtime_filter() const { return enable_topn_runtime_filter_; }
   inline void set_enable_topn_runtime_filter(bool enabled) { enable_topn_runtime_filter_ = enabled; }
 private:
@@ -838,6 +842,7 @@ private:
   bool partition_wise_plan_enabled_;
   bool enable_px_ordered_coord_;
   ObEnableOptRowGoal enable_opt_row_goal_;
+  bool enable_distributed_das_scan_;
   bool enable_topn_runtime_filter_;
 };
 }

--- a/src/sql/plan_cache/ob_plan_cache_util.h
+++ b/src/sql/plan_cache/ob_plan_cache_util.h
@@ -934,7 +934,7 @@ public:
   static int get_phy_locations(const ObIArray<ObTableLocation> &table_locations,
                                const ObPlanCacheCtx &pc_ctx,
                                ObIArray<ObCandiTableLoc> &phy_location_infos);
-
+  
   // used for adding plan
   static int get_phy_locations(const common::ObIArray<ObTablePartitionInfo *> &partition_infos,
                                //ObIArray<ObDASTableLoc> &phy_locations,
@@ -988,6 +988,7 @@ public:
     enable_das_batch_rescan_flag_(0),
     enable_var_assign_use_das_(false),
     enable_das_keep_order_(false),
+    enable_nlj_spf_use_rich_format_(false),
     enable_index_merge_(false),
     bloom_filter_ratio_(0),
     realistic_runtime_bloom_filter_size_(false),
@@ -1040,6 +1041,7 @@ public:
   int64_t enable_das_batch_rescan_flag_;
   bool enable_var_assign_use_das_;
   bool enable_das_keep_order_;
+  bool enable_nlj_spf_use_rich_format_;
   bool enable_index_merge_;
   int bloom_filter_ratio_;
   bool realistic_runtime_bloom_filter_size_;
@@ -1055,7 +1057,7 @@ private:
   int64_t cluster_config_version_;
   // Current runtime configuration version.
   int64_t runtime_config_version_;
-
+  
 };
 
 }


### PR DESCRIPTION
## Task Description
ObPxResourceAnalyzer maintained per-server WorkerMap instances for expected and minimal PX worker usage and copied both maps into every physical plan. Runtime PX admission and DFO scaling consume only the scalar expected_worker_count and minimal_worker_count values; no runtime path reads the stored address maps.
The maps therefore add persistent plan-cache memory and compilation-time hash container work without providing functional behavior.

## Solution Description
- Remove WorkerMap fields and APIs from ObPlanStat, ObOptimizerContext, and ObPhysicalPlan, together with the code-generation copy path.
- Remove per-address DFO location discovery, address sets, worker maps, nested map propagation, and the associated hash-map helpers.
- Keep the DFO scheduling simulation and scalar peak thread/group calculation used by PX admission and DFO worker scaling.
- Rename the traversal flag from append_map to update_max to describe its remaining scalar behavior.

## Passed Regressions
- git diff --check
- Full debug ob-make build
- px_expected_worker_cnt: all 19 PX SQL scenarios executed successfully
- A/B comparison against unmodified HEAD: all 23 PxResAnaly scalar TRACE results matched exactly
The original mysqltest audit queries reference GV$OB_SQL_AUDIT, which has already been removed from seekdb. The focused run retained all PX SQL scenarios and removed only those stale audit-view checks.

## Upgrade Compatibility
No SQL, storage, protocol, or configuration compatibility impact. Cached plans are process-local and will be regenerated normally.

## Other Information
This MR contains one focused commit. It changes 11 source files with 67 insertions and 495 deletions, and contains no unrelated changes.
Related links:
- DIMA-2026072700117775421

## Release Note
