### PR TITLE
[seekdb][tx] Keep commit retry task after accepted request

### DIFF
--- a/src/storage/tx/ob_trans_service_v4.cpp
+++ b/src/storage/tx/ob_trans_service_v4.cpp
@@ -174,10 +174,15 @@ int ObTransService::do_commit_tx_slowpath_(ObTxDesc &tx)
                                              tx.op_sn_,
                                              tx.commit_start_scn_,
                                              commit_version);
-  if (OB_SUCCESS == commit_ret) {
-    ++tx.commit_times_;
-  } else if (commit_need_retry_(commit_ret)) {
-    if (OB_FAIL(register_commit_retry_task_(tx, POST_COMMIT_REQ_RETRY_INTERVAL))) {
+  const bool request_accepted = OB_SUCCESS == commit_ret;
+  if (request_accepted || commit_need_retry_(commit_ret)) {
+    if (request_accepted) {
+      ++tx.commit_times_;
+    }
+    const int64_t max_delay = request_accepted
+        ? INT64_MAX
+        : POST_COMMIT_REQ_RETRY_INTERVAL;
+    if (OB_FAIL(register_commit_retry_task_(tx, max_delay))) {
     }
   } else {
     ret = handle_tx_commit_result_(tx, commit_ret, commit_version);


### PR DESCRIPTION
## Task Description
The issue was introduced by commit `8e2b24ff01af`, which stopped the commit retry scheduler from waiting for the final asynchronous callback after an initial commit request was accepted.

## Solution Description

## Passed Regressions

## Upgrade Compatibility

## Other Information
- Related links:
  - [DIMA-2026081100118160123](https://project.alipay.com/workItem?workItemId=2026081100118160123)

## Release Note