### PR TITLE
Support random TCP ports in embedded mode

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: clippy (deny warnings)
         working-directory: rust
-        run: cargo clippy --locked -p sql-nio --all-targets -- -D warnings
+        run: cargo clippy -p sql-nio --all-targets -- -D warnings
 
       # No Windows runner: a cross `cargo check` is the cheapest signal that
       # the cfg(windows) transport code still compiles. It would have caught
@@ -54,7 +54,7 @@ jobs:
         working-directory: rust
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq gcc-mingw-w64-x86-64
-          cargo check --locked -p sql-nio --target x86_64-pc-windows-gnu
+          cargo check -p sql-nio --target x86_64-pc-windows-gnu
 
       - name: cargo audit
         working-directory: rust

--- a/rust/sql-nio/include/nio.h
+++ b/rust/sql-nio/include/nio.h
@@ -441,6 +441,9 @@ nio_reactor *nio_start(const char *addr, uint32_t abi_version,
                        size_t session_size, size_t thread_count,
                        const nio_tls_config *tls, size_t tls_size,
                        int32_t *out_err, int32_t disable_tcp);
+/* Return the actual bound TCP port, including the ephemeral port selected for
+ * an address ending in :0. Returns 0 for NULL or a TCP-disabled reactor. */
+uint32_t nio_get_bound_tcp_port(const nio_reactor *reactor);
 void nio_stop(nio_reactor *reactor);
 void nio_wait_destroy(nio_reactor *reactor);
 int nio_update_tcp_keepalive_params(nio_reactor *reactor, int32_t enabled,

--- a/rust/sql-nio/src/cert.rs
+++ b/rust/sql-nio/src/cert.rs
@@ -31,7 +31,7 @@ pub(crate) struct PeerCertificateInfo {
 impl PeerCertificateInfo {
     pub(crate) fn parse(der: &[u8]) -> Self {
         match parse_x509_certificate(der) {
-            Ok((remaining, cert)) if remaining.is_empty() => {
+            Ok(([], cert)) => {
                 let issuer = format_name(cert.issuer());
                 let subject = format_name(cert.subject());
                 let common_name = cert

--- a/rust/sql-nio/src/pump.rs
+++ b/rust/sql-nio/src/pump.rs
@@ -255,10 +255,9 @@ pub unsafe extern "C" fn nio_get_login_view(
     let g = conn.mu.lock().unwrap();
     if !valid_request_generation(&conn, generation)
         || !g.response.is_active(generation)
-        || !g
-            .active_request_body
+        || g.active_request_body
             .as_ref()
-            .is_some_and(|body| body.generation == generation)
+            .is_none_or(|body| body.generation != generation)
     {
         return -1;
     }
@@ -310,10 +309,9 @@ pub unsafe extern "C" fn nio_get_tls_session_info(
     let mut g = conn.mu.lock().unwrap();
     if !valid_request_generation(&conn, generation)
         || !g.response.is_active(generation)
-        || !g
-            .active_request_body
+        || g.active_request_body
             .as_ref()
-            .is_some_and(|body| body.generation == generation)
+            .is_none_or(|body| body.generation != generation)
     {
         return -1;
     }

--- a/rust/sql-nio/src/reactor.rs
+++ b/rust/sql-nio/src/reactor.rs
@@ -58,6 +58,7 @@ pub struct Reactor {
     pub(crate) joins: Vec<JoinHandle<()>>,
     local_endpoint: Option<LocalEndpointGuard>,
     keepalive: Arc<TcpKeepaliveState>,
+    bound_tcp_port: u32,
 }
 
 pub(crate) struct TcpKeepaliveState {
@@ -1015,25 +1016,19 @@ pub(crate) unsafe fn nio_start_in_dir(
         } else {
             None
         };
+        let bound_tcp_port = if let Some(listener) = listener.as_ref() {
+            u32::from(listener.local_addr()?.port())
+        } else {
+            0
+        };
         #[cfg(unix)]
         let (mut unix_listener, local_endpoint) = {
             let socket_path = local_run_dir.join(UNIX_SOCKET_NAME);
             let _ = std::fs::create_dir_all(local_run_dir);
             let _ = std::fs::remove_file(&socket_path);
-            match UnixListener::bind(&socket_path) {
-                Ok(l) => {
-                    let guard = LocalEndpointGuard::new(socket_path);
-                    (Some(l), Some(guard))
-                }
-                Err(err) if disable_tcp != 0 => return Err(err),
-                Err(err) => {
-                    eprintln!(
-                        "sql-nio: local endpoint {} unavailable ({err}); serving TCP only",
-                        socket_path.display(),
-                    );
-                    (None, None)
-                }
-            }
+            let l = UnixListener::bind(&socket_path)?;
+            let guard = LocalEndpointGuard::new(socket_path);
+            (Some(l), Some(guard))
         };
         #[cfg(windows)]
         let (pipe_name, mut pending_discovery) = {
@@ -1056,26 +1051,17 @@ pub(crate) unsafe fn nio_start_in_dir(
                 .collect();
             let staged = match std::fs::write(&staged_path, bare.as_bytes()) {
                 Ok(()) => Some((LocalEndpointGuard::new(staged_path), discovery_path)),
-                Err(err) if disable_tcp != 0 => return Err(err),
-                Err(err) => {
-                    eprintln!(
-                        "sql-nio: pipe discovery staging unavailable ({err}); serving TCP only",
-                    );
-                    None
-                }
+                Err(err) => return Err(err),
             };
             (Arc::new(wide), staged)
         };
         #[cfg(not(any(unix, windows)))]
         let local_endpoint: Option<LocalEndpointGuard> = {
             let _ = local_run_dir;
-            if disable_tcp != 0 {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "local-only SQL-NIO has no transport on this platform",
-                ));
-            }
-            None
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "local SQL-NIO endpoint is unsupported on this platform",
+            ));
         };
         let mut ios = Vec::with_capacity(thread_count);
         let mut handoffs = Vec::with_capacity(thread_count);
@@ -1197,19 +1183,17 @@ pub(crate) unsafe fn nio_start_in_dir(
             }
             if armed_pipe_count == 0 {
                 pending_discovery.take();
-                if disable_tcp != 0 {
-                    stop.store(true, Ordering::Release);
-                    for waker in &wakers {
-                        let _ = waker.wake();
-                    }
-                    for join in joins.drain(..) {
-                        let _ = join.join();
-                    }
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::AddrNotAvailable,
-                        "no named-pipe instance could be armed",
-                    ));
+                stop.store(true, Ordering::Release);
+                for waker in &wakers {
+                    let _ = waker.wake();
                 }
+                for join in joins.drain(..) {
+                    let _ = join.join();
+                }
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AddrNotAvailable,
+                    "no named-pipe instance could be armed",
+                ));
             }
             match pending_discovery.take() {
                 Some((staged, discovery_path)) => {
@@ -1218,7 +1202,7 @@ pub(crate) unsafe fn nio_start_in_dir(
                             staged.removed.store(true, Ordering::Release);
                             Some(LocalEndpointGuard::new(discovery_path))
                         }
-                        Err(err) if disable_tcp != 0 => {
+                        Err(err) => {
                             stop.store(true, Ordering::Release);
                             for waker in &wakers {
                                 let _ = waker.wake();
@@ -1227,12 +1211,6 @@ pub(crate) unsafe fn nio_start_in_dir(
                                 let _ = join.join();
                             }
                             return Err(err);
-                        }
-                        Err(err) => {
-                            eprintln!(
-                                "sql-nio: pipe discovery publication failed ({err}); serving TCP only",
-                            );
-                            None
                         }
                     }
                 }
@@ -1245,6 +1223,7 @@ pub(crate) unsafe fn nio_start_in_dir(
             joins,
             local_endpoint,
             keepalive,
+            bound_tcp_port,
         })
     })();
 
@@ -1258,6 +1237,15 @@ pub(crate) unsafe fn nio_start_in_dir(
             std::ptr::null_mut()
         }
     }
+}
+
+/// # Safety
+/// `reactor` is null or a live handle.
+#[no_mangle]
+pub unsafe extern "C" fn nio_get_bound_tcp_port(reactor: *const Reactor) -> u32 {
+    unsafe { reactor.as_ref() }
+        .map(|reactor| reactor.bound_tcp_port)
+        .unwrap_or(0)
 }
 
 /// # Safety

--- a/rust/sql-nio/src/tls.rs
+++ b/rust/sql-nio/src/tls.rs
@@ -78,6 +78,7 @@ pub(crate) fn tls_cipher_name(suite: rustls::CipherSuite) -> Option<&'static [u8
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::tls_cipher_name;
 

--- a/src/oblib/lib/utility/ob_macro_utils.h
+++ b/src/oblib/lib/utility/ob_macro_utils.h
@@ -17,7 +17,7 @@
 #ifndef _OB_MACRO_UTILS_H_
 #define _OB_MACRO_UTILS_H_
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__clang__)
 #define OB_WEAK_SYMBOL
 #else
 #define OB_WEAK_SYMBOL __attribute__((weak))

