### PR TITLE
Remove unused macOS RE2 dependency

### DIFF
--- a/deps/oblib/src/CMakeLists.txt
+++ b/deps/oblib/src/CMakeLists.txt
@@ -354,7 +354,7 @@ else()
     ${_LIB_PATH}/libarrow.a
     ${_LIB_PATH}/libparquet.a
     $<$<NOT:$<PLATFORM_ID:Darwin>>:${_LIB_PATH}/libarrow_bundled_dependencies.a>
-    $<$<PLATFORM_ID:Darwin>:-L/opt/homebrew/lib -lutf8proc -lthrift -lre2 -lbrotlicommon -lbrotlienc -lbrotlidec -lbz2>
+    $<$<PLATFORM_ID:Darwin>:-L/opt/homebrew/lib -lutf8proc -lthrift -lbrotlicommon -lbrotlienc -lbrotlidec -lbz2>
     ${_LIB_PATH_EXTRA}/liborc.a
     ${_LIB_PATH_EXTRA}/libsnappy.a
     $<$<NOT:$<BOOL:${ANDROID}>>:${_LIB_PATH_EXTRA}/libprotoc.a>


### PR DESCRIPTION
## Summary

- remove the unused Homebrew `-lre2` entry from the macOS link list
- stop `seekdb` from acquiring a dynamic RE2 dependency and its transitive Abseil dylibs
- keep gRPC's vendored static `libre2.a` unchanged

## Root cause

The Darwin dependency list unconditionally linked Homebrew RE2 even though the final `seekdb` executable has no unresolved RE2 or Abseil symbols. That unnecessary load command expanded the wheel's runtime dependency closure.

## Impact

This reduces the macOS runtime dependency set and avoids packaging/scanning RE2 plus its transitive Abseil dylibs. Other platforms are unchanged.

## Validation

- `cmake --build build_release --target seekdb -- -j2` (macOS arm64, RelWithDebInfo, Xcode SDK)
- `build_release/src/observer/seekdb --version`
- `otool -L build_release/src/observer/seekdb`: no RE2 or Abseil dylibs
- `nm -u build_release/src/observer/seekdb`: no RE2 or Abseil symbols
- `git diff --check`

Build-environment note: gRPC code generation was rerun through `/usr/bin/env` after the local `cmake -E env` invocation killed `protoc-gen-grpc`; that generated-build-file workaround is not part of this PR.