### PR TITLE
[seekdb][PX] Downgrade admission to available workers

### DIFF
--- a/src/observer/omt/ob_server_runtime.cpp
+++ b/src/observer/omt/ob_server_runtime.cpp
@@ -21,6 +21,7 @@
 #include "lib/stat/ob_diagnostic_info_guard.h"
 #include "lib/statistic_event/ob_stat_event.h"
 #include "share/interrupt/ob_global_interrupt_call.h"
+#include "share/ob_cpu_share_calculator.h"
 
 #include "sql/engine/px/ob_px_target_monitor.h"
 #include "sql/dtl/ob_dtl_fc_server.h"
@@ -803,6 +804,10 @@ void ObServerRuntime::check_parallel_servers_target()
               SYS_VAR_PARALLEL_SERVERS_TARGET,
               val))) {
   } else {
+    val = ObCpuShareCalculator::resolve_parallel_servers_target(
+        val,
+        static_cast<int64_t>(GCONF.get_server_default_min_cpu()),
+        GCONF.px_workers_per_cpu_quota);
     OB_PX_TARGET_MONITOR.set_parallel_servers_target(val);
   }
 }

--- a/src/rootserver/ob_runtime_ddl_service.cpp
+++ b/src/rootserver/ob_runtime_ddl_service.cpp
@@ -33,6 +33,7 @@
 #include "share/rc/ob_server_runtime.h"
 #include "share/scn.h"
 #include "share/ob_server_struct.h"
+#include "share/ob_cpu_share_calculator.h"
 #include "share/ob_version_parser.h"
 
 // The input of value must be a string
@@ -299,19 +300,13 @@ int ObRuntimeDDLService::init_system_variables(
         SET_RUNTIME_VARIABLE(SYS_VAR_READ_ONLY, read_only_value);
       }
 
-      // Derive the default PX thread target from the local server CPU floor.
-      int64_t default_px_thread_count = 0;
       if (OB_SUCC(ret)) {
-        const int64_t server_default_min_cpu =
-            static_cast<int64_t>(GCONF.get_server_default_min_cpu());
-        default_px_thread_count = std::max(
-            static_cast<int64_t>(3),
-            server_default_min_cpu * GCONF.px_workers_per_cpu_quota);
-      }
-
-      if (OB_SUCC(ret) && default_px_thread_count > 0) {
         // target cannot be less than 3, otherwise any px query will not come in
-        int64_t default_px_servers_target = std::max(static_cast<int64_t>(3), static_cast<int64_t>(default_px_thread_count));
+        const int64_t default_px_servers_target =
+            common::ObCpuShareCalculator::resolve_parallel_servers_target(
+                0,
+                static_cast<int64_t>(GCONF.get_server_default_min_cpu()),
+                GCONF.px_workers_per_cpu_quota);
         VAR_INT_TO_STRING(val_buf, default_px_servers_target);
         SET_RUNTIME_VARIABLE(SYS_VAR_PARALLEL_SERVERS_TARGET, val_buf);
       }

--- a/src/share/ob_cpu_share_calculator.cpp
+++ b/src/share/ob_cpu_share_calculator.cpp
@@ -27,7 +27,8 @@ namespace common
 
 int64_t ObCpuShareCalculator::calc_px_pool_share(int64_t min_cpu)
 {
-  return std::max(static_cast<int64_t>(3), min_cpu * GCONF.px_workers_per_cpu_quota);
+  return resolve_parallel_servers_target(
+      0, min_cpu, GCONF.px_workers_per_cpu_quota);
 }
 
 } // namespace common

--- a/src/share/ob_cpu_share_calculator.h
+++ b/src/share/ob_cpu_share_calculator.h
@@ -17,6 +17,7 @@
 #ifndef OCEANBASE_COMMON_OB_CPU_SHARE_CALCULATOR_
 #define OCEANBASE_COMMON_OB_CPU_SHARE_CALCULATOR_
 
+#include <algorithm>
 #include <cstdint>
 
 namespace oceanbase
@@ -29,6 +30,19 @@ class ObCpuShareCalculator
 public:
   /* Return value: The number of px threads assigned */
   static int64_t calc_px_pool_share(int64_t min_cpu);