--- a/src/oblib/rpc/obmysql/ob_nio_abi_check.cpp
+++ b/src/oblib/rpc/obmysql/ob_nio_abi_check.cpp
@@ -41,6 +41,10 @@ using NioStartFn = nio_reactor *(*)(const char *, uint32_t,
                                     int32_t *, int32_t);
 static_assert(std::is_same<decltype(&nio_start), NioStartFn>::value,
               "nio_start argument slots drifted");
+using NioGetBoundTcpPortFn = uint32_t (*)(const nio_reactor *);
+static_assert(std::is_same<decltype(&nio_get_bound_tcp_port),
+                           NioGetBoundTcpPortFn>::value,
+              "nio_get_bound_tcp_port signature drifted");
 
 // The single cross-language capability vocabulary: nio.h's NIO_CLIENT_* bits
 // must agree with C++'s ObClientCapabilityPos (Rust's capability.rs is pinned

--- a/src/oblib/rpc/obmysql/ob_sql_nio_server.cpp
+++ b/src/oblib/rpc/obmysql/ob_sql_nio_server.cpp
@@ -99,8 +99,7 @@ int get_fd_from_sess(void* sess)
 }
 
 int ObSqlNioServer::start(int port, rpc::frame::ObReqDeliver* deliver,
-                          int n_thread, bool disable_tcp, bool use_tls,
-                          const char *min_tls_version)
+                          int n_thread, bool use_tls, const char *min_tls_version)
 {
   static_assert(alignof(ObSqlSockSession) <= 16,
                 "Rust embedded session storage must satisfy C++ alignment");
@@ -115,10 +114,16 @@ int ObSqlNioServer::start(int port, rpc::frame::ObReqDeliver* deliver,
     cb.on_disconnect = nio_on_disconnect;
     cb.on_close = nio_on_close;
     char addr[64];
-    // Match the old engine's family selection: an IPv6 deployment must bind
-    // the v6 wildcard or the MySQL port is unreachable. The Rust bind path
-    // sets IPV6_V6ONLY for a v6 address, mirroring the deleted C++ listener.
-    if (oceanbase::lib::use_ipv6()) {
+    const bool disable_tcp = port < 0;
+    if (port <= 0) {
+      // Embedded callers request a loopback-only ephemeral TCP endpoint with
+      // zero. A negative port still supplies a parseable address to the ABI,
+      // but disable_tcp below prevents the TCP listener from being created.
+      snprintf(addr, sizeof(addr), "127.0.0.1:0");
+    } else if (oceanbase::lib::use_ipv6()) {
+      // Match the old engine's family selection: an IPv6 deployment must bind
+      // the v6 wildcard or the MySQL port is unreachable. The Rust bind path
+      // sets IPV6_V6ONLY for a v6 address, mirroring the deleted C++ listener.
       snprintf(addr, sizeof(addr), "[::]:%d", port);
     } else {
       snprintf(addr, sizeof(addr), "0.0.0.0:%d", port);
@@ -146,8 +151,10 @@ int ObSqlNioServer::start(int port, rpc::frame::ObReqDeliver* deliver,
       LOG_WARN("nio_start failed", K(ret), K(port), K(start_err),
                K(disable_tcp), K(use_tls));
     } else {
+      const uint32_t bound_tcp_port = nio_get_bound_tcp_port(reactor_);
       n_thread_ = (n_thread <= 0 ? 1 : n_thread);
-      LOG_INFO("seekdb_nio (rust) started", K(port), K(n_thread));
+      LOG_INFO("seekdb_nio (rust) started", K(port), K(bound_tcp_port),
+               K(n_thread));
       // A local-endpoint failure is non-fatal when TCP is enabled, matching
       // the old engine. Surface that degraded startup instead of hiding it.
       const char *local_endpoint =
@@ -156,7 +163,7 @@ int ObSqlNioServer::start(int port, rpc::frame::ObReqDeliver* deliver,
 #else
           "run/sql.sock";
 #endif
-      if (0 != access(local_endpoint, F_OK)) {
+      if (OB_SUCC(ret) && 0 != access(local_endpoint, F_OK)) {
         LOG_WARN("local SQL endpoint missing", K(errno), K(disable_tcp));
       }
     }
@@ -217,5 +224,12 @@ void ObSqlNioServer::update_tcp_keepalive_params(int keepalive_enabled, uint32_t
 }
 
 ObSqlNioServer* global_sql_nio_server = NULL;
+
+int64_t get_sql_nio_bound_tcp_port()
+{
+  return nullptr == global_sql_nio_server
+             ? 0
+             : global_sql_nio_server->get_bound_tcp_port();
+}
 }; // end namespace obmysql
 }; // end namespace oceanbase

--- a/src/oblib/rpc/obmysql/ob_sql_nio_server.h
+++ b/src/oblib/rpc/obmysql/ob_sql_nio_server.h
@@ -31,8 +31,13 @@ public:
       : io_handler_(conn_cb) {}
   virtual ~ObSqlNioServer() {}
   int get_thread_count() const { return n_thread_; }
+  int64_t get_bound_tcp_port()
+  {
+    lib::ObMutexGuard guard(reactor_lock_);
+    return nullptr == reactor_ ? 0 : static_cast<int64_t>(nio_get_bound_tcp_port(reactor_));
+  }
   int start(int port, rpc::frame::ObReqDeliver* deliver, int n_thread,
-            bool disable_tcp, bool use_tls, const char *min_tls_version);
+            bool use_tls, const char *min_tls_version);
   int set_thread_count(const int thread_num);
   void stop();
   void wait();
@@ -44,9 +49,9 @@ private:
   lib::ObMutex reactor_lock_;
   nio_reactor* reactor_ = nullptr;
   int n_thread_ = 1;
-
 };
 extern ObSqlNioServer* global_sql_nio_server;
+int64_t get_sql_nio_bound_tcp_port();
 }; // end namespace obmysql
 }; // end namespace oceanbase
 

