### PR TITLE
fix(vector): use legacy VSAG serialization format

### DIFF
--- a/src/oblib/lib/vector/ob_vsag_adaptor.cpp
+++ b/src/oblib/lib/vector/ob_vsag_adaptor.cpp
@@ -618,6 +618,8 @@ int construct_vsag_create_param(
     break;
   }
   }
+  // ObIStreamBuf only supports seeking within the current callback buffer, while
+  // VSAG's new format seeks to the footer. Keep the legacy format until global seek is supported.
   int64_t pos = 0;
   int64_t buff_size = 0;
   if (OB_FAIL(databuff_printf(result_param_str, buf_len, pos, "{\"dim\":%d",
@@ -634,7 +636,7 @@ int construct_vsag_create_param(
                                  extra_info_size))) {
     LOG_WARN("failed to fill result_param_str", K(ret), K(extra_info_size));
   } else if (OB_FAIL(databuff_printf(result_param_str, buf_len, pos,
-                                 ",\"use_old_serial_format\":false"))) {
+                                 ",\"use_old_serial_format\":true"))) {
   } else if (OB_FAIL(databuff_printf(result_param_str, buf_len, pos,
                                      ",\"%s\":{",
                                      index_type_str))) {


### PR DESCRIPTION
## Task Description
This change addresses an issue introduced by a previous commit that removed unsupported distributed features. The fix ensures compatibility by reverting to the legacy VSAG serialization format for vector data.

## Solution Description
The implementation involves modifying the vector serialization logic to use the previous (legacy) format for VSAG (Vector Storage and Access Graph) instead of the new format introduced in the problematic commit. This rollback restores functionality that was broken by the removal of unsupported distributed features.

## Passed Regressions

## Upgrade Compatibility

## Other Information
- Issue introduced by commit: f7387fb2520509b3772d57cb0d9d51b47fe2d3f0 ("refactor: remove unsupported distributed features")
- Related internal link: [DIMA-2026081100118155873](https://project.alipay.com/workItem?workItemId=2026081100118155873)

## Release Note
Fix: Restored compatibility by using the legacy VSAG serialization format for vector data, addressing a regression introduced when removing unsupported distributed features.