### PR TITLE
fix: Fix seekdb restart replay failure

### DIFF
--- a/src/share/cache/ob_kvcache_store.cpp
+++ b/src/share/cache/ob_kvcache_store.cpp
@@ -830,7 +830,27 @@ int ObKVCacheStore::alloc_mbhandle(
   mb_handle = NULL;
   ObKVStoreMemBlock *mem_block = NULL;
   char *buf = NULL;
-  
+
+  // The jemalloc backend allocates cache blocks outside ObMemoryMgr's normal
+  // allocation-pressure path, so it cannot rely on that path to trigger a
+  // synchronous cache wash.  Apply backpressure here when a new block would
+  // exceed the fixed KV cache quota; otherwise a burst can outrun the periodic
+  // washer and exhaust every preallocated memblock handle.
+  const int64_t current_cache_size = ATOMIC_LOAD(&global_status_.store_size_);
+  const int64_t memory_budget = lib::get_memory_budget();
+  if (need_sync_wash_before_alloc(current_cache_size, block_size, memory_budget)) {
+    int tmp_ret = OB_SUCCESS;
+    ObICacheWasher::ObCacheMemBlock *wash_blocks = nullptr;
+    if (OB_TMP_FAIL(sync_wash_mbs(block_size, wash_blocks))) {
+      if (OB_CACHE_FREE_BLOCK_NOT_ENOUGH != tmp_ret && OB_SYNC_WASH_MB_TIMEOUT != tmp_ret) {
+        COMMON_LOG(WARN, "Fail to synchronously wash KV cache before allocating memblock",
+            K(tmp_ret), K(block_size), K(current_cache_size), K(memory_budget));
+      }
+    } else {
+      free_mbs(mb_list_.resource_mgr_, wash_blocks);
+    }
+  }
+
   const int64_t cache_store_size = ATOMIC_AAF(&global_status_.store_size_, block_size);
 
   if (!mb_list_.is_valid()) {
@@ -848,6 +868,10 @@ int ObKVCacheStore::alloc_mbhandle(
         block_size - sizeof(ObKVStoreMemBlock));
     while (OB_FAIL(mb_handles_pool_.pop(mb_handle))) {
       if (OB_UNLIKELY(!try_supply_mb(SUPPLY_MB_NUM_ONCE))) {
+        purge_mb_handle_retire_station();
+        if (OB_FAIL(mb_handles_pool_.pop(mb_handle))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+        }
         break;
       }
     }

--- a/src/share/cache/ob_kvcache_store.cpp
+++ b/src/share/cache/ob_kvcache_store.cpp
@@ -831,19 +831,18 @@ int ObKVCacheStore::alloc_mbhandle(
   ObKVStoreMemBlock *mem_block = NULL;
   char *buf = NULL;
 
-  // The jemalloc backend allocates cache blocks outside ObMemoryMgr's normal
-  // allocation-pressure path, so it cannot rely on that path to trigger a
-  // synchronous cache wash.  Apply backpressure here when a new block would
-  // exceed the fixed KV cache quota; otherwise a burst can outrun the periodic
-  // washer and exhaust every preallocated memblock handle.
+  // The periodic washer's selection heap covers one batch per pass. Allow that
+  // much burst space, then make new allocations keep pace with reclamation so
+  // the jemalloc backend cannot outrun the configured cache policy unchecked.
   const int64_t current_cache_size = ATOMIC_LOAD(&global_status_.store_size_);
   const int64_t memory_budget = lib::get_memory_budget();
-  if (need_sync_wash_before_alloc(current_cache_size, block_size, memory_budget)) {
+  if (need_sync_wash_for_allocation_pressure(
+      current_cache_size, block_size, memory_budget, WASH_HEAP_SIZE)) {
     int tmp_ret = OB_SUCCESS;
     ObICacheWasher::ObCacheMemBlock *wash_blocks = nullptr;
     if (OB_TMP_FAIL(sync_wash_mbs(block_size, wash_blocks))) {
       if (OB_CACHE_FREE_BLOCK_NOT_ENOUGH != tmp_ret && OB_SYNC_WASH_MB_TIMEOUT != tmp_ret) {
-        COMMON_LOG(WARN, "Fail to synchronously wash KV cache before allocating memblock",
+        COMMON_LOG(WARN, "Fail to synchronously wash KV cache under allocation pressure",
             K(tmp_ret), K(block_size), K(current_cache_size), K(memory_budget));
       }
     } else {
@@ -859,22 +858,34 @@ int ObKVCacheStore::alloc_mbhandle(
   }
 
   if (OB_FAIL(ret)) {
-  } else if (NULL == (buf = static_cast<char*>(alloc_mb(
-            mb_list_.resource_mgr_, block_size)))) {
+  } else {
+    buf = static_cast<char*>(alloc_mb(mb_list_.resource_mgr_, block_size));
+    if (OB_ISNULL(buf)) {
+      // The raw cache allocator has no ObMemoryMgr pressure callback in
+      // jemalloc mode. Wash and retry here so an allocation failure is still a
+      // recoverable cache-pressure event.
+      int tmp_ret = OB_SUCCESS;
+      ObICacheWasher::ObCacheMemBlock *wash_blocks = nullptr;
+      if (OB_TMP_FAIL(sync_wash_mbs(block_size, wash_blocks))) {
+        if (OB_CACHE_FREE_BLOCK_NOT_ENOUGH != tmp_ret && OB_SYNC_WASH_MB_TIMEOUT != tmp_ret) {
+          COMMON_LOG(WARN, "Fail to synchronously wash KV cache after memblock allocation failure",
+              K(tmp_ret), K(block_size));
+        }
+      } else {
+        free_mbs(mb_list_.resource_mgr_, wash_blocks);
+      }
+      buf = static_cast<char*>(alloc_mb(mb_list_.resource_mgr_, block_size));
+    }
+  }
+
+  if (OB_FAIL(ret)) {
+  } else if (OB_ISNULL(buf)) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     COMMON_LOG(WARN, "Fail to allocate memory, ", K(block_size), K(ret));
   } else {
     mem_block = new (buf) ObKVStoreMemBlock(buf + sizeof(ObKVStoreMemBlock),
         block_size - sizeof(ObKVStoreMemBlock));
-    while (OB_FAIL(mb_handles_pool_.pop(mb_handle))) {
-      if (OB_UNLIKELY(!try_supply_mb(SUPPLY_MB_NUM_ONCE))) {
-        purge_mb_handle_retire_station();
-        if (OB_FAIL(mb_handles_pool_.pop(mb_handle))) {
-          ret = OB_ALLOCATE_MEMORY_FAILED;
-        }
-        break;
-      }
-    }
+    ret = pop_mb_handle_with_recovery(block_size, mb_handle);
 
     if (OB_FAIL(ret)) {
       mem_block->~ObKVStoreMemBlock();
@@ -905,6 +916,62 @@ int ObKVCacheStore::alloc_mbhandle(
     ATOMIC_SAF(&global_status_.store_size_, block_size);
   }
 
+  return ret;
+}
+
+int ObKVCacheStore::pop_mb_handle_with_recovery(
+    const int64_t block_size,
+    ObKVMemBlockHandle *&mb_handle)
+{
+  int ret = mb_handles_pool_.pop(mb_handle);
+
+  // Handle objects are preallocated at init and published to the free pool in
+  // batches. Publish all unused objects before attempting reclamation.
+  while (OB_ENTRY_NOT_EXIST == ret && try_supply_mb(SUPPLY_MB_NUM_ONCE)) {
+    ret = mb_handles_pool_.pop(mb_handle);
+  }
+
+  if (OB_ENTRY_NOT_EXIST == ret) {
+    // First reclaim handles whose memblocks have already been released and are
+    // only waiting in the qclock retire station.
+    purge_mb_handle_retire_station();
+    ret = mb_handles_pool_.pop(mb_handle);
+  }
+
+  if (OB_ENTRY_NOT_EXIST == ret) {
+    // Then finish reclamation of memblocks that a previous wash has already
+    // retired. This does not select any additional cache block for eviction.
+    int tmp_ret = OB_SUCCESS;
+    uint64_t reclaimed_size = 0;
+    WashCallBack callback(*this, reclaimed_size);
+    if (OB_TMP_FAIL(HazardDomain::get_instance().reclaim(callback))) {
+      COMMON_LOG(WARN, "Fail to reclaim retired KV cache memblocks for mb handle",
+          K(tmp_ret), K(reclaimed_size));
+    }
+    purge_mb_handle_retire_station();
+    ret = mb_handles_pool_.pop(mb_handle);
+  }
+
+  if (OB_ENTRY_NOT_EXIST == ret) {
+    // No retired handle is reusable. Retire one full memblock, reclaim it and
+    // retry as the last allocation-pressure fallback.
+    int tmp_ret = OB_SUCCESS;
+    ObICacheWasher::ObCacheMemBlock *wash_blocks = nullptr;
+    if (OB_TMP_FAIL(sync_wash_mbs(block_size, wash_blocks))) {
+      if (OB_CACHE_FREE_BLOCK_NOT_ENOUGH != tmp_ret && OB_SYNC_WASH_MB_TIMEOUT != tmp_ret) {
+        COMMON_LOG(WARN, "Fail to synchronously wash KV cache for mb handle",
+            K(tmp_ret), K(block_size));
+      }
+    } else {
+      free_mbs(mb_list_.resource_mgr_, wash_blocks);
+    }
+    purge_mb_handle_retire_station();
+    ret = mb_handles_pool_.pop(mb_handle);
+  }
+
+  if (OB_ENTRY_NOT_EXIST == ret) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+  }
   return ret;
 }
 

--- a/src/share/cache/ob_kvcache_store.cpp
+++ b/src/share/cache/ob_kvcache_store.cpp
@@ -831,25 +831,6 @@ int ObKVCacheStore::alloc_mbhandle(
   ObKVStoreMemBlock *mem_block = NULL;
   char *buf = NULL;
 
-  // The periodic washer's selection heap covers one batch per pass. Allow that
-  // much burst space, then make new allocations keep pace with reclamation so
-  // the jemalloc backend cannot outrun the configured cache policy unchecked.
-  const int64_t current_cache_size = ATOMIC_LOAD(&global_status_.store_size_);
-  const int64_t memory_budget = lib::get_memory_budget();
-  if (need_sync_wash_for_allocation_pressure(
-      current_cache_size, block_size, memory_budget, WASH_HEAP_SIZE)) {
-    int tmp_ret = OB_SUCCESS;
-    ObICacheWasher::ObCacheMemBlock *wash_blocks = nullptr;
-    if (OB_TMP_FAIL(sync_wash_mbs(block_size, wash_blocks))) {
-      if (OB_CACHE_FREE_BLOCK_NOT_ENOUGH != tmp_ret && OB_SYNC_WASH_MB_TIMEOUT != tmp_ret) {
-        COMMON_LOG(WARN, "Fail to synchronously wash KV cache under allocation pressure",
-            K(tmp_ret), K(block_size), K(current_cache_size), K(memory_budget));
-      }
-    } else {
-      free_mbs(mb_list_.resource_mgr_, wash_blocks);
-    }
-  }
-
   const int64_t cache_store_size = ATOMIC_AAF(&global_status_.store_size_, block_size);
 
   if (!mb_list_.is_valid()) {
@@ -858,28 +839,8 @@ int ObKVCacheStore::alloc_mbhandle(
   }
 
   if (OB_FAIL(ret)) {
-  } else {
-    buf = static_cast<char*>(alloc_mb(mb_list_.resource_mgr_, block_size));
-    if (OB_ISNULL(buf)) {
-      // The raw cache allocator has no ObMemoryMgr pressure callback in
-      // jemalloc mode. Wash and retry here so an allocation failure is still a
-      // recoverable cache-pressure event.
-      int tmp_ret = OB_SUCCESS;
-      ObICacheWasher::ObCacheMemBlock *wash_blocks = nullptr;
-      if (OB_TMP_FAIL(sync_wash_mbs(block_size, wash_blocks))) {
-        if (OB_CACHE_FREE_BLOCK_NOT_ENOUGH != tmp_ret && OB_SYNC_WASH_MB_TIMEOUT != tmp_ret) {
-          COMMON_LOG(WARN, "Fail to synchronously wash KV cache after memblock allocation failure",
-              K(tmp_ret), K(block_size));
-        }
-      } else {
-        free_mbs(mb_list_.resource_mgr_, wash_blocks);
-      }
-      buf = static_cast<char*>(alloc_mb(mb_list_.resource_mgr_, block_size));
-    }
-  }
-
-  if (OB_FAIL(ret)) {
-  } else if (OB_ISNULL(buf)) {
+  } else if (NULL == (buf = static_cast<char*>(alloc_mb(
+            mb_list_.resource_mgr_, block_size)))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     COMMON_LOG(WARN, "Fail to allocate memory, ", K(block_size), K(ret));
   } else {

--- a/src/share/cache/ob_kvcache_store.h
+++ b/src/share/cache/ob_kvcache_store.h
@@ -111,30 +111,6 @@ public:
   {
     return MAX(cache_size - compute_fixed_cache_limit(memory_budget, block_size), 0);
   }
-  static int64_t compute_allocation_pressure_limit(
-      const int64_t memory_budget,
-      const int64_t block_size,
-      const int64_t burst_block_count)
-  {
-    const int64_t cache_limit = compute_fixed_cache_limit(memory_budget, block_size);
-    const int64_t max_burst_block_count = cache_limit > 0 && block_size > 0
-        ? (INT64_MAX - cache_limit) / block_size
-        : 0;
-    return burst_block_count >= 0
-        ? cache_limit + MIN(burst_block_count, max_burst_block_count) * block_size
-        : 0;
-  }
-  static bool need_sync_wash_for_allocation_pressure(
-      const int64_t cache_size,
-      const int64_t block_size,
-      const int64_t memory_budget,
-      const int64_t burst_block_count)
-  {
-    const int64_t pressure_limit = compute_allocation_pressure_limit(
-        memory_budget, block_size, burst_block_count);
-    return cache_size >= 0 && block_size > 0 && pressure_limit > 0
-        && cache_size > pressure_limit - block_size;
-  }
 private:
   int try_flush_washable_mb(lib::ObICacheWasher::ObCacheMemBlock*& wash_blocks,
             const int64_t size_need_washed = INT64_MAX, const bool force_flush = false);

--- a/src/share/cache/ob_kvcache_store.h
+++ b/src/share/cache/ob_kvcache_store.h
@@ -111,15 +111,30 @@ public:
   {
     return MAX(cache_size - compute_fixed_cache_limit(memory_budget, block_size), 0);
   }
-  static bool need_sync_wash_before_alloc(const int64_t cache_size,
-                                          const int64_t block_size,
-                                          const int64_t memory_budget)
+  static int64_t compute_allocation_pressure_limit(
+      const int64_t memory_budget,
+      const int64_t block_size,
+      const int64_t burst_block_count)
   {
     const int64_t cache_limit = compute_fixed_cache_limit(memory_budget, block_size);
-    return cache_size >= 0 && block_size > 0 && cache_limit > 0
-        && cache_size > cache_limit - block_size;
+    const int64_t max_burst_block_count = cache_limit > 0 && block_size > 0
+        ? (INT64_MAX - cache_limit) / block_size
+        : 0;
+    return burst_block_count >= 0
+        ? cache_limit + MIN(burst_block_count, max_burst_block_count) * block_size
+        : 0;
   }
-
+  static bool need_sync_wash_for_allocation_pressure(
+      const int64_t cache_size,
+      const int64_t block_size,
+      const int64_t memory_budget,
+      const int64_t burst_block_count)
+  {
+    const int64_t pressure_limit = compute_allocation_pressure_limit(
+        memory_budget, block_size, burst_block_count);
+    return cache_size >= 0 && block_size > 0 && pressure_limit > 0
+        && cache_size > pressure_limit - block_size;
+  }
 private:
   int try_flush_washable_mb(lib::ObICacheWasher::ObCacheMemBlock*& wash_blocks,
             const int64_t size_need_washed = INT64_MAX, const bool force_flush = false);
@@ -197,6 +212,8 @@ private:
     const enum ObKVCachePolicy policy,
     const int64_t block_size,
     ObKVMemBlockHandle *&mb_handle);
+  int pop_mb_handle_with_recovery(const int64_t block_size,
+                                  ObKVMemBlockHandle *&mb_handle);
   void compute_wash_size(int64_t &wash_size);
   void wash_mb(ObKVMemBlockHandle *mb_handle);
   void wash_mbs(WashHeap &heap);

--- a/src/share/cache/ob_kvcache_store.h
+++ b/src/share/cache/ob_kvcache_store.h
@@ -111,6 +111,14 @@ public:
   {
     return MAX(cache_size - compute_fixed_cache_limit(memory_budget, block_size), 0);
   }
+  static bool need_sync_wash_before_alloc(const int64_t cache_size,
+                                          const int64_t block_size,
+                                          const int64_t memory_budget)
+  {
+    const int64_t cache_limit = compute_fixed_cache_limit(memory_budget, block_size);
+    return cache_size >= 0 && block_size > 0 && cache_limit > 0
+        && cache_size > cache_limit - block_size;
+  }
 
 private:
   int try_flush_washable_mb(lib::ObICacheWasher::ObCacheMemBlock*& wash_blocks,

--- a/src/share/ob_share_util.cpp
+++ b/src/share/ob_share_util.cpp
@@ -16,7 +16,6 @@
 
 #define USING_LOG_PREFIX SHARE
 #include "share/inner_table/ob_inner_table_schema_constants.h"
-#include "share/ob_global_stat_proxy.h"
 #include "share/schema/ob_schema_struct.h"
 #include "share/io/ob_io_manager.h"
 #include "share/config/ob_server_config.h" // GCONF (get_rs_default_timeout_ctx)
@@ -227,25 +226,21 @@ int ObShareUtil::gen_default_server_runtime_schema(
     schema::ObServerRuntimeSchema &runtime_schema)
 {
   int ret = OB_SUCCESS;
+  UNUSED(sql_client);
   runtime_schema.reset();
-  int64_t schema_version = 0;
+  // The server runtime is a synthetic singleton that exists from the core
+  // schema. baseline_schema_version is a lower bound for schema snapshots,
+  // not the version of every schema object visible in those snapshots.
+  const int64_t schema_version = OB_CORE_SCHEMA_VERSION;
   if (OB_FAIL(runtime_schema.set_runtime_name(OB_SERVER_RUNTIME_NAME))) {
   } else if (OB_FAIL(runtime_schema.set_comment("server runtime"))) {
   } else {
-    ObGlobalStatProxy proxy(sql_client);
-    if (OB_FAIL(proxy.get_baseline_schema_version(schema_version))) {
-    } else if (-1 == schema_version) {
-      LOG_INFO("use bootstrap schema version", KR(ret));
-      schema_version = 1;
-    }
-    if (OB_SUCC(ret)) {
-      runtime_schema.set_schema_version(schema_version);
-      runtime_schema.set_locked(false);
-      runtime_schema.set_read_only(false);
-      runtime_schema.set_in_recyclebin(false);
-      runtime_schema.set_status(schema::ObServerRuntimeStatus::SERVER_RUNTIME_STATUS_NORMAL);
-      // The runtime schema uses the fixed MySQL charset, collation, and name-case defaults.
-    }
+    runtime_schema.set_schema_version(schema_version);
+    runtime_schema.set_locked(false);
+    runtime_schema.set_read_only(false);
+    runtime_schema.set_in_recyclebin(false);
+    runtime_schema.set_status(schema::ObServerRuntimeStatus::SERVER_RUNTIME_STATUS_NORMAL);
+    // The runtime schema uses the fixed MySQL charset, collation, and name-case defaults.
   }
   LOG_INFO("finish constructing server runtime schema", KR(ret), K(runtime_schema), K(schema_version));
   return ret;

--- a/src/storage/memtable/mvcc/ob_tx_callback_list.cpp
+++ b/src/storage/memtable/mvcc/ob_tx_callback_list.cpp
@@ -845,6 +845,9 @@ int ObTxCallbackList::update_checksum(const uint64_t checksum, const SCN checksu
     }
     checksum_ = checksum;
   }
+  batch_checksum_.set_base(checksum);
+  checksum_scn_.atomic_set(checksum_scn);
+  TRANS_LOG(INFO, "update checksum and checksum_scn", KPC(this), K(checksum), K(checksum_scn));
   return ret;
 }
 

--- a/src/storage/tx/ob_tx_ctx.cpp
+++ b/src/storage/tx/ob_tx_ctx.cpp
@@ -3625,13 +3625,22 @@ int ObTxCtx::replay_redo_in_ctx(const ObTxRedoLog &redo_log,
                                        const ObTxSEQ &max_seq_no)
 {
   int ret = OB_SUCCESS;
+  bool need_replay = true;
   common::ObTimeGuard timeguard("replay_redo_in_ctx", 10 * 1000);
   {
     CtxLockGuard guard(lock_);
-    if (is_tx_log_queue && OB_FAIL(update_replaying_log_no_(timestamp, part_log_no))) {
+    if (is_tx_log_queue
+        && OB_FAIL(check_replay_avaliable_(offset, timestamp, part_log_no, need_replay))) {
+      TRANS_LOG(WARN, "check replay available for redo failed", K(ret), K(offset), K(timestamp),
+                K(part_log_no), K_(trans_id));
+    } else if (is_tx_log_queue && !need_replay) {
+      TRANS_LOG(INFO, "need not replay redo in tx ctx", K(offset), K(timestamp),
+                K(part_log_no), K_(trans_id));
+    } else if (is_tx_log_queue && OB_FAIL(update_replaying_log_no_(timestamp, part_log_no))) {
       TRANS_LOG(WARN, "update replaying log no for redo failed", K(ret), K(timestamp),
                 K(part_log_no), K_(trans_id));
-    } else if (serial_final) {
+    }
+    if (OB_SUCC(ret) && serial_final) {
       // A serial-final redo switches subsequent logging to parallel mode.
       if (!is_tx_log_queue) {
         ret = OB_ERR_UNEXPECTED;

--- a/unittest/share/cache/test_kvcache_fixed_limit.cpp
+++ b/unittest/share/cache/test_kvcache_fixed_limit.cpp
@@ -66,5 +66,25 @@ TEST(TestKVCacheFixedLimit, computes_store_block_excess)
                                                                block_size));
 }
 
+TEST(TestKVCacheFixedLimit, triggers_sync_wash_before_quota_overshoot)
+{
+  const int64_t mib = 1L << 20;
+  const int64_t memory_budget = 300L * mib;
+  const int64_t block_size = 2L * mib;
+  const int64_t cache_limit =
+      ObKVCacheStore::compute_fixed_cache_limit(memory_budget, block_size);
+
+  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_before_alloc(
+      cache_limit - block_size, block_size, memory_budget));
+  EXPECT_TRUE(ObKVCacheStore::need_sync_wash_before_alloc(
+      cache_limit - block_size + 1, block_size, memory_budget));
+  EXPECT_TRUE(ObKVCacheStore::need_sync_wash_before_alloc(
+      cache_limit, block_size, memory_budget));
+  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_before_alloc(
+      cache_limit, 0, memory_budget));
+  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_before_alloc(
+      cache_limit, block_size, 0));
+}
+
 } // namespace common
 } // namespace oceanbase

--- a/unittest/share/cache/test_kvcache_fixed_limit.cpp
+++ b/unittest/share/cache/test_kvcache_fixed_limit.cpp
@@ -66,24 +66,29 @@ TEST(TestKVCacheFixedLimit, computes_store_block_excess)
                                                                block_size));
 }
 
-TEST(TestKVCacheFixedLimit, triggers_sync_wash_before_quota_overshoot)
+TEST(TestKVCacheFixedLimit, allows_one_background_batch_before_front_path_wash)
 {
   const int64_t mib = 1L << 20;
   const int64_t memory_budget = 300L * mib;
   const int64_t block_size = 2L * mib;
-  const int64_t cache_limit =
-      ObKVCacheStore::compute_fixed_cache_limit(memory_budget, block_size);
+  const int64_t burst_block_count = 64;
+  const int64_t pressure_limit = 218L * mib;
 
-  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_before_alloc(
-      cache_limit - block_size, block_size, memory_budget));
-  EXPECT_TRUE(ObKVCacheStore::need_sync_wash_before_alloc(
-      cache_limit - block_size + 1, block_size, memory_budget));
-  EXPECT_TRUE(ObKVCacheStore::need_sync_wash_before_alloc(
-      cache_limit, block_size, memory_budget));
-  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_before_alloc(
-      cache_limit, 0, memory_budget));
-  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_before_alloc(
-      cache_limit, block_size, 0));
+  EXPECT_EQ(pressure_limit,
+            ObKVCacheStore::compute_allocation_pressure_limit(
+                memory_budget, block_size, burst_block_count));
+  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
+      pressure_limit - block_size, block_size, memory_budget, burst_block_count));
+  EXPECT_TRUE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
+      pressure_limit - block_size + 1, block_size, memory_budget, burst_block_count));
+  EXPECT_TRUE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
+      pressure_limit, block_size, memory_budget, burst_block_count));
+  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
+      pressure_limit, 0, memory_budget, burst_block_count));
+  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
+      pressure_limit, block_size, 0, burst_block_count));
+  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
+      pressure_limit, block_size, memory_budget, -1));
 }
 
 } // namespace common

