### PR TITLE
[seekdb][log] Redirect standard streams to seekdb.log

### DIFF
--- a/src/observer/main.cpp
+++ b/src/observer/main.cpp
@@ -755,7 +755,7 @@ int inner_main(int argc, char *argv[])
     OB_LOGGER.set_log_level(opts->log_level_);
     OB_LOGGER.set_max_file_size(LOG_FILE_SIZE);
     OB_LOGGER.set_new_file_info(syslog_file_info);
-    OB_LOGGER.set_file_name(LOG_FILE_NAME, true/*no_redirect_flag*/);
+    OB_LOGGER.set_file_name(LOG_FILE_NAME, false/*no_redirect_flag*/);
     ObPLogWriterCfg log_cfg;
     LOG_INFO("succ to init logger",
              "default file", LOG_FILE_NAME,


### PR DESCRIPTION
## Task Description
seekdb initializes the logger with `no_redirect_flag=true`. As a result, stdout and stderr are not redirected to `seekdb.log`. In daemon mode, direct writes to these file descriptors go to `/dev/null` and diagnostic output can be lost.

## Solution Description
Initialize the server logger with `no_redirect_flag=false`. ObLogger then redirects `STDOUT_FILENO` and `STDERR_FILENO` to `log/seekdb.log` using `dup2`, and preserves the redirection when the log file is reopened or rotated.

## Passed Regressions
- Full Release build: `./build.sh release --make -j8`
- Started a temporary seekdb instance with `--nodaemon`.
- Verified `/proc/<pid>/fd/1`, `/proc/<pid>/fd/2`, and `seekdb.log` had the same device and inode.
- Wrote distinct stdout and stderr markers through the process descriptors and verified both markers in `seekdb.log`.

## Upgrade Compatibility
No storage format, protocol, configuration, or upgrade compatibility impact. Only the destination of stdout and stderr after logger initialization changes.

## Other Information
This MR contains one commit: `54e8ffa3d15`. No unrelated commits or files are included.

## Release Note
