### PR TITLE
chore: remove internal-only deps blocks from deps/init

### DIFF
--- a/deps/init/oceanbase.al8.aarch64.deps
+++ b/deps/init/oceanbase.al8.aarch64.deps
@@ -37,21 +37,12 @@ obdevtools-cmake-3.22.1-122024092710.al8.aarch64.rpm
 obdevtools-flex-2.5.35-42024092621.al8.aarch64.rpm
 obdevtools-gcc-12.3.0-32024122017.al8.aarch64.rpm
 obdevtools-llvm-17.0.6-202026032415.al8.aarch64.rpm
-#RANGE_IF_BUSINESS
-ob-sanity-1.0.0-182026021018.al8.aarch64.rpm
-#RANGE_END
 
 [tools-deps]
 obshell-4.4.1.1-32026031914.al8.aarch64.rpm target=community
 #obshell-4.5.0.0-12026050816.al8.aarch64.rpm target=community
 
 [test-utils]
-#RANGE_IF_BUSINESS
-ob-deploy-4.1.x-190.al8.aarch64.rpm target=test
-obclient-2.2.3-202024102217.al8.aarch64.rpm
-libobclient-2.2.3-152024102213.al8.aarch64.rpm
-#RANGE_ELSE
-#ob-deploy-4.1.0-2.al8.aarch64.rpm target=community
-#obclient-2.2.3-202024102217.al8.aarch64.rpm target=community
-#libobclient-2.2.3-152024102213.al8.aarch64.rpm target=community
-#RANGE_END
+ob-deploy-4.1.0-2.al8.aarch64.rpm target=community
+obclient-2.2.3-202024102217.al8.aarch64.rpm target=community
+libobclient-2.2.3-152024102213.al8.aarch64.rpm target=community

--- a/deps/init/oceanbase.al8.x86_64.deps
+++ b/deps/init/oceanbase.al8.x86_64.deps
@@ -38,21 +38,12 @@ obdevtools-cmake-3.22.1-122024092710.al8.x86_64.rpm
 obdevtools-flex-2.5.35-42024092621.al8.x86_64.rpm
 obdevtools-gcc-12.3.0-32024122017.al8.x86_64.rpm
 obdevtools-llvm-17.0.6-202026032415.al8.x86_64.rpm
-#RANGE_IF_BUSINESS
-ob-sanity-1.0.0-182026021018.al8.x86_64.rpm
-#RANGE_END
 
 [tools-deps]
 obshell-4.4.1.1-32026031914.al8.x86_64.rpm target=community
 #obshell-4.5.0.0-12026050816.al8.x86_64.rpm target=community
 
 [test-utils]
-#RANGE_IF_BUSINESS
-ob-deploy-4.1.x-190.al8.x86_64.rpm target=test
-obclient-2.2.3-202024102217.al8.x86_64.rpm
-libobclient-2.2.3-152024102213.al8.x86_64.rpm
-#RANGE_ELSE
-#ob-deploy-4.1.0-2.al8.x86_64.rpm target=community
-#obclient-2.2.3-202024102217.al8.x86_64.rpm target=community
-#libobclient-2.2.3-152024102213.al8.x86_64.rpm target=community
-#RANGE_END
+ob-deploy-4.1.0-2.al8.x86_64.rpm target=community
+obclient-2.2.3-202024102217.al8.x86_64.rpm target=community
+libobclient-2.2.3-152024102213.al8.x86_64.rpm target=community

--- a/deps/init/oceanbase.el7.aarch64.deps
+++ b/deps/init/oceanbase.el7.aarch64.deps
@@ -8,17 +8,6 @@ os=7
 arch=aarch64
 repo=http://mirrors.oceanbase.com/oceanbase/community/stable/el/7/aarch64/
 
-#RANGE_IF_BUSINESS
-[target-obdeploy]
-os=7
-arch=aarch64
-repo=https://ob-yum.oceanbase-dev.com/7/aarch64/test/ob-deploy/
-
-[target-obshell]
-os=7
-arch=aarch64
-repo=https://ob-yum.oceanbase-dev.com/7/aarch64/test/obshell/
-#RANGE_END
 
 [deps]
 devdeps-gtest-1.8.0-312026021311.el7.aarch64.rpm
@@ -49,21 +38,12 @@ obdevtools-cmake-3.30.3-52024111819.el7.aarch64.rpm
 obdevtools-flex-2.5.35-12022100417.el7.aarch64.rpm
 obdevtools-gcc-12.3.0-32024122017.el7.aarch64.rpm
 obdevtools-llvm-17.0.6-202026032415.el7.aarch64.rpm