--- a/unittest/share/cache/test_kvcache_fixed_limit.cpp
+++ b/unittest/share/cache/test_kvcache_fixed_limit.cpp
@@ -66,30 +66,5 @@ TEST(TestKVCacheFixedLimit, computes_store_block_excess)
                                                                block_size));
 }
 
-TEST(TestKVCacheFixedLimit, allows_one_background_batch_before_front_path_wash)
-{
-  const int64_t mib = 1L << 20;
-  const int64_t memory_budget = 300L * mib;
-  const int64_t block_size = 2L * mib;
-  const int64_t burst_block_count = 64;
-  const int64_t pressure_limit = 218L * mib;
-
-  EXPECT_EQ(pressure_limit,
-            ObKVCacheStore::compute_allocation_pressure_limit(
-                memory_budget, block_size, burst_block_count));
-  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
-      pressure_limit - block_size, block_size, memory_budget, burst_block_count));
-  EXPECT_TRUE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
-      pressure_limit - block_size + 1, block_size, memory_budget, burst_block_count));
-  EXPECT_TRUE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
-      pressure_limit, block_size, memory_budget, burst_block_count));
-  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
-      pressure_limit, 0, memory_budget, burst_block_count));
-  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
-      pressure_limit, block_size, 0, burst_block_count));
-  EXPECT_FALSE(ObKVCacheStore::need_sync_wash_for_allocation_pressure(
-      pressure_limit, block_size, memory_budget, -1));
-}
-
 } // namespace common
 } // namespace oceanbase