+
+  // parallel_servers_target=0 means AUTO.  Resolve it before publishing the
+  // value to runtime consumers so that no consumer treats AUTO as zero
+  // capacity.
+  static int64_t resolve_parallel_servers_target(
+      int64_t configured_target,
+      int64_t min_cpu,
+      int64_t workers_per_cpu_quota)
+  {
+    return 0 == configured_target
+        ? std::max(static_cast<int64_t>(3), min_cpu * workers_per_cpu_quota)
+        : configured_target;
+  }
 };
 
 }

--- a/src/sql/engine/px/ob_px_admission.cpp
+++ b/src/sql/engine/px/ob_px_admission.cpp
@@ -50,12 +50,9 @@ int ObPxAdmission::get_parallel_session_target(ObSQLSessionInfo &session,
   }
   return ret;
 }
-// If the current remaining number of threads can meet req_cnt, then allocate threads to the request
-// But considering that the system should allow the first request to execute when idle, need to handle the following special cases:
-//   If the number of request threads req_cnt is greater than limit, and there are no other px requests currently (used = 0)
-//   Then assign up to the limit to this request (admit_cnt = used = limit)
-//
-//   Inference: A request that requires **excess** threads will only be scheduled after the system becomes idle
+// Fix the worker count once before execution. If the currently available quota can
+// satisfy the minimum required by the plan, start immediately with as many workers
+// as are available, up to req_cnt. The query does not scale up during execution.
 int64_t ObPxAdmission::admit(ObSQLSessionInfo &session, ObExecContext &exec_ctx,
                              int64_t wait_time_us, int64_t minimal_px_worker_count,
                              int64_t &session_target, int64_t req_cnt, int64_t &admit_cnt)
@@ -68,7 +65,8 @@ int64_t ObPxAdmission::admit(ObSQLSessionInfo &session, ObExecContext &exec_ctx,
   do {
     if (OB_FAIL(THIS_WORKER.check_status())) {
     } else if (OB_FAIL(OB_PX_TARGET_MONITOR.apply_target(
-                   wait_time_us, session_target, req_cnt, admit_cnt))) {
+                   wait_time_us, session_target, minimal_px_worker_count,
+                   req_cnt, admit_cnt))) {
     } else if (0 != admit_cnt) {
       exec_ctx.set_admission_acquired(true);
     }