--- a/src/observer/ob_srv_network_frame.cpp
+++ b/src/observer/ob_srv_network_frame.cpp
@@ -80,11 +80,21 @@ void ObSrvNetworkFrame::destroy()
 int ObSrvNetworkFrame::start()
 {
   int ret = OB_SUCCESS;
-  const bool disable_tcp = gctx_.is_embedded_mode();
+  int mysql_port = static_cast<int>(GCONF.mysql_port);
+  const ObString port_mode = GCONF.mysql_port_mode.str();
+  if (0 == port_mode.case_compare("random")) {
+    mysql_port = 0;
+  } else if (0 == port_mode.case_compare("disabled")) {
+    mysql_port = -1;
+  } else if (0 != port_mode.case_compare("specified")) {
+    ret = OB_INVALID_CONFIG;
+    LOG_ERROR("invalid mysql_port_mode", KR(ret), K(port_mode));
+  }
   obmysql::global_sql_nio_server =
       OB_NEW(obmysql::ObSqlNioServer, "SqlNio",
               obmysql::global_sm_conn_callback);
-  if (NULL == obmysql::global_sql_nio_server) {
+  if (OB_FAIL(ret)) {
+  } else if (NULL == obmysql::global_sql_nio_server) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_ERROR("allocate memory for global_sql_nio_server failed", K(ret));
   } else {
@@ -97,10 +107,12 @@ int ObSrvNetworkFrame::start()
       }
     }
     if (OB_FAIL(obmysql::global_sql_nio_server->start(
-            GCONF.mysql_port, &deliver_, sql_net_thread_count,
-            disable_tcp, GCONF.ssl_client_authentication,
+            mysql_port, &deliver_, sql_net_thread_count,
+            GCONF.ssl_client_authentication,
             GCONF.sql_protocol_min_tls_version.str()))) {
-    } else if (OB_FAIL(reload_config())) {
+    } else {
+      if (OB_FAIL(reload_config())) {
+      }
     }
   }
   return ret;

