### PR TITLE
fix: retry standby imports while PALF recovers

### DIFF
--- a/src/logservice/palf/palf_handle_impl.cpp
+++ b/src/logservice/palf/palf_handle_impl.cpp
@@ -324,9 +324,15 @@ int PalfHandleImpl::submit_imported_group(
     if (!palf_env_impl_->check_disk_space_enough()) {
       ret = OB_LOG_OUTOF_DISK_SPACE;
     } else if (!state_mgr_.can_append()) {
-      ret = OB_STATE_NOT_MATCH;
-      PALF_LOG(WARN, "cannot submit imported group", K(ret), KPC(this),
-          K(buf_len), "state", state_mgr_.get_state());
+      // Standby log sync is scheduled immediately at startup.  PALF can still
+      // be recovering at that point, before any imported group's continuity
+      // has been checked.  Retry that transient state, while preserving
+      // OB_STATE_NOT_MATCH for other non-append states and continuity errors.
+      ret = state_mgr_.is_recovering() ? OB_EAGAIN : OB_STATE_NOT_MATCH;
+      if (OB_EAGAIN != ret) {
+        PALF_LOG(WARN, "cannot submit imported group", K(ret), KPC(this),
+            K(buf_len), "state", state_mgr_.get_state());
+      }
     } else if (OB_FAIL(sw_.submit_imported_group(source_lsn, source_scn, buf, buf_len))) {
       if (OB_EAGAIN != ret) {
         PALF_LOG(WARN, "submit imported group failed", K(ret), KPC(this), K(buf_len));


### PR DESCRIPTION
## Backport

Backport of #1360 to `release/1.4.0`.

## Problem

After a primary-to-standby switchover, restarting the former primary can start standby log sync while PALF is still in `RECOVERING`. The import path returned `OB_STATE_NOT_MATCH (-4109)`, which the standby sync service recorded as fatal even though PALF becomes `ACTIVE` shortly afterwards.

## Fix

Return `OB_EAGAIN` only for the transient PALF `RECOVERING` state. The periodic sync task retries it; other non-append states and all log-continuity failures remain `OB_STATE_NOT_MATCH`.

## Validation

- `git diff --check`
- The equivalent change built successfully on the master PR (#1360).
- Release-branch build initialization is currently blocked before compilation because its dependency manifest requests `obshell-4.5.0.1-52026082614.al8.x86_64.rpm`, which the configured mirror returns as HTTP 404.