### PR TITLE
[macOS] Fix log timestamp formatting performance

### DIFF
--- a/deps/oblib/src/lib/oblog/ob_log_time_fmt.cpp
+++ b/deps/oblib/src/lib/oblog/ob_log_time_fmt.cpp
@@ -17,6 +17,7 @@
 #include "ob_log_time_fmt.h"
 #include <time.h>
 #include <stdio.h>
+#include "lib/utility/utility.h"
 #include "lib/utility/ob_macro_utils.h"
 
 namespace oceanbase
@@ -40,28 +41,23 @@ using TimestampStrBuffer_ = char[TIME_BUFFER_SIZE];
 using TimestampStrBuffer = TimestampStrBuffer_[MAX_TIMESTAMP_BUFFER];
 TLOCAL(TimestampStrBuffer, timestamp_str_buffer);
 TLOCAL(int, buffer_idx) = 0;
+TLOCAL(time_t, last_timestamp_unix_sec);
+TLOCAL(struct tm, last_timestamp_localtime);
 
 const char *ObTime2Str::ob_timestamp_str(const int64_t ts)
 {
   struct tm t;
   time_t ts_s = ts / 1000000;// convert to second precision
   TimestampStrBuffer_ &buffer = timestamp_str_buffer[buffer_idx++ & IDX_MASK];
+  ob_fast_localtime(last_timestamp_unix_sec, last_timestamp_localtime, ts_s, &t);
 #ifdef _WIN32
-  if (ts_s < 0) ts_s = 0;
-  errno_t err = localtime_s(&t, &ts_s);
-  if (err != 0) {
-    memset(&t, 0, sizeof(t));
-    t.tm_year = 70;
-    t.tm_mday = 1;
-  }
-  size_t idx = strftime(&buffer[0], sizeof(buffer), "%F %T", &t);
-  idx += snprintf(&buffer[idx], TIME_BUFFER_SIZE - idx, ".%lld", ts % 1000000);
+  int idx = snprintf(&buffer[0], sizeof(buffer), "%04d-%02d-%02d %02d:%02d:%02d",
+                     t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec);
+  idx += snprintf(&buffer[idx], TIME_BUFFER_SIZE - idx, ".%lld", static_cast<long long>(ts % 1000000));
 #else
-  size_t idx = strftime(&buffer[0],
-                        sizeof(buffer),
-                        "%F %T",
-                        localtime_r(&ts_s, &t));
-  idx += snprintf(&buffer[idx], TIME_BUFFER_SIZE - idx, ".%ld", ts % 1000000);
+  int idx = snprintf(&buffer[0], sizeof(buffer), "%04d-%02d-%02d %02d:%02d:%02d",
+                     t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec);
+  idx += snprintf(&buffer[idx], TIME_BUFFER_SIZE - idx, ".%ld", static_cast<long>(ts % 1000000));
 #endif
   buffer[idx] = '\0';
   return buffer;

--- a/deps/oblib/src/lib/utility/utility.cpp
+++ b/deps/oblib/src/lib/utility/utility.cpp
@@ -1821,8 +1821,8 @@ struct tm *ob_localtime(const time_t *unix_sec, struct tm *result)
   const int32_t tz_minutes = static_cast<int32_t>(__timezone / 60);
 #endif
 
-//only support time > 1970/1/1 8:0:0
-  if (OB_LIKELY(NULL != result) && OB_LIKELY(NULL != unix_sec) && OB_LIKELY(*unix_sec > 0)) {
+//only support time >= 1970/1/1 8:0:0
+  if (OB_LIKELY(NULL != result) && OB_LIKELY(NULL != unix_sec) && OB_LIKELY(*unix_sec >= 0)) {
     result->tm_sec  = static_cast<int>((*unix_sec) % MINUTES_IN_HOUR);
     int tmp_i       = static_cast<int>((*unix_sec) / MINUTES_IN_HOUR) - tz_minutes;
     result->tm_min  = tmp_i % MINUTES_IN_HOUR;
@@ -1847,9 +1847,10 @@ void ob_fast_localtime(time_t &cached_unix_sec, struct tm &cached_localtime,
     const time_t &input_unix_sec, struct tm *output_localtime)
 {
   if (OB_LIKELY(NULL != output_localtime)) {
-    if (cached_unix_sec == input_unix_sec) {
+    const bool is_inited = (0 != cached_unix_sec || 0 != cached_localtime.tm_mday);
+    if (OB_LIKELY(is_inited && cached_unix_sec == input_unix_sec)) {
       *output_localtime = cached_localtime;
-    } else if (OB_UNLIKELY(0 == cached_unix_sec)) {//init
+    } else if (OB_UNLIKELY(!is_inited)) {//init
       cached_unix_sec = input_unix_sec;
 #ifdef _WIN32
       localtime_s(output_localtime, &input_unix_sec);

--- a/deps/oblib/unittest/lib/utility/test_utility.cpp
+++ b/deps/oblib/unittest/lib/utility/test_utility.cpp
@@ -506,22 +506,36 @@ TEST(utility, ob_localtime)
     EXPECT_EQ(std_tm.tm_year, last_tm.tm_year);
   }
 
-  ob_tm.tm_sec = 0;
-  ob_tm.tm_min = 0;
-  ob_tm.tm_hour = 0;
-  ob_tm.tm_mday = 0;
-  ob_tm.tm_mon = 0;
-  ob_tm.tm_year = 0;
-
+  // ob_localtime only supports unix_sec >= 0 (cf. "only support time >= 1970/1/1 8:0:0").
+  // special_value[14] == 0 is the epoch second and is now converted; validate it against
+  // the libc reference like the loop above. The remaining pre-epoch values are still
+  // unsupported: the struct is left untouched, so reset it first and expect zeros.
   for (int64_t i = 14; i < 18; ++i) {
+    ob_tm.tm_sec = 0;
+    ob_tm.tm_min = 0;
+    ob_tm.tm_hour = 0;
+    ob_tm.tm_mday = 0;
+    ob_tm.tm_mon = 0;
+    ob_tm.tm_year = 0;
+
     ob_localtime((const time_t *)(special_value + i), &ob_tm);
 
-    EXPECT_EQ(0, ob_tm.tm_sec);
-    EXPECT_EQ(0, ob_tm.tm_min);
-    EXPECT_EQ(0, ob_tm.tm_hour);
-    EXPECT_EQ(0, ob_tm.tm_mday);
-    EXPECT_EQ(0, ob_tm.tm_mon);
-    EXPECT_EQ(0, ob_tm.tm_year);
+    if (special_value[i] >= 0) {
+      ::localtime_r((const time_t *)(special_value + i), &std_tm);
+      EXPECT_EQ(std_tm.tm_sec, ob_tm.tm_sec);
+      EXPECT_EQ(std_tm.tm_min, ob_tm.tm_min);
+      EXPECT_EQ(std_tm.tm_hour, ob_tm.tm_hour);
+      EXPECT_EQ(std_tm.tm_mday, ob_tm.tm_mday);
+      EXPECT_EQ(std_tm.tm_mon, ob_tm.tm_mon);
+      EXPECT_EQ(std_tm.tm_year, ob_tm.tm_year);
+    } else {
+      EXPECT_EQ(0, ob_tm.tm_sec);
+      EXPECT_EQ(0, ob_tm.tm_min);
+      EXPECT_EQ(0, ob_tm.tm_hour);
+      EXPECT_EQ(0, ob_tm.tm_mday);
+      EXPECT_EQ(0, ob_tm.tm_mon);
+      EXPECT_EQ(0, ob_tm.tm_year);
+    }
   }
 }
 

--- a/src/sql/dtl/ob_dtl_basic_channel.cpp
+++ b/src/sql/dtl/ob_dtl_basic_channel.cpp
@@ -882,9 +882,6 @@ void ObDtlBasicChannel::free_buf(ObDtlLinkedBuffer *buf)
   } else {
     free_buffer_count();
   }
-  if (nullptr != buf) {
-    free_buffer_count();
-  }
 }
 
 int ObDtlBasicChannel::push_back_send_list()


### PR DESCRIPTION
## Task Description
1. Fix log timestamp formatting performance.
2. Fix DDL stats sync retry on gather stats lock conflict.

## Solution Description

## Passed Regressions

## Upgrade Compatibility

## Other Information

## Release Note