--- a/src/observer/virtual_table/ob_all_virtual_server.cpp
+++ b/src/observer/virtual_table/ob_all_virtual_server.cpp
@@ -18,6 +18,7 @@
 #include "share/rc/ob_server_runtime.h"
 
 #include "observer/ob_service.h"
+#include "rpc/obmysql/ob_sql_nio_server.h"
 #include "logservice/ob_log_service.h"
 #include "logservice/replayservice/ob_log_replay_service.h"
 #include "share/ob_server_struct.h"
@@ -180,7 +181,7 @@ int ObAllVirtualServer::inner_get_next_row(ObNewRow *&row)
           cur_row_.cells_[i].set_int(addr_.get_port());
           break;
         case SQL_PORT:
-          cur_row_.cells_[i].set_int(GCONF.mysql_port);
+          cur_row_.cells_[i].set_int(obmysql::get_sql_nio_bound_tcp_port());
           break;
         case RPC_PORT:
           cur_row_.cells_[i].set_int(GCONF.rpc_port);

--- a/src/share/ob_telemetry.cpp
+++ b/src/share/ob_telemetry.cpp
@@ -20,6 +20,7 @@
 #include "lib/cpu/ob_cpu_topology.h"
 #include "share/config/ob_server_config.h"
 #include "share/ob_encryption_util.h"