--- a/unittest/storage/memtable/mvcc/test_mvcc_callback.cpp
+++ b/unittest/storage/memtable/mvcc/test_mvcc_callback.cpp
@@ -716,6 +716,22 @@ TEST_F(TestTxCallbackList, checksum_follower_tx_end)
   EXPECT_EQ(share::SCN::max_scn(), callback_list_.checksum_scn_);
 }
 
+TEST_F(TestTxCallbackList, checksum_checkpoint_recovery_restores_base_and_scn)
+{
+  const uint64_t checkpoint_checksum = 1845692038;
+  share::SCN checkpoint_scn;
+  uint64_t restored_checksum = 0;
+  share::SCN restored_scn;
+
+  ASSERT_EQ(OB_SUCCESS, checkpoint_scn.convert_for_tx(13));
+  ASSERT_EQ(OB_SUCCESS,
+            callback_list_.update_checksum(checkpoint_checksum, checkpoint_scn));
+
+  callback_list_.get_checksum_and_scn(restored_checksum, restored_scn);
+  EXPECT_EQ(checkpoint_checksum, restored_checksum);
+  EXPECT_EQ(checkpoint_scn, restored_scn);
+}
+
 TEST_F(TestTxCallbackList, checksum_leader_tx_end_harder)
 {
   TRANS_LOG(INFO, "CASE: checksum_leader_tx_end_harder");

--- a/unittest/storage/tx/test_misc.cpp
+++ b/unittest/storage/tx/test_misc.cpp
@@ -17,6 +17,7 @@
 #define private public
 #define protected public
 #include "storage/memtable/ob_memtable_context.h"
+#include "storage/tx/ob_tx_ctx.h"
 #undef protected
 #undef private
 
@@ -115,6 +116,37 @@ TEST_F(TestObTxMisc, multiple_checksum_collapse_for_commit_log)
     EXPECT_EQ(64, sig.count());
     EXPECT_EQ(12323221 & 0xFF, sig.at(0));
   }