--- a/src/sql/engine/px/ob_px_target_monitor.cpp
+++ b/src/sql/engine/px/ob_px_target_monitor.cpp
@@ -71,17 +71,19 @@ int64_t ObPxTargetMonitor::get_parallel_session_count()
 }
 
 int ObPxTargetMonitor::apply_target(int64_t wait_time_us, int64_t session_target,
-                                   int64_t req_cnt, int64_t &admit_count)
+                                   int64_t minimal_req_cnt, int64_t req_cnt,
+                                   int64_t &admit_count)
 {
   int ret = OB_SUCCESS;
   admit_count = 0;
   bool need_wait = false;
   {
     SpinWLockGuard guard(spin_lock_);
-    int64_t target = session_target;
-    int64_t total_use = px_target_used_;
-    if (total_use == 0 || total_use + req_cnt <= target) {
-      const int64_t acquired = std::min(req_cnt, target);
+    const int64_t target = session_target;
+    const int64_t total_use = px_target_used_;
+    const int64_t available = total_use < target ? target - total_use : 0;
+    const int64_t acquired = std::min(req_cnt, available);
+    if (acquired >= minimal_req_cnt) {
       px_target_used_ += acquired;
       admit_count = acquired;
       parallel_session_count_++;

--- a/src/sql/engine/px/ob_px_target_monitor.h
+++ b/src/sql/engine/px/ob_px_target_monitor.h
@@ -72,8 +72,8 @@ public:
 
 
   // for px_admission
-  int apply_target(int64_t wait_time_us, int64_t session_target, int64_t req_cnt,
-                   int64_t &admit_count);
+  int apply_target(int64_t wait_time_us, int64_t session_target,
+                   int64_t minimal_req_cnt, int64_t req_cnt, int64_t &admit_count);
   int release_target(int64_t worker_count);
 
   // for virtual_table iter

--- a/src/storage/tablet/ob_tablet.cpp
+++ b/src/storage/tablet/ob_tablet.cpp
@@ -1723,6 +1723,9 @@ int ObTablet::load_deserialize_current(
     if (OB_UNLIKELY(ObSecondaryMetaType::TABLET_MACRO_INFO != desc.type_ || desc.length_ <= 0)) {
       ret = OB_DESERIALIZE_ERROR;
       LOG_WARN("invalid inline tablet macro info descriptor", K(ret), K(desc));
+    } else if (OB_UNLIKELY(len - new_pos < desc.length_)) {
+      ret = OB_DESERIALIZE_ERROR;
+      LOG_WARN("buffer is not enough for inline tablet macro info", K(ret), K(len), K(new_pos), K(desc));
     } else if (OB_UNLIKELY(!tablet_addr_.is_valid() || !tablet_addr_.is_block())) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("tablet address is invalid", K(ret), K(tablet_addr_));
@@ -1730,21 +1733,16 @@ int ObTablet::load_deserialize_current(
     } else if (OB_UNLIKELY(size < desc.length_)) {
       ret = OB_DESERIALIZE_ERROR;
       LOG_WARN("tablet block is smaller than inline tablet macro info", K(ret), K(size), K(desc));
+    } else if (OB_FAIL(deserialize_macro_info(
+        allocator, buf, new_pos + desc.length_, new_pos, macro_info_addr_.ptr_))) {
+    } else if (OB_UNLIKELY(new_pos - secondary_meta_pos != desc.length_)) {
+      ret = OB_DESERIALIZE_ERROR;
+      LOG_WARN("inline tablet macro info length mismatch", K(ret), K(new_pos), K(secondary_meta_pos), K(desc));
     } else if (OB_FAIL(macro_info_addr_.addr_.set_block_addr(
         macro_id,
         offset + (size - desc.length_),
         desc.length_,
         ObMetaDiskAddr::DiskType::RAW_BLOCK))) {
-    } else if (len - new_pos >= desc.length_) {
-      // The first-level tablet load intentionally reads only a prefix of a RAW_BLOCK. Keep the
-      // address so macro info can be loaded lazily when the prefix does not contain the inline
-      // bytes in full.
-      if (OB_FAIL(deserialize_macro_info(
-          allocator, buf, new_pos + desc.length_, new_pos, macro_info_addr_.ptr_))) {
-      } else if (OB_UNLIKELY(new_pos - secondary_meta_pos != desc.length_)) {
-        ret = OB_DESERIALIZE_ERROR;
-        LOG_WARN("inline tablet macro info length mismatch", K(ret), K(new_pos), K(secondary_meta_pos), K(desc));
-      }
     }
   }
 
@@ -1906,6 +1904,9 @@ int ObTablet::deserialize(
       if (OB_UNLIKELY(ObSecondaryMetaType::TABLET_MACRO_INFO != desc.type_ || desc.length_ <= 0)) {
         ret = OB_DESERIALIZE_ERROR;
         LOG_WARN("invalid inline tablet macro info descriptor", K(ret), K(desc));
+      } else if (OB_UNLIKELY(len - new_pos < desc.length_)) {
+        ret = OB_DESERIALIZE_ERROR;
+        LOG_WARN("buffer is not enough for inline tablet macro info", K(ret), K(len), K(new_pos), K(desc));
       } else if (OB_UNLIKELY(!tablet_addr_.is_valid() || !tablet_addr_.is_block())) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("tablet address is invalid", K(ret), K(tablet_addr_));
@@ -1918,7 +1919,7 @@ int ObTablet::deserialize(
           offset + (size - desc.length_),
           desc.length_,
           ObMetaDiskAddr::DiskType::RAW_BLOCK))) {
-      } else if (len - new_pos >= desc.length_) {
+      } else {
         ObTabletMacroInfo *tablet_macro_info = nullptr;
         int64_t macro_info_size = 0;
         if (OB_FAIL(deserialize_macro_info(

--- a/src/storage/tablet/ob_tablet.cpp
+++ b/src/storage/tablet/ob_tablet.cpp
@@ -1723,9 +1723,6 @@ int ObTablet::load_deserialize_current(
     if (OB_UNLIKELY(ObSecondaryMetaType::TABLET_MACRO_INFO != desc.type_ || desc.length_ <= 0)) {
       ret = OB_DESERIALIZE_ERROR;
       LOG_WARN("invalid inline tablet macro info descriptor", K(ret), K(desc));
-    } else if (OB_UNLIKELY(len - new_pos < desc.length_)) {
-      ret = OB_DESERIALIZE_ERROR;
-      LOG_WARN("buffer is not enough for inline tablet macro info", K(ret), K(len), K(new_pos), K(desc));
     } else if (OB_UNLIKELY(!tablet_addr_.is_valid() || !tablet_addr_.is_block())) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("tablet address is invalid", K(ret), K(tablet_addr_));
@@ -1733,16 +1730,21 @@ int ObTablet::load_deserialize_current(
     } else if (OB_UNLIKELY(size < desc.length_)) {
       ret = OB_DESERIALIZE_ERROR;
       LOG_WARN("tablet block is smaller than inline tablet macro info", K(ret), K(size), K(desc));
-    } else if (OB_FAIL(deserialize_macro_info(
-        allocator, buf, new_pos + desc.length_, new_pos, macro_info_addr_.ptr_))) {
-    } else if (OB_UNLIKELY(new_pos - secondary_meta_pos != desc.length_)) {
-      ret = OB_DESERIALIZE_ERROR;
-      LOG_WARN("inline tablet macro info length mismatch", K(ret), K(new_pos), K(secondary_meta_pos), K(desc));
     } else if (OB_FAIL(macro_info_addr_.addr_.set_block_addr(
         macro_id,
         offset + (size - desc.length_),
         desc.length_,
         ObMetaDiskAddr::DiskType::RAW_BLOCK))) {
+    } else if (len - new_pos >= desc.length_) {
+      // The first-level tablet load intentionally reads only a prefix of a RAW_BLOCK. Keep the
+      // address so macro info can be loaded lazily when the prefix does not contain the inline
+      // bytes in full.
+      if (OB_FAIL(deserialize_macro_info(
+          allocator, buf, new_pos + desc.length_, new_pos, macro_info_addr_.ptr_))) {
+      } else if (OB_UNLIKELY(new_pos - secondary_meta_pos != desc.length_)) {
+        ret = OB_DESERIALIZE_ERROR;
+        LOG_WARN("inline tablet macro info length mismatch", K(ret), K(new_pos), K(secondary_meta_pos), K(desc));
+      }
     }
   }
 
@@ -1904,9 +1906,6 @@ int ObTablet::deserialize(
       if (OB_UNLIKELY(ObSecondaryMetaType::TABLET_MACRO_INFO != desc.type_ || desc.length_ <= 0)) {
         ret = OB_DESERIALIZE_ERROR;
         LOG_WARN("invalid inline tablet macro info descriptor", K(ret), K(desc));
-      } else if (OB_UNLIKELY(len - new_pos < desc.length_)) {
-        ret = OB_DESERIALIZE_ERROR;
-        LOG_WARN("buffer is not enough for inline tablet macro info", K(ret), K(len), K(new_pos), K(desc));
       } else if (OB_UNLIKELY(!tablet_addr_.is_valid() || !tablet_addr_.is_block())) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("tablet address is invalid", K(ret), K(tablet_addr_));
@@ -1919,7 +1918,7 @@ int ObTablet::deserialize(
           offset + (size - desc.length_),
           desc.length_,
           ObMetaDiskAddr::DiskType::RAW_BLOCK))) {
-      } else {
+      } else if (len - new_pos >= desc.length_) {
         ObTabletMacroInfo *tablet_macro_info = nullptr;
         int64_t macro_info_size = 0;
         if (OB_FAIL(deserialize_macro_info(


### PR DESCRIPTION
## Task Description
DBMS_STATS internal SQL can request a Degree of Parallelism (DOP) higher than `parallel_servers_target`. The existing PX admission path would wait unless the complete request could be satisfied or no PX query was running. Under sustained concurrent PX traffic, smaller requests could repeatedly consume released workers and delay the large request until query timeout.

## Solution Description
Determine the admitted worker count once before execution from the currently available PX quota. Pass the plan's minimum worker count into the target monitor, admit `min(requested, available)` workers when that count satisfies the minimum, and otherwise keep waiting. Existing DFO assignment proportionally downgrades the query to the admitted count, and the worker count remains fixed for that execution.

## Passed Regressions
- `./build.sh release --init`
- `ob-make ob_sql`
- `git diff --check`

## Upgrade Compatibility
No schema, configuration, or external API compatibility impact. The change only adjusts the internal PX admission decision.

## Other Information
This MR contains one commit: `076ad53ea7d`. The local untracked file named `2` is unrelated and is not included.

## Release Note
