### PR TITLE
storage: defer tablet macro info loading for truncated metadata

### DIFF
--- a/src/storage/tablet/ob_tablet.cpp
+++ b/src/storage/tablet/ob_tablet.cpp
@@ -1723,9 +1723,6 @@ int ObTablet::load_deserialize_current(
     if (OB_UNLIKELY(ObSecondaryMetaType::TABLET_MACRO_INFO != desc.type_ || desc.length_ <= 0)) {
       ret = OB_DESERIALIZE_ERROR;
       LOG_WARN("invalid inline tablet macro info descriptor", K(ret), K(desc));
-    } else if (OB_UNLIKELY(len - new_pos < desc.length_)) {
-      ret = OB_DESERIALIZE_ERROR;
-      LOG_WARN("buffer is not enough for inline tablet macro info", K(ret), K(len), K(new_pos), K(desc));
     } else if (OB_UNLIKELY(!tablet_addr_.is_valid() || !tablet_addr_.is_block())) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("tablet address is invalid", K(ret), K(tablet_addr_));
@@ -1733,16 +1730,21 @@ int ObTablet::load_deserialize_current(
     } else if (OB_UNLIKELY(size < desc.length_)) {
       ret = OB_DESERIALIZE_ERROR;
       LOG_WARN("tablet block is smaller than inline tablet macro info", K(ret), K(size), K(desc));
-    } else if (OB_FAIL(deserialize_macro_info(
-        allocator, buf, new_pos + desc.length_, new_pos, macro_info_addr_.ptr_))) {
-    } else if (OB_UNLIKELY(new_pos - secondary_meta_pos != desc.length_)) {
-      ret = OB_DESERIALIZE_ERROR;
-      LOG_WARN("inline tablet macro info length mismatch", K(ret), K(new_pos), K(secondary_meta_pos), K(desc));
     } else if (OB_FAIL(macro_info_addr_.addr_.set_block_addr(
         macro_id,
         offset + (size - desc.length_),
         desc.length_,
         ObMetaDiskAddr::DiskType::RAW_BLOCK))) {
+    } else if (len - new_pos >= desc.length_) {
+      // The first-level tablet load intentionally reads only a prefix of a RAW_BLOCK. Keep the
+      // address so macro info can be loaded lazily when the prefix does not contain the inline
+      // bytes in full.
+      if (OB_FAIL(deserialize_macro_info(
+          allocator, buf, new_pos + desc.length_, new_pos, macro_info_addr_.ptr_))) {
+      } else if (OB_UNLIKELY(new_pos - secondary_meta_pos != desc.length_)) {
+        ret = OB_DESERIALIZE_ERROR;
+        LOG_WARN("inline tablet macro info length mismatch", K(ret), K(new_pos), K(secondary_meta_pos), K(desc));
+      }
     }
   }
 
@@ -1904,9 +1906,6 @@ int ObTablet::deserialize(
       if (OB_UNLIKELY(ObSecondaryMetaType::TABLET_MACRO_INFO != desc.type_ || desc.length_ <= 0)) {
         ret = OB_DESERIALIZE_ERROR;
         LOG_WARN("invalid inline tablet macro info descriptor", K(ret), K(desc));
-      } else if (OB_UNLIKELY(len - new_pos < desc.length_)) {
-        ret = OB_DESERIALIZE_ERROR;
-        LOG_WARN("buffer is not enough for inline tablet macro info", K(ret), K(len), K(new_pos), K(desc));
       } else if (OB_UNLIKELY(!tablet_addr_.is_valid() || !tablet_addr_.is_block())) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("tablet address is invalid", K(ret), K(tablet_addr_));
@@ -1919,7 +1918,7 @@ int ObTablet::deserialize(
           offset + (size - desc.length_),
           desc.length_,
           ObMetaDiskAddr::DiskType::RAW_BLOCK))) {
-      } else {
+      } else if (len - new_pos >= desc.length_) {
         ObTabletMacroInfo *tablet_macro_info = nullptr;
         int64_t macro_info_size = 0;
         if (OB_FAIL(deserialize_macro_info(


### PR DESCRIPTION
## Task Description
Defer the loading of tablet macro information for truncated metadata to optimize performance.

## Solution Description
Modified the storage layer logic to postpone the loading of macro block information associated with truncated tablet metadata until it is actually required, rather than loading it eagerly during initialization or certain operations.

## Passed Regressions

## Upgrade Compatibility

## Other Information
- **Related Issue:** [DIMA-2026081200118181890](https://project.alipay.com/workItem?workItemId=2026081200118181890)

## Release Note
Performance optimization: Tablet macro information for truncated metadata is now loaded lazily, improving startup and operational performance in scenarios with significant metadata truncation.