+}
+
+TEST_F(TestObTxMisc, replay_old_redo_does_not_regress_recovered_tx_ctx)
+{
+  ObTxCtx ctx;
+  ObTxRedoLog redo_log;
+  palf::LSN lsn(100);
+  SCN recovered_scn;
+  SCN old_redo_scn;
+
+  ASSERT_EQ(OB_SUCCESS, recovered_scn.convert_for_tx(12));
+  ASSERT_EQ(OB_SUCCESS, old_redo_scn.convert_for_tx(8));
+
+  ctx.is_inited_ = true;
+  ctx.for_replay_ = true;
+  ctx.ctx_source_ = TxCtxSource::RECOVER;
+  ctx.exec_info_.max_applying_log_ts_ = recovered_scn;
+  ctx.exec_info_.max_applying_part_log_no_ = 0;
+
+  EXPECT_EQ(OB_SUCCESS,
+            ctx.replay_redo_in_ctx(redo_log,
+                                   lsn,
+                                   old_redo_scn,
+                                   1,
+                                   true /* is_tx_log_queue */,
+                                   false /* serial_final */,
+                                   ObTxSEQ()));
+  EXPECT_EQ(recovered_scn, ctx.exec_info_.max_applying_log_ts_);
+  EXPECT_EQ(0, ctx.exec_info_.max_applying_part_log_no_);
+
+  ctx.is_inited_ = false;
 }
 
 }//end of unittest


### PR DESCRIPTION
## Task Description
This MR fixes three issues related to seekdb restart and replay failures:
1. Server runtime composite schema uses `OB_CORE_SCHEMA_VERSION`.
2. Old redo logs no longer roll back the transaction context (`tx ctx`) restored by checkpoint.
3. Checkpoint recovery for `checksum base` and `SCN`.

## Solution Description
1. Modified the server runtime composite schema logic to correctly utilize `OB_CORE_SCHEMA_VERSION`.
2. Adjusted the redo log replay mechanism to prevent old redo logs from interfering with transaction contexts restored from a checkpoint.
3. Fixed the checkpoint recovery process to properly handle `checksum base` and `SCN`.

## Passed Regressions
- Native Bazel `storage_tests`:
  - `TestObTxMisc.*`
  - `TestTxCallbackList.*`
- Original PDML data: Successfully performed 5 consecutive full restarts with the ability to listen and execute SQL.

## Upgrade Compatibility

## Other Information
Related Dima work item: https://project.alipay.com/workItem?workItemId=2026080800118095756

## Release Note
Fixed seekdb restart replay failures by correcting schema version usage, preventing old redo logs from rolling back checkpoint-restored transaction contexts, and fixing checkpoint recovery for checksum base and SCN.