### PR TITLE
fix Windows weak symbol handling for clang-cl

### DIFF
--- a/src/oblib/lib/utility/ob_macro_utils.h
+++ b/src/oblib/lib/utility/ob_macro_utils.h
@@ -17,7 +17,7 @@
 #ifndef _OB_MACRO_UTILS_H_
 #define _OB_MACRO_UTILS_H_
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__clang__)
 #define OB_WEAK_SYMBOL
 #else
 #define OB_WEAK_SYMBOL __attribute__((weak))


### PR DESCRIPTION
### Task Description

On Windows clang-cl builds, `OB_WEAK_SYMBOL` was expanded to an empty macro for every `_WIN32` compiler. This turned weak fallback implementations and their strong server implementations into duplicate strong symbols. With `/FORCE:MULTIPLE`, link order could select the fallback implementation.

For `create_inner_sql_connection_for_proxy`, selecting the fallback returned `OB_NOT_SUPPORTED` during standalone seekDB bootstrap and caused startup to fail at STEP 3.2.

### Solution Description

Keep the empty `OB_WEAK_SYMBOL` definition for non-Clang Windows compilers, while allowing clang-cl to use its supported `__attribute__((weak))` implementation.

This restores weak/strong symbol selection without changing link order or adding a one-off workaround for the inner-SQL function.

### Passed Regressions

- Windows release build completed with Ninja `-j 8`; a canonical rerun returned `no work to do` with exit code 0.
- Object-symbol audit confirmed the inner-SQL fallback is weak (`W`) and the observer implementation is strong (`T`). The same weak/strong selection was confirmed for the CPU, futex, abort, logging, and request-finish hooks present in the Windows build.
- A clean-base Windows seekDB instance passed bootstrap, listener, version, database, and basic SQL checks.
- An 8-thread smoke completed 400/400 queries successfully.
- Linux PowerContext against the Windows seekDB server passed the default CI-equivalent scope: 7/7 collect-all cases and 3/3 fail-fast reruns, with 70/70 evaluator assertions passing.

### Upgrade Compatibility

No SQL protocol, persisted data, configuration, ABI, or object-layout change is introduced. MSVC behavior remains unchanged, and non-Windows builds continue using the existing weak attribute.

### Other Information

`OB_WEAK_SYMBOL` is used by 34 declarations or definitions in the release branch. The global macro correction intentionally restores the designed override semantics for all clang-cl weak hooks instead of relying on link order for one symbol.

### Release Note

Fix Windows clang-cl builds selecting weak fallback implementations instead of the corresponding seekDB server implementations.