-#RANGE_IF_BUSINESS
-ob-sanity-1.0.0-182026021018.el7.aarch64.rpm
-#RANGE_END
 
 [tools-deps]
 obshell-4.4.1.1-32026031914.el7.aarch64.rpm target=community
 #obshell-4.5.0.0-12026050816.el7.aarch64.rpm target=community
 
 [test-utils]
-#RANGE_IF_BUSINESS
-ob-deploy-4.1.x-190.el7.aarch64.rpm target=obdeploy
-obclient-2.2.3-20230515141610.el7.aarch64.rpm
-libobclient-2.2.3-20230512140006.el7.aarch64.rpm
-#RANGE_ELSE
-#ob-deploy-4.1.0-2.el7.aarch64.rpm target=community
-#obclient-2.2.2-1.el7.aarch64.rpm target=community
-#libobclient-2.2.2-3.el7.aarch64.rpm target=community
-#RANGE_END
+ob-deploy-4.1.0-2.el7.aarch64.rpm target=community
+obclient-2.2.2-1.el7.aarch64.rpm target=community
+libobclient-2.2.2-3.el7.aarch64.rpm target=community

--- a/deps/init/oceanbase.el7.x86_64.deps
+++ b/deps/init/oceanbase.el7.x86_64.deps
@@ -3,29 +3,12 @@ os=7
 arch=x86_64
 repo=http://mirrors.oceanbase.com/oceanbase/development-kit/el/7/x86_64/
 
-#RANGE_IF_BUSINESS
-[target-tbsite]
-os=7
-arch=x86_64
-repo=http://yum.tbsite.net/taobao/7/x86_64/test/ob-deploy/
-
-[target-obdeploy]
-os=7
-arch=x86_64
-repo=https://ob-yum.oceanbase-dev.com/7/x86_64/test/ob-deploy/
-#RANGE_END
 
 [target-community]
 os=7
 arch=x86_64
 repo=http://mirrors.oceanbase.com/oceanbase/community/stable/el/7/x86_64/
 
-#RANGE_IF_BUSINESS
-[target-obshell]
-os=7
-arch=x86_64
-repo=https://ob-yum.oceanbase-dev.com/7/x86_64/test/obshell/
-#RANGE_END
 
 [deps]
 devdeps-gtest-1.8.0-312026021311.el7.x86_64.rpm
@@ -57,21 +40,12 @@ obdevtools-cmake-3.30.3-52024111819.el7.x86_64.rpm
 obdevtools-flex-2.5.35-12022100417.el7.x86_64.rpm
 obdevtools-gcc-12.3.0-32024122017.el7.x86_64.rpm
 obdevtools-llvm-17.0.6-202026032415.el7.x86_64.rpm
-#RANGE_IF_BUSINESS
-ob-sanity-1.0.0-182026021018.el7.x86_64.rpm
-#RANGE_END
 
 [tools-deps]
 obshell-4.4.1.1-32026031914.el7.x86_64.rpm target=community
 #obshell-4.5.0.0-12026050816.el7.x86_64.rpm target=community
 
 [test-utils]
-#RANGE_IF_BUSINESS
-ob-deploy-4.1.x-190.el7.x86_64.rpm target=obdeploy
-obclient-2.2.3-20230515141610.el7.x86_64.rpm
-libobclient-2.2.3-20230512140006.el7.x86_64.rpm
-#RANGE_ELSE
-#ob-deploy-4.1.0-2.el7.x86_64.rpm target=community
-#obclient-2.2.2-1.el7.x86_64.rpm target=community
-#libobclient-2.2.2-3.el7.x86_64.rpm target=community
-#RANGE_END
+ob-deploy-4.1.0-2.el7.x86_64.rpm target=community
+obclient-2.2.2-1.el7.x86_64.rpm target=community
+libobclient-2.2.2-3.el7.x86_64.rpm target=community

--- a/deps/init/oceanbase.el8.aarch64.deps
+++ b/deps/init/oceanbase.el8.aarch64.deps
@@ -8,17 +8,6 @@ os=8
 arch=aarch64
 repo=http://mirrors.oceanbase.com/oceanbase/community/stable/el/8/aarch64/
 
-#RANGE_IF_BUSINESS
-[target-obshell]
-os=8
-arch=aarch64
-repo=https://ob-yum.oceanbase-dev.com/8/aarch64/test/obshell/
-
-[target-obdeploy]
-os=8
-arch=aarch64
-repo=https://ob-yum.oceanbase-dev.com/8/aarch64/test/ob-deploy/
-#RANGE_END
 
 [deps]
 devdeps-gtest-1.8.0-312026021311.el8.aarch64.rpm
@@ -55,11 +44,6 @@ obshell-4.4.1.1-32026031914.el8.aarch64.rpm target=community
 #obshell-4.5.0.0-12026050816.el8.aarch64.rpm target=community
 
 [test-utils]