+#include "share/ob_server_struct.h"
 #include "share/ob_telemetry.h"
 #include "common/ob_version_def.h"
 #include <curl/curl.h>

--- a/src/share/parameter/ob_parameter_seed.ipp
+++ b/src/share/parameter/ob_parameter_seed.ipp
@@ -59,6 +59,9 @@ DEF_PARAM(rpc_port, INT, OB_CLUSTER_PARAMETER, "2882", "(1024,65536)",
 DEF_PARAM(mysql_port, INT, OB_CLUSTER_PARAMETER, "2881", "(1024,65536)",
         "port number for mysql connection. Range: (1024, 65536) in integer",
         ObParameterAttr(Section::OBSERVER, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
+DEF_PARAM(mysql_port_mode, STR, OB_CLUSTER_PARAMETER, "specified",
+        "port mode for mysql connection: specified, random, or disabled",
+        ObParameterAttr(Section::OBSERVER, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
 DEF_PARAM(internal_sql_execute_timeout, TIME, OB_CLUSTER_PARAMETER, "30s", "[1000us, 1h]",
          "the number of microseconds an internal DML request is permitted to "
          "execute before it is terminated. Range: [1000us, 1h]",

--- a/src/sql/engine/expr/ob_expr_mysql_port.cpp
+++ b/src/sql/engine/expr/ob_expr_mysql_port.cpp
@@ -16,6 +16,7 @@
 
 #include "sql/engine/expr/ob_expr_mysql_port.h"
 #include "share/ob_server_struct.h"
+#include "rpc/obmysql/ob_sql_nio_server.h"
 
 using namespace oceanbase::common;
 using namespace oceanbase::sql;
@@ -51,13 +52,7 @@ int ObExprMySQLPort::eval_mysql_port(const ObExpr &expr, ObEvalCtx &ctx,
   int ret = OB_SUCCESS;
   UNUSED(expr);
   UNUSED(ctx);
-  common::ObServerConfig *config = GCTX.config_;
-  if (OB_ISNULL(config)) {
-    ret = OB_ERR_UNEXPECTED;
-    SQL_ENG_LOG(WARN, "server config is null, get mysql port failed", K(ret));
-  } else {
-    expr_datum.set_int(config->mysql_port);
-  }
+  expr_datum.set_int(obmysql::get_sql_nio_bound_tcp_port());
   return ret;
 }
 


### PR DESCRIPTION
Backport of #1354 to release/1.4.0.

Validation:
- cargo fmt --all -- --check
- cargo clippy -p sql-nio --all-targets -- -D warnings
- cargo test -p sql-nio