-#RANGE_IF_BUSINESS
-ob-deploy-4.1.x-190.el8.aarch64.rpm target=obshell
-obclient-2.0.2-3.el8.aarch64.rpm target=community
-#RANGE_ELSE
-#ob-deploy-4.1.0-2.el8.aarch64.rpm target=community
-#obclient-2.2.2-1.el8.aarch64.rpm target=community
-#libobclient-2.2.2-3.el8.aarch64.rpm target=community
-#RANGE_END
+ob-deploy-4.1.0-2.el8.aarch64.rpm target=community
+obclient-2.2.2-1.el8.aarch64.rpm target=community
+libobclient-2.2.2-3.el8.aarch64.rpm target=community

--- a/deps/init/oceanbase.el8.x86_64.deps
+++ b/deps/init/oceanbase.el8.x86_64.deps
@@ -8,17 +8,6 @@ os=8
 arch=x86_64
 repo=http://mirrors.oceanbase.com/oceanbase/community/stable/el/8/x86_64/
 
-#RANGE_IF_BUSINESS
-[target-obshell]
-os=8
-arch=x86_64
-repo=https://ob-yum.oceanbase-dev.com/8/x86_64/test/obshell/
-
-[target-obdeploy]
-os=8
-arch=x86_64
-repo=https://ob-yum.oceanbase-dev.com/8/x86_64/test/ob-deploy/
-#RANGE_END
 
 [deps]
 devdeps-gtest-1.8.0-312026021311.el8.x86_64.rpm
@@ -56,11 +45,6 @@ obshell-4.4.1.1-32026031914.el8.x86_64.rpm target=community
 #obshell-4.5.0.0-12026050816.el8.x86_64.rpm target=community
 
 [test-utils]
-#RANGE_IF_BUSINESS
-ob-deploy-4.1.x-190.el8.x86_64.rpm target=obshell
-obclient-2.0.2-3.el8.x86_64.rpm target=community
-#RANGE_ELSE
-#ob-deploy-4.1.0-2.el8.x86_64.rpm target=community
-#obclient-2.2.2-1.el8.x86_64.rpm target=community
-#libobclient-2.2.2-3.el8.x86_64.rpm target=community
-#RANGE_END
+ob-deploy-4.1.0-2.el8.x86_64.rpm target=community
+obclient-2.2.2-1.el8.x86_64.rpm target=community
+libobclient-2.2.2-3.el8.x86_64.rpm target=community

--- a/deps/init/oceanbase.el9.aarch64.deps
+++ b/deps/init/oceanbase.el9.aarch64.deps
@@ -13,17 +13,6 @@ os=9
 arch=aarch64
 repo=http://mirrors.oceanbase.com/oceanbase/development-kit/el/9/aarch64/
 
-#RANGE_IF_BUSINESS
-[target-obshell]
-os=8
-arch=aarch64
-repo=https://ob-yum.oceanbase-dev.com/8/aarch64/test/obshell/
-
-[target-obdeploy]
-os=8
-arch=aarch64
-repo=https://ob-yum.oceanbase-dev.com/8/aarch64/test/ob-deploy/
-#RANGE_END
 
 [deps]
 devdeps-gtest-1.8.0-242026020914.el8.aarch64.rpm
@@ -62,14 +51,6 @@ obshell-4.4.1.1-32026031914.el8.aarch64.rpm target=community
 #obshell-4.5.0.0-12026050816.el8.aarch64.rpm target=community
 
 [test-utils]
+ob-deploy-4.1.0-2.el8.aarch64.rpm target=community
 obclient-2.2.2-1.el8.aarch64.rpm target=community
 libobclient-2.2.2-3.el8.aarch64.rpm target=community
-
-[test-utils]
-#RANGE_IF_BUSINESS
-ob-deploy-4.1.x-190.el8.aarch64.rpm target=obdeploy
-#RANGE_ELSE
-#ob-deploy-4.1.0-2.el8.aarch64.rpm target=community
-#obclient-2.2.2-1.el8.aarch64.rpm target=community
-#libobclient-2.2.2-3.el8.aarch64.rpm target=community
-#RANGE_END


### PR DESCRIPTION
## Summary
- Remove `#RANGE_IF_BUSINESS` guarded sections from `deps/init/*.deps` that reference internal repositories (ob-yum.oceanbase-dev.com, yum.tbsite.net) unavailable in the public space
- Keep community alternatives for test utilities where `#RANGE_ELSE` branches existed
- Affected platforms: el7, el8, al8, el9 (x86_64 and aarch64)

## Test plan
- [ ] CI passes on this PR

Related issue: [SEEK-498](https://antmultica.alipay.com/seekdb/issues/SEEK-498)

Made with [Cursor](https://cursor.com)