### PR TITLE
refactor(sql): manage SQL plan lifetime with session references

### DIFF
--- a/src/observer/mysql/obmp_auth_response.cpp
+++ b/src/observer/mysql/obmp_auth_response.cpp
@@ -47,6 +47,8 @@ int ObMPAuthResponse::process()
   } else if (OB_FAIL(session->set_login_auth_data(auth_data_))) {
   } else if (OB_FAIL(load_privilege_info_for_change_user(session))) {
   } else {
+    // This is the successful completion of the auth-switch CHANGE USER path.
+    session->reset_session_plan_refs();
     conn->set_auth_phase();
     ObOKPParam ok_param; // use default values
     ok_param.is_on_change_user_ = true;

--- a/src/observer/mysql/obmp_change_user.cpp
+++ b/src/observer/mysql/obmp_change_user.cpp
@@ -88,6 +88,11 @@ int ObMPChangeUser::process()
       } else if (need_send_auth_switch) {
         // do nothing
       } else if (OB_FAIL(load_privilege_info_for_change_user(session))) {
+      } else {
+        // Privilege loading completes CHANGE USER for clients without an auth
+        // switch round trip. Drop the old user's plan references immediately;
+        // later PS/cursor cleanup failures must not retain the old identity.
+        session->reset_session_plan_refs();
       }
     }
   }

--- a/src/observer/mysql/obmp_reset_connection.cpp
+++ b/src/observer/mysql/obmp_reset_connection.cpp
@@ -192,6 +192,9 @@ int ObMPResetConnection::process()
 
 
     if (OB_SUCC(ret)) {
+      // RESET CONNECTION starts a fresh logical connection on the same
+      // session object; it must not inherit retained Plan references.
+      session->reset_session_plan_refs();
       session->clean_status();
     }
   }

--- a/src/observer/ob_server.cpp
+++ b/src/observer/ob_server.cpp
@@ -912,6 +912,15 @@ void ObServer::destroy()
 
   if (!has_destroy_ && has_stopped_) {
 
+    // Drain runtime workers and sessions before destroying the session manager
+    // or the plan-cache memory context. Sessions can retain SQL plan references
+    // between requests, so destroying the plan cache first would leave dangling
+    // references in sessions whose physical destruction is still deferred.
+    FLOG_INFO("begin to wait server runtime");
+    server_runtime_controller_.stop();
+    server_runtime_controller_.wait();
+    FLOG_INFO("server runtime wait finished");
+
     FLOG_INFO("begin to destroy OB_LOGGER");
     OB_LOGGER.destroy();
     FLOG_INFO("OB_LOGGER destroyed");

--- a/src/observer/ob_server.cpp
+++ b/src/observer/ob_server.cpp
@@ -912,15 +912,6 @@ void ObServer::destroy()
 
   if (!has_destroy_ && has_stopped_) {
 
-    // Drain runtime workers and sessions before destroying the session manager
-    // or the plan-cache memory context. Sessions can retain SQL plan references
-    // between requests, so destroying the plan cache first would leave dangling
-    // references in sessions whose physical destruction is still deferred.
-    FLOG_INFO("begin to wait server runtime");
-    server_runtime_controller_.stop();
-    server_runtime_controller_.wait();
-    FLOG_INFO("server runtime wait finished");
-
     FLOG_INFO("begin to destroy OB_LOGGER");
     OB_LOGGER.destroy();
     FLOG_INFO("OB_LOGGER destroyed");

--- a/src/pl/pl_cache/ob_pl_cache_mgr.cpp
+++ b/src/pl/pl_cache/ob_pl_cache_mgr.cpp
@@ -97,13 +97,10 @@ int ObPLCacheMgr::get_pl_object(ObPlanCache *lib_cache, ObILibCacheCtx &ctx, ObC
   } else if (OB_FAIL(get_sys_var_in_pl_cache_str(*pc_ctx.session_info_, tmp_alloc, pc_ctx.key_.sys_vars_str_))) {
   } else {
     if (OB_FAIL(lib_cache->get_cache_obj(ctx, &pc_ctx.key_, guard))) {
-      // if schema expired, update pl cache;
+      // get_cache_obj() evicts an old-schema entry by its exact node pointer.
+      // The logical key may already refer to a replacement here.
       if (OB_OLD_SCHEMA_VERSION == ret) {
-        PL_CACHE_LOG(WARN, "start to remove pl object", K(ret), K(pc_ctx.key_));
-        if (OB_FAIL(lib_cache->remove_cache_node(&pc_ctx.key_))) {
-        } else {
-          ret = OB_SQL_PC_NOT_EXIST;
-        }
+        ret = OB_SQL_PC_NOT_EXIST;
       }
     } else if (OB_ISNULL(guard.get_cache_obj()) ||
               (!guard.get_cache_obj()->is_prcr() &&
@@ -176,14 +173,6 @@ int ObPLCacheMgr::add_pl_object(ObPlanCache *lib_cache,
     do {
       if (OB_FAIL(lib_cache->add_cache_obj(ctx, &pc_ctx.key_, cache_obj)) && OB_OLD_SCHEMA_VERSION == ret) {
         PL_CACHE_LOG(INFO, "schema in pl cache value is old, start to remove pl object", K(ret), K(pc_ctx.key_));
-      }
-      if (ctx.need_destroy_node_) {
-        PL_CACHE_LOG(WARN, "fail to add cache obj, need destroy node", K(ret), K(pc_ctx.key_));
-        int tmp_ret = OB_SUCCESS;
-        if (OB_SUCCESS != (tmp_ret = lib_cache->remove_cache_node(&pc_ctx.key_))) {
-          ret = tmp_ret;
-          PL_CACHE_LOG(WARN, "fail to remove lib cache node", K(ret));
-        }
       }
     } while (OB_OLD_SCHEMA_VERSION == ret);
     pc_ctx.key_.sys_vars_str_.reset();

--- a/src/sql/plan_cache/ob_dist_plans.cpp
+++ b/src/sql/plan_cache/ob_dist_plans.cpp
@@ -170,6 +170,27 @@ int ObDistPlans::remove_all_plan()
 
   return ret;
 }
+
+int ObDistPlans::remove_plan(const ObPhysicalPlan *plan, bool &removed)
+{
+  int ret = OB_SUCCESS;
+  removed = false;
+  if (OB_ISNULL(plan)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid null physical plan", K(ret));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && !removed && i < dist_plans_.count(); ++i) {
+      if (dist_plans_.at(i) == plan) {
+        if (OB_FAIL(dist_plans_.remove(i))) {
+          LOG_WARN("failed to remove distributed plan", K(ret), K(i), KP(plan));
+        } else {
+          removed = true;
+        }
+      }
+    }
+  }
+  return ret;
+}
 // Get all plan memory usage
 int64_t ObDistPlans::get_mem_size() const
 {

--- a/src/sql/plan_cache/ob_dist_plans.h
+++ b/src/sql/plan_cache/ob_dist_plans.h
@@ -65,6 +65,10 @@ public:
    */
   int remove_all_plan();
 
+  int remove_plan(const ObPhysicalPlan *plan, bool &removed);
+
+  bool empty() const { return dist_plans_.empty(); }
+
   /**
    * @brief return the memory used by dist plan list
    *

--- a/src/sql/plan_cache/ob_i_lib_cache_context.h
+++ b/src/sql/plan_cache/ob_i_lib_cache_context.h
@@ -31,15 +31,13 @@ struct ObILibCacheCtx
 {
 public:
   ObILibCacheCtx()
-    : key_(NULL),
-    need_destroy_node_(false)
+    : key_(NULL)
   {
   }
   virtual ~ObILibCacheCtx() {}
   VIRTUAL_TO_STRING_KV(KP_(key));
 
   ObILibCacheKey *key_;
-  bool need_destroy_node_; // Indicate whether the cache node corresponding to key_ in lib cache is invalid
 };
 
 } // namespace common

--- a/src/sql/plan_cache/ob_i_lib_cache_node.cpp
+++ b/src/sql/plan_cache/ob_i_lib_cache_node.cpp
@@ -35,6 +35,29 @@ ObILibCacheNode::~ObILibCacheNode()
   co_list_.reset();
 }
 
+int64_t ObILibCacheNode::detach_cache_obj_owners()
+{
+  int64_t detached_count = 0;
+  SpinRLockGuard lock_guard(co_list_lock_);
+  for (CacheObjList::iterator iter = co_list_.begin(); iter != co_list_.end(); ++iter) {
+    ObILibCacheObject *obj = *iter;
+    if (OB_ISNULL(obj)) {
+      LOG_ERROR_RET(OB_ERR_UNEXPECTED, "invalid null cache object");
+    } else {
+      ObByteLockGuard obj_guard(obj->cache_node_lock_);
+      if (obj->cache_node_ == this) {
+        obj->cache_node_ = nullptr;
+        obj->set_added_lc(false);
+        ++detached_count;
+      } else if (OB_NOT_NULL(obj->cache_node_)) {
+        LOG_ERROR_RET(OB_ERR_UNEXPECTED, "cache object belongs to another node",
+                      KP(obj), KP(this), KP(obj->cache_node_));
+      }
+    }
+  }
+  return detached_count;
+}
+
 int ObILibCacheNode::init(ObILibCacheCtx &ctx, const ObILibCacheObject *cache_obj)
 {
   UNUSED(ctx);
@@ -56,6 +79,22 @@ void ObILibCacheNode::free_cache_obj_array()
       if (OB_ISNULL(obj)) {
         //do nothing
       } else {
+        {
+          ObByteLockGuard obj_guard(obj->cache_node_lock_);
+          if (obj->cache_node_ == this) {
+            LOG_ERROR_RET(OB_ERR_UNEXPECTED,
+                          "cache object owner was not detached before node destruction",
+                          KP(obj), KP(this));
+            obj->cache_node_ = nullptr;
+            obj->set_added_lc(false);
+          } else if (OB_NOT_NULL(obj->cache_node_)) {
+            LOG_ERROR_RET(OB_ERR_UNEXPECTED,
+                          "cache object belongs to another node during node destruction",
+                          KP(obj), KP(this), KP(obj->cache_node_));
+          } else {
+            obj->set_added_lc(false);
+          }
+        }
         mgr.free(obj);
         obj = NULL;
       }
@@ -76,9 +115,14 @@ int ObILibCacheNode::remove_all_plan_stat()
     for (; iter != co_list_.end(); iter++) {
       if (OB_ISNULL(obj = *iter)) {
         // do nothing
-      } else if (obj->added_lc()
-        && OB_FAIL(lib_cache_->remove_cache_obj_stat_entry(obj->get_object_id()))) {
-        LOG_WARN("failed to remove plan stat", K(obj->get_object_id()), K(ret));
+      } else {
+        const int tmp_ret = lib_cache_->remove_cache_obj_stat_entry(obj->get_object_id());
+        if (OB_SUCCESS != tmp_ret) {
+          if (OB_SUCC(ret)) {
+            ret = tmp_ret;
+          }
+          LOG_WARN("failed to remove plan stat", K(obj->get_object_id()), K(tmp_ret));
+        }
       }
     }
   }
@@ -125,6 +169,49 @@ int ObILibCacheNode::add_cache_obj(ObILibCacheCtx &ctx,
   }
   if (OB_FAIL(ret) && ret != OB_SQL_PC_PLAN_DUPLICATE) {
     is_invalid_ = true;
+  }
+  return ret;
+}
+
+int ObILibCacheNode::attach_cache_obj_owner(ObILibCacheObject *cache_obj)
+{
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(cache_obj)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid null cache object", K(ret));
+  } else {
+    ObByteLockGuard obj_guard(cache_obj->cache_node_lock_);
+    if (OB_ISNULL(cache_obj->cache_node_)) {
+      cache_obj->cache_node_ = this;
+    } else if (cache_obj->cache_node_ != this) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_ERROR("cache object already belongs to another node", K(ret),
+                KP(cache_obj), KP(this), KP(cache_obj->cache_node_));
+    }
+  }
+  return ret;
+}
+
+int ObILibCacheNode::unlink_cache_obj(ObILibCacheObject *cache_obj,
+                                      bool &removed,
+                                      bool &empty)
+{
+  int ret = OB_SUCCESS;
+  removed = false;
+  empty = false;
+  if (OB_ISNULL(cache_obj)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid null cache object", K(ret));
+  } else {
+    SpinWLockGuard lock_guard(co_list_lock_);
+    for (CacheObjList::iterator iter = co_list_.begin();
+         !removed && iter != co_list_.end(); ++iter) {
+      if (*iter == cache_obj) {
+        co_list_.erase(iter);
+        removed = true;
+      }
+    }
+    empty = co_list_.empty();
   }
   return ret;
 }
@@ -221,31 +308,6 @@ int64_t ObILibCacheNode::dec_ref_count()
 int ObILibCacheNode::before_cache_evicted()
 {
   int ret = OB_SUCCESS;
-  return ret;
-}
-
-int ObILibCacheNode::remove_cache_obj_entry(const ObCacheObjID obj_id)
-{
-  int ret = OB_SUCCESS;
-  if (OB_ISNULL(lib_cache_)) {
-    ret = OB_ERR_UNEXPECTED;
-    LOG_WARN("lib cache is invalid");
-  } else {
-    ObLCObjectManager &mgr = lib_cache_->get_cache_obj_mgr();
-    SpinWLockGuard lock_guard(co_list_lock_);
-    CacheObjList::iterator iter = co_list_.begin();
-    for (; OB_SUCC(ret) && iter != co_list_.end(); iter++) {
-      ObILibCacheObject *obj = *iter;
-      if (OB_ISNULL(obj)) {
-        BACKTRACE(ERROR, true, "invalid cache obj");
-      } else if (obj_id == obj->get_object_id()) {
-        co_list_.erase(iter);
-        mgr.free(obj);
-        obj = NULL;
-        break;
-      }
-    }
-  }
   return ret;
 }
 

--- a/src/sql/plan_cache/ob_i_lib_cache_node.cpp
+++ b/src/sql/plan_cache/ob_i_lib_cache_node.cpp
@@ -38,7 +38,6 @@ ObILibCacheNode::~ObILibCacheNode()
 int64_t ObILibCacheNode::detach_cache_obj_owners()
 {
   int64_t detached_count = 0;
-  SpinRLockGuard lock_guard(co_list_lock_);
   for (CacheObjList::iterator iter = co_list_.begin(); iter != co_list_.end(); ++iter) {
     ObILibCacheObject *obj = *iter;
     if (OB_ISNULL(obj)) {
@@ -72,7 +71,6 @@ void ObILibCacheNode::free_cache_obj_array()
     LOG_WARN_RET(OB_INVALID_ARGUMENT, "lib cache is invalid");
   } else {
     ObLCObjectManager &mgr = lib_cache_->get_cache_obj_mgr();
-    SpinWLockGuard lock_guard(co_list_lock_);
     ObILibCacheObject* obj = nullptr;
     while (!co_list_.empty()) {
       co_list_.pop_front(obj);
@@ -109,7 +107,6 @@ int ObILibCacheNode::remove_all_plan_stat()
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("lib cache is invalid");
   } else {
-    SpinRLockGuard lock_guard(co_list_lock_);
     ObILibCacheObject* obj = nullptr;
     CacheObjList::const_iterator iter = co_list_.begin();
     for (; iter != co_list_.end(); iter++) {
@@ -157,10 +154,7 @@ int ObILibCacheNode::add_cache_obj(ObILibCacheCtx &ctx,
     LOG_WARN("invalid argument", K(ret), K(key), K(obj));
   } else if (OB_FAIL(inner_add_cache_obj(ctx, key, obj))) {
   } else {
-    {
-      SpinWLockGuard lock_guard(co_list_lock_);
-      if (OB_FAIL(co_list_.push_back(obj))) {
-      }
+    if (OB_FAIL(co_list_.push_back(obj))) {
     }
     if (OB_SUCC(ret)) {
       obj->inc_ref_count();
@@ -203,7 +197,6 @@ int ObILibCacheNode::unlink_cache_obj(ObILibCacheObject *cache_obj,
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid null cache object", K(ret));
   } else {
-    SpinWLockGuard lock_guard(co_list_lock_);
     for (CacheObjList::iterator iter = co_list_.begin();
          !removed && iter != co_list_.end(); ++iter) {
       if (*iter == cache_obj) {
@@ -249,7 +242,7 @@ int64_t ObILibCacheNode::get_mem_size()
 {
   int ret = OB_SUCCESS;
   int64_t total_mem_size = 0;
-  SpinRLockGuard lock_guard(co_list_lock_);
+  TCRLockGuard lock_guard(rwlock_);
   CacheObjList::iterator iter = co_list_.begin();
   for (; OB_SUCC(ret) && iter != co_list_.end(); iter++) {
     ObILibCacheObject *obj = *iter;
@@ -260,23 +253,6 @@ int64_t ObILibCacheNode::get_mem_size()
     }
   }
   total_mem_size += allocator_.total();
-  return total_mem_size;
-}
-
-int64_t ObILibCacheNode::get_cache_obj_mem_size()
-{
-  int ret = OB_SUCCESS;
-  int64_t total_mem_size = 0;
-  SpinRLockGuard lock_guard(co_list_lock_);
-  CacheObjList::iterator iter = co_list_.begin();
-  for (; OB_SUCC(ret) && iter != co_list_.end(); iter++) {
-    ObILibCacheObject *obj = *iter;
-    if (OB_ISNULL(obj)) {
-      BACKTRACE(ERROR, true, "invalid cache obj");
-    } else {
-      total_mem_size += obj->get_mem_size();
-    }
-  }
   return total_mem_size;
 }
 

--- a/src/sql/plan_cache/ob_i_lib_cache_node.h
+++ b/src/sql/plan_cache/ob_i_lib_cache_node.h
@@ -108,10 +108,9 @@ public:
       ref_count_(0),
       lib_cache_(lib_cache),
       cache_key_(nullptr),
-      co_list_lock_(common::ObLatchIds::PLAN_SET_LOCK),
       co_list_(allocator_),
       is_invalid_(false),
-      eviction_started_(false),
+      marked_for_eviction_(false),
       accounted_size_(0)
   {}
   virtual ~ObILibCacheNode();
@@ -128,6 +127,8 @@ public:
   /**
    * @brief remove all plan stat from all cache objects in the library cache node
    */
+  // Caller holds the node write lock, except during unpublished construction
+  // or destruction after the last node reference has been released.
   int remove_all_plan_stat();
   int attach_cache_obj_owner(ObILibCacheObject *cache_obj);
   int unlink_cache_obj(ObILibCacheObject *cache_obj,
@@ -163,8 +164,9 @@ public:
   common::ObIAllocator *get_allocator() { return &allocator_; }
   common::ObIAllocator &get_allocator_ref() { return allocator_; }
   lib::MemoryContext &get_mem_context() { return mem_context_; }
+  // Acquires the node read lock. Caller must hold a node reference, but no
+  // node, object-owner, or key-map bucket lock.
   int64_t get_mem_size();
-  int64_t get_cache_obj_mem_size();
   int64_t get_own_mem_size() const { return allocator_.total(); }
   int64_t exchange_accounted_size(const int64_t size)
   {
@@ -177,16 +179,16 @@ public:
   // Must be called under the node write lock. Retirement removes all weak
   // object-id entries and detaches cache object owners before this exact node
   // is removed from cache_key_node_map_.
-  bool begin_eviction()
+  bool mark_for_eviction()
   {
-    const bool can_start = !eviction_started_;
-    if (can_start) {
-      eviction_started_ = true;
+    const bool newly_marked = !marked_for_eviction_;
+    if (newly_marked) {
+      marked_for_eviction_ = true;
       is_invalid_ = true;
     }
-    return can_start;
+    return newly_marked;
   }
-  bool eviction_started() const { return eviction_started_; }
+  bool is_marked_for_eviction() const { return marked_for_eviction_; }
   int64_t detach_cache_obj_owners();
 
   VIRTUAL_TO_STRING_KV(K_(ref_count));
@@ -235,10 +237,12 @@ protected:
   // The key stored in cache_key_node_map_.  It is allocated from allocator_
   // and remains valid for the complete node lifetime.
   ObILibCacheKey *cache_key_;
-  common::SpinRWLock co_list_lock_;
+  // Protected by rwlock_, together with the plan lookup structures.
+  // Nested locking order: node rwlock_ -> object cache_node_lock_.
+  // Never acquire rwlock_ while holding an object-owner lock.
   CacheObjList co_list_;
   bool is_invalid_;
-  bool eviction_started_;
+  bool marked_for_eviction_;
   int64_t accounted_size_;
 };
 

--- a/src/sql/plan_cache/ob_i_lib_cache_node.h
+++ b/src/sql/plan_cache/ob_i_lib_cache_node.h
@@ -107,9 +107,11 @@ public:
       rwlock_(),
       ref_count_(0),
       lib_cache_(lib_cache),
+      cache_key_(nullptr),
       co_list_lock_(common::ObLatchIds::PLAN_SET_LOCK),
       co_list_(allocator_),
       is_invalid_(false),
+      eviction_started_(false),
       accounted_size_(0)
   {}
   virtual ~ObILibCacheNode();
@@ -127,12 +129,10 @@ public:
    * @brief remove all plan stat from all cache objects in the library cache node
    */
   int remove_all_plan_stat();
-  /**
-   * @brief remove cache obj from cache_obj_list_
-   * @param obj_id[in], obj id to remove
-   * @return if success, return OB_SUCCESS, otherwise, return errno
-   */
-  int remove_cache_obj_entry(const ObCacheObjID obj_id);
+  int attach_cache_obj_owner(ObILibCacheObject *cache_obj);
+  int unlink_cache_obj(ObILibCacheObject *cache_obj,
+                       bool &removed,
+                       bool &empty);
   /**
    * @brief get cache object from library cache
    * @param ctx[in], library cache context
@@ -153,6 +153,7 @@ public:
    */
   //int erase_cache_obj(ObILibCacheCtx &context, ObILibCacheObject *cache_obj);
   virtual int lock(bool is_rdlock);
+  int lock_for_eviction() { return rwlock_.wrlock(); }
   virtual int update_node_stat(ObILibCacheCtx &ctx);
   StmtStat *get_node_stat() { return &node_stat_; }
   int unlock() { return rwlock_.unlock(); }
@@ -171,6 +172,22 @@ public:
   }
   ObPlanCache *get_lib_cache() const { return lib_cache_; }
   bool is_invalid() const { return is_invalid_; }
+  void set_cache_key(ObILibCacheKey *key) { cache_key_ = key; }
+  ObILibCacheKey *get_cache_key() const { return cache_key_; }
+  // Must be called under the node write lock. Retirement removes all weak
+  // object-id entries and detaches cache object owners before this exact node
+  // is removed from cache_key_node_map_.
+  bool begin_eviction()
+  {
+    const bool can_start = !eviction_started_;
+    if (can_start) {
+      eviction_started_ = true;
+      is_invalid_ = true;
+    }
+    return can_start;
+  }
+  bool eviction_started() const { return eviction_started_; }
+  int64_t detach_cache_obj_owners();
 
   VIRTUAL_TO_STRING_KV(K_(ref_count));
 
@@ -215,9 +232,13 @@ protected:
   int64_t ref_count_;
   StmtStat node_stat_;
   ObPlanCache *lib_cache_;
+  // The key stored in cache_key_node_map_.  It is allocated from allocator_
+  // and remains valid for the complete node lifetime.
+  ObILibCacheKey *cache_key_;
   common::SpinRWLock co_list_lock_;
   CacheObjList co_list_;
   bool is_invalid_;
+  bool eviction_started_;
   int64_t accounted_size_;
 };
 

--- a/src/sql/plan_cache/ob_i_lib_cache_object.cpp
+++ b/src/sql/plan_cache/ob_i_lib_cache_object.cpp
@@ -127,7 +127,7 @@ bool ObILibCacheObject::try_inc_session_ref()
       if (OB_SUCCESS == cache_node->lock(true /* read lock */)) {
         {
           ObByteLockGuard lock_guard(cache_node_lock_);
-          if (cache_node_ == cache_node && !cache_node->eviction_started()) {
+          if (cache_node_ == cache_node && !cache_node->is_marked_for_eviction()) {
             inc_ref_count();
             retained = true;
           }

--- a/src/sql/plan_cache/ob_i_lib_cache_object.cpp
+++ b/src/sql/plan_cache/ob_i_lib_cache_object.cpp
@@ -16,6 +16,7 @@
 
 #define USING_LOG_PREFIX SQL_PC
 #include "ob_i_lib_cache_object.h"
+#include "ob_i_lib_cache_node.h"
 
 using namespace oceanbase::common;
 using namespace oceanbase::share::schema;
@@ -28,6 +29,8 @@ ObILibCacheObject::ObILibCacheObject(ObLibCacheNameSpace ns, lib::MemoryContext 
   : mem_context_(mem_context),
     allocator_(mem_context->get_safe_arena_allocator()),
     ref_count_(0),
+    cache_node_lock_(),
+    cache_node_(nullptr),
     object_id_(OB_INVALID_ID),
     log_del_time_(INT64_MAX),
     added_to_lc_(false),
@@ -41,6 +44,7 @@ ObILibCacheObject::ObILibCacheObject(ObLibCacheNameSpace ns, lib::MemoryContext 
 void ObILibCacheObject::reset()
 {
   ref_count_ = 0;
+  cache_node_ = nullptr;
   object_id_ = OB_INVALID_ID;
   log_del_time_ = INT64_MAX;
   added_to_lc_ = false;
@@ -105,6 +109,41 @@ bool ObILibCacheObject::try_inc_ref_count()
     ref_cnt = ATOMIC_LOAD(&ref_count_);
   }
   return ref_cnt > 0;
+}
+
+bool ObILibCacheObject::try_inc_session_ref()
+{
+  bool retained = false;
+  ObILibCacheNode *cache_node = nullptr;
+  if (is_sql_crsr()) {
+    {
+      ObByteLockGuard lock_guard(cache_node_lock_);
+      if (OB_NOT_NULL(cache_node_)) {
+        cache_node = cache_node_;
+        cache_node->inc_ref_count();
+      }
+    }
+    if (OB_NOT_NULL(cache_node)) {
+      if (OB_SUCCESS == cache_node->lock(true /* read lock */)) {
+        {
+          ObByteLockGuard lock_guard(cache_node_lock_);
+          if (cache_node_ == cache_node && !cache_node->eviction_started()) {
+            inc_ref_count();
+            retained = true;
+          }
+        }
+        cache_node->unlock();
+      }
+      cache_node->dec_ref_count();
+    }
+  }
+  return retained;
+}
+
+bool ObILibCacheObject::is_attached_to_cache_node()
+{
+  ObByteLockGuard lock_guard(cache_node_lock_);
+  return OB_NOT_NULL(cache_node_);
 }
 
 int64_t ObILibCacheObject::dec_ref_count()

--- a/src/sql/plan_cache/ob_i_lib_cache_object.h
+++ b/src/sql/plan_cache/ob_i_lib_cache_object.h
@@ -19,6 +19,7 @@
 
 #include "sql/plan_cache/ob_lib_cache_register.h"
 #include "sql/plan_cache/ob_i_lib_cache_context.h"
+#include "lib/lock/ob_small_spin_lock.h"
 
 namespace oceanbase
 {
@@ -30,6 +31,7 @@ class ObIAllocator;
 namespace sql
 {
 class ObPlanCache;
+class ObILibCacheNode;
 
 // The abstract interface class of library cache object, each object in the ObLibCacheNameSpace
 // enum structure needs to inherit from this interface and implement its own implementation class
@@ -37,6 +39,7 @@ class ObILibCacheObject
 {
 friend class ObLCObjectManager;
 friend class ObPlanCache;
+friend class ObILibCacheNode;
 public:
   enum CacheObjStatus
   {
@@ -67,6 +70,10 @@ public:
   int64_t get_ref_count() const { return ATOMIC_LOAD(&ref_count_); }
   int64_t inc_ref_count();
   bool try_inc_ref_count();
+  // Retain a SQL plan for a session only while it remains reachable through
+  // its shared cache node. The caller already owns an execution/compile guard.
+  bool try_inc_session_ref();
+  bool is_attached_to_cache_node();
   inline common::ObIAllocator &get_allocator() { return allocator_; }
   inline lib::MemoryContext &get_mem_context() { return mem_context_; }
   inline bool added_lc() const { return added_to_lc_; }
@@ -101,7 +108,19 @@ private:
 protected:
   lib::MemoryContext mem_context_;
   common::ObIAllocator &allocator_;
-  volatile int64_t ref_count_;
+  // SQL plans use one lifetime reference count for execution/diagnostic
+  // guards, session holders, and the single cache-node membership reference.
+  // While cache_node_ is
+  // non-null, this object is in that node's co_list_ and exactly one ref
+  // belongs to that membership. When no guard or session holder remains, the
+  // object is retired synchronously and releases the membership ref.
+  // Other namespaces retain their original object-id-map reference as well.
+  int64_t ref_count_;
+  // Serializes the weak owner-node pointer with node retirement.  The owner
+  // pointer never owns the node; a releaser pins the node while holding this
+  // lock before it starts retirement.
+  common::ObByteLock cache_node_lock_;
+  ObILibCacheNode *cache_node_;
   uint64_t object_id_;
   int64_t log_del_time_;
   bool added_to_lc_;

--- a/src/sql/plan_cache/ob_lib_cache_object_manager.cpp
+++ b/src/sql/plan_cache/ob_lib_cache_object_manager.cpp
@@ -28,6 +28,23 @@ class ObIAllocator;
 namespace sql
 {
 
+struct ObDestroyCacheObjPred
+{
+  explicit ObDestroyCacheObjPred(const bool is_leaked)
+    : is_leaked_(is_leaked)
+  {}
+
+  bool operator()(
+      common::hash::HashMapPair<ObCacheObjID, ObILibCacheObject *> &entry) const
+  {
+    return OB_NOT_NULL(entry.second)
+        && (is_leaked_ ? !entry.second->is_sql_crsr()
+                       : 0 == entry.second->get_ref_count());
+  }
+
+  bool is_leaked_;
+};
+
 int ObLCObjectManager::init(int64_t hash_bucket, ObPlanCache *lib_cache)
 {
   int ret = OB_SUCCESS;
@@ -103,6 +120,9 @@ int ObLCObjectManager::erase_cache_obj(ObCacheObjID id)
   int ret = OB_SUCCESS;
   ObILibCacheObject *cache_obj = NULL;
   if (OB_FAIL(cache_obj_map_.erase_refactored(id, &cache_obj))) {
+    if (OB_HASH_NOT_EXIST == ret) {
+      ret = OB_SUCCESS;
+    }
   } else {
     if (NULL != cache_obj) {
       // set logical deleted time
@@ -111,7 +131,11 @@ int ObLCObjectManager::erase_cache_obj(ObCacheObjID id)
                                         K(cache_obj->get_object_id()),
                                         K(cache_obj->added_lc()),
                                         K(cache_obj));
-      common_free(cache_obj);
+      // The SQL-plan object-id map is a weak diagnostic index.  Other
+      // library-cache namespaces retain their original owning index ref.
+      if (!cache_obj->is_sql_crsr()) {
+        common_free(cache_obj);
+      }
       cache_obj = NULL;
     }
   }
@@ -123,7 +147,10 @@ void ObLCObjectManager::common_free(ObILibCacheObject *cache_obj)
   int ret = OB_SUCCESS;
   if (OB_ISNULL(cache_obj)) {
     // do nothing
-  } else {
+  } else if (!cache_obj->is_sql_crsr()) {
+    // Keep the legacy PL/package lifecycle unchanged. In particular, refresh
+    // the safe-timestamp anchor on every release after logical eviction, and
+    // do not destroy the object when its eviction callback fails.
     if (!cache_obj->added_lc()) {
       cache_obj->set_logical_del_time(ObTimeUtility::current_monotonic_time());
       LOG_WARN("set logical del time", K(cache_obj->get_logical_del_time()),
@@ -131,13 +158,77 @@ void ObLCObjectManager::common_free(ObILibCacheObject *cache_obj)
                                        K(cache_obj->get_object_id()),
                                        K(lbt()));
     }
-    int64_t ref_count = cache_obj->dec_ref_count();
+    const int64_t ref_count = cache_obj->dec_ref_count();
     if (ref_count > 0) {
       // do nothing
-    } else if (ref_count == 0) {
-      
+    } else if (0 == ref_count) {
       if (OB_FAIL(cache_obj->before_cache_evicted())) {
       } else if (OB_FAIL(destroy_cache_obj(false, cache_obj->get_object_id()))) {
+      }
+    } else {
+      LOG_ERROR("invalid cache obj ref count", K(ref_count), KP(cache_obj));
+    }
+  } else {
+    ObILibCacheNode *cache_node = nullptr;
+    int64_t ref_count = 0;
+    if (!cache_obj->added_lc()
+        && INT64_MAX == cache_obj->get_logical_del_time()) {
+      cache_obj->set_logical_del_time(ObTimeUtility::current_monotonic_time());
+      LOG_TRACE("set logical del time for uncached SQL plan",
+                K(cache_obj->get_logical_del_time()),
+                K(cache_obj->get_object_id()));
+    }
+
+    // Ref counts above two cannot be the transition to the sole node
+    // membership reference, so release them without serializing every hot
+    // plan-guard release on cache_node_lock_.
+    ref_count = ATOMIC_LOAD(&cache_obj->ref_count_);
+    while (ref_count > 2
+           && !ATOMIC_BCAS(&cache_obj->ref_count_, ref_count, ref_count - 1)) {
+      ref_count = ATOMIC_LOAD(&cache_obj->ref_count_);
+    }
+    if (ref_count > 2) {
+      --ref_count;
+    } else {
+      // A SQL cache node keeps exactly one membership reference. Serialize
+      // the transition to that last reference with owner detachment, and
+      // pin the node before dropping the object lock.
+      ObByteLockGuard lock_guard(cache_obj->cache_node_lock_);
+      ref_count = cache_obj->dec_ref_count();
+      if (1 == ref_count && OB_NOT_NULL(cache_obj->cache_node_)) {
+        cache_node = cache_obj->cache_node_;
+        cache_node->inc_ref_count();
+      }
+    }
+
+    if (OB_NOT_NULL(cache_node)) {
+      if (OB_ISNULL(lib_cache_)) {
+        LOG_ERROR_RET(OB_ERR_UNEXPECTED, "invalid null lib cache");
+      } else if (OB_FAIL(lib_cache_->try_remove_unused_sql_plan(cache_node, cache_obj))) {
+        LOG_ERROR("failed to retire unused SQL plan", K(ret), KP(cache_node), KP(cache_obj));
+      }
+      cache_node->dec_ref_count();
+    } else if (ref_count > 0) {
+      // do nothing
+    } else if (ref_count == 0) {
+      // cache_obj_map_ is a weak diagnostic index.  Node retirement normally
+      // erased it before dropping the membership reference; erase again here
+      // so no error path can leave a dangling object-id entry behind.
+      const int erase_ret = erase_cache_obj(cache_obj->get_object_id());
+      if (OB_SUCCESS != erase_ret) {
+        LOG_ERROR("failed to erase cache object id before destruction",
+                  K(erase_ret), KP(cache_obj));
+        // Keep the zero-ref object in alloc_cache_obj_map_: leaking is safer
+        // than destroying it while a weak object-id entry may still point at
+        // the allocation.
+      } else {
+        if (OB_FAIL(cache_obj->before_cache_evicted())) {
+          LOG_WARN("failed to process before cache object eviction", K(ret), KP(cache_obj));
+        }
+        // Reaching zero is terminal.  A callback failure must not leave an
+        // object at zero in alloc_cache_obj_map_ forever.
+        if (OB_FAIL(destroy_cache_obj(false, cache_obj->get_object_id()))) {
+        }
       }
     } else {
       LOG_ERROR("invalid cache obj ref count", K(ref_count), KP(cache_obj));
@@ -149,17 +240,31 @@ int ObLCObjectManager::destroy_cache_obj(const bool is_leaked,
                                          const uint64_t object_id)
 {
   int ret = OB_SUCCESS;
-  ObILibCacheObject *to_del_obj;
-  if (OB_FAIL(alloc_cache_obj_map_.erase_refactored(object_id, &to_del_obj))) {
-    if (OB_HASH_NOT_EXIST == ret) {
-      ret = OB_SUCCESS;
+  ObILibCacheObject *to_del_obj = nullptr;
+  bool is_erased = false;
+  ObDestroyCacheObjPred destroy_pred(is_leaked);
+  ret = alloc_cache_obj_map_.erase_if(
+      object_id, destroy_pred, is_erased, &to_del_obj);
+  if (OB_HASH_NOT_EXIST == ret) {
+    ret = OB_SUCCESS;
+  } else if (OB_SUCCESS != ret) {
+    LOG_WARN("failed to erase element from alloc obj list", K(object_id), K(ret));
+  } else if (!is_erased) {
+    if (is_leaked) {
+      // SQL cursors are governed solely by their reference count.  The
+      // safe-timestamp leak heuristic must not invalidate a live plan guard.
+      LOG_DEBUG("skip forced destruction of referenced SQL plan", K(object_id));
     } else {
-      LOG_WARN("failed to erase element from alloc obj list", K(object_id), K(ret));
+      ret = OB_ERR_UNEXPECTED;
+      LOG_ERROR("cache object destruction requires zero references",
+                K(ret), K(object_id));
     }
   } else if (OB_ISNULL(to_del_obj)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("invalid cache obj", K(to_del_obj));
   } else {
+    // Preserve the legacy forced-cleanup behavior for PL and other non-SQL
+    // namespaces.  Only SQL cursors opt out of is_leaked destruction.
     to_del_obj->dump_deleted_log_info(!is_leaked);
     inner_free(to_del_obj);
   }

--- a/src/sql/plan_cache/ob_lib_cache_object_manager.h
+++ b/src/sql/plan_cache/ob_lib_cache_object_manager.h
@@ -80,8 +80,11 @@ private:
    *                        cache_obj  cache_obj  cache_obj
    *
    * In the library cache, each key corresponds to a cache node structure, which is very
-   * inconvenient when traversing the output of the virtual table, so a map of key-cache_obj
-   * is used to facilitate traversal.
+   * inconvenient when traversing the output of the virtual table, so an object-id index is
+   * used to facilitate traversal.  SQL-plan entries are non-owning: atomic lookup acquires
+   * a real object reference while holding the map bucket lock, and node retirement erases
+   * the entry before releasing the node's membership reference.  Other library-cache
+   * namespaces retain the original owning index reference.
    */
   IdCacheObjectMap cache_obj_map_;
   /**

--- a/src/sql/plan_cache/ob_pcv_set.cpp
+++ b/src/sql/plan_cache/ob_pcv_set.cpp
@@ -58,6 +58,7 @@ int ObPCVSet::init(ObILibCacheCtx &ctx, const ObILibCacheObject *obj)
 void ObPCVSet::destroy()
 {
   if (is_inited_) {
+    SpinWLockGuard pcv_list_guard(pcv_list_lock_);
     while (!pcv_list_.is_empty()) {
       ObPlanCacheValue *pcv= pcv_list_.get_first();
       if (OB_ISNULL(pcv)) {
@@ -188,6 +189,7 @@ int ObPCVSet::inner_add_cache_obj(ObILibCacheCtx &ctx,
 {
   UNUSED(key);
   int ret = OB_SUCCESS;
+  SpinWLockGuard pcv_list_guard(pcv_list_lock_);
   bool is_new = true;
   ObPlanCacheObject *plan = static_cast<ObPlanCacheObject*>(cache_obj);
   ObPlanCacheCtx &pc_ctx = static_cast<ObPlanCacheCtx&>(ctx);
@@ -240,6 +242,12 @@ int ObPCVSet::inner_add_cache_obj(ObILibCacheCtx &ctx,
     } else if (!pcv_list_.add_last(pcv)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("fail to add pcv to pcv_list", K(ret));
+      const int tmp_ret = remove_sql_id(
+          common::ObString::make_string(pcv->get_sql_id()));
+      if (OB_SUCCESS != tmp_ret) {
+        LOG_ERROR("failed to remove SQL ID for rejected PCV",
+                  K(tmp_ret), KP(pcv));
+      }
       free_pcv(pcv);
       pcv = NULL;
     } else {
@@ -276,8 +284,6 @@ int ObPCVSet::create_pcv_and_add_plan(ObPlanCacheObject *cache_obj,
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected null for new_pcv", K(new_pcv));
   } else if (OB_FAIL(new_pcv->init(this, cache_obj, pc_ctx))) {
-  } else if (OB_FAIL(ob_write_string(allocator_, sql_id_org, sql_id))) {
-  } else if (OB_FAIL(push_sql_id(sql_id))) {
   } else {
     // do nothing
   }
@@ -288,6 +294,16 @@ int ObPCVSet::create_pcv_and_add_plan(ObPlanCacheObject *cache_obj,
       if (!is_not_supported_err(ret)) {
         SQL_PC_LOG(WARN, "failed to add plan to plan cache value",  K(ret));
       }
+    }
+  }
+
+  // Keep one SQL-ID entry for each live PCV. Add it only after the Plan was
+  // accepted so a failed PCV construction cannot leave historical entries.
+  if (OB_SUCC(ret)) {
+    if (OB_FAIL(ob_write_string(allocator_, sql_id_org, sql_id))) {
+    } else if (OB_FAIL(push_sql_id(sql_id))) {
+      allocator_.free(sql_id.ptr());
+      sql_id.reset();
     }
   }
 
@@ -346,6 +362,39 @@ void ObPCVSet::free_pcv(ObPlanCacheValue *pcv)
     allocator_.free(pcv);
     pcv = nullptr;
   }
+}
+
+int ObPCVSet::remove_sql_id(const common::ObString &sql_id)
+{
+  int ret = OB_SUCCESS;
+  int64_t found_idx = -1;
+  for (int64_t i = 0; i < sql_ids_.count() && found_idx < 0; ++i) {
+    if (sql_ids_.at(i) == sql_id) {
+      found_idx = i;
+    }
+  }
+  if (found_idx < 0) {
+    ret = OB_ENTRY_NOT_EXIST;
+    LOG_ERROR("SQL ID for PCV is absent", K(ret), K(sql_id), KP(this));
+  } else {
+    char *sql_id_buf = const_cast<char *>(sql_ids_.at(found_idx).ptr());
+    if (OB_FAIL(sql_ids_.remove(found_idx))) {
+      LOG_ERROR("failed to remove SQL ID for PCV", K(ret), K(found_idx));
+    } else if (OB_NOT_NULL(sql_id_buf)) {
+      allocator_.free(sql_id_buf);
+    }
+  }
+  return ret;
+}
+
+bool ObPCVSet::contains_sql_id(const common::ObString &sql_id)
+{
+  bool contains = false;
+  SpinRLockGuard pcv_list_guard(pcv_list_lock_);
+  for (int64_t i = 0; !contains && i < sql_ids_.count(); ++i) {
+    contains = (sql_ids_.at(i) == sql_id);
+  }
+  return contains;
 }
 
 int ObPCVSet::set_raw_param_info_if_needed(ObPlanCacheObject *cache_obj)
@@ -458,6 +507,7 @@ int ObPCVSet::check_raw_param_for_dup_col(ObPlanCacheCtx &pc_ctx, bool &contain_
 int ObPCVSet::check_contains_table(uint64_t db_id, common::ObString tab_name, bool &contains)
 {
   int ret = OB_SUCCESS;
+  SpinRLockGuard pcv_list_guard(pcv_list_lock_);
   DLIST_FOREACH(pcv, pcv_list_) {
     if (OB_ISNULL(pcv)) {
       ret = OB_INVALID_ARGUMENT;
@@ -467,6 +517,57 @@ int ObPCVSet::check_contains_table(uint64_t db_id, common::ObString tab_name, bo
       // continue find
     } else {
       break;
+    }
+  }
+  return ret;
+}
+
+int ObPCVSet::remove_plan(const ObPlanCacheObject *cache_obj,
+                          bool &removed,
+                          bool &empty)
+{
+  int ret = OB_SUCCESS;
+  removed = false;
+  empty = false;
+  if (OB_ISNULL(cache_obj) || !cache_obj->is_sql_crsr()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid SQL cache object", K(ret), KP(cache_obj));
+  } else {
+    int64_t removed_count = 0;
+    SpinWLockGuard pcv_list_guard(pcv_list_lock_);
+    DLIST_FOREACH_REMOVESAFE(pcv, pcv_list_) {
+      bool removed_from_pcv = false;
+      bool pcv_empty = false;
+      if (OB_FAIL(pcv->remove_plan(cache_obj, removed_from_pcv, pcv_empty))) {
+      } else if (removed_from_pcv) {
+        ++removed_count;
+        if (pcv_empty) {
+          if (OB_FAIL(remove_sql_id(
+                  common::ObString::make_string(pcv->get_sql_id())))) {
+            LOG_ERROR("failed to remove SQL ID for empty PCV",
+                      K(ret), KP(pcv), KP(cache_obj));
+          } else {
+            pcv_list_.remove(pcv);
+            free_pcv(pcv);
+            pcv = nullptr;
+          }
+        }
+      }
+    }
+    if (OB_SUCC(ret) && removed_count > 1) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_ERROR("physical plan occurs in multiple plan cache values",
+                K(ret), K(removed_count), KP(cache_obj), KP(this));
+    } else if (OB_SUCC(ret) && 1 == removed_count) {
+      removed = true;
+      if (OB_UNLIKELY(plan_num_ <= 0)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_ERROR("invalid plan count while removing physical plan",
+                  K(ret), K_(plan_num), KP(cache_obj));
+      } else {
+        --plan_num_;
+        empty = (0 == plan_num_);
+      }
     }
   }
   return ret;

--- a/src/sql/plan_cache/ob_pcv_set.h
+++ b/src/sql/plan_cache/ob_pcv_set.h
@@ -65,6 +65,7 @@ public:
   ObPCVSet(ObPlanCache *lib_cache, lib::MemoryContext &mem_context)
     : ObILibCacheNode(lib_cache, mem_context),
       is_inited_(false),
+      pcv_list_lock_(common::ObLatchIds::PLAN_SET_LOCK),
       pc_key_(),
       pc_alloc_(NULL),
       sql_(),
@@ -87,8 +88,7 @@ public:
                                   ObILibCacheKey *key,
                                   ObILibCacheObject *cache_obj);
   void destroy();
-  common::ObIArray<common::ObString> &get_sql_id() { return sql_ids_; }
-  int push_sql_id(common::ObString sql_id) { return sql_ids_.push_back(sql_id); }
+  bool contains_sql_id(const common::ObString &sql_id);
   ObPlanCache *get_plan_cache() const { return lib_cache_; }
   common::ObIAllocator *get_pc_allocator() const { return pc_alloc_; }
   void set_plan_cache_key(ObPlanCacheKey &key) { pc_key_ = key; }
@@ -100,6 +100,9 @@ public:
   int deep_copy_sql(const common::ObString &sql);
   int check_contains_table(uint64_t db_id, common::ObString tab_name, bool &contains);
   bool set_expired_time();
+  int remove_plan(const ObPlanCacheObject *cache_obj,
+                  bool &removed,
+                  bool &empty);
 
   TO_STRING_KV(K_(is_inited));
 
@@ -112,6 +115,8 @@ private:
   int64_t get_plan_num() const { return plan_num_; }
   int create_new_pcv(ObPlanCacheValue *&new_pcv);
   void free_pcv(ObPlanCacheValue *pcv);
+  int push_sql_id(common::ObString sql_id) { return sql_ids_.push_back(sql_id); }
+  int remove_sql_id(const common::ObString &sql_id);
   // If sql contains a subquery, and the projection columns of the subquery are parameterized, due to the constraint of having the same column names in the subquery, plan cache needs to perform constraint checking when matching
   // For example select * (select 1, 2, 3 from dual), parameterized as select * (select ?, ?, ? from dual), plan cache cached this plan
   // If a sql select * (select 1, 1, 3 from dual) comes in, it hits the plan, but the subquery has ambiguous columns
@@ -120,6 +125,7 @@ private:
   int check_raw_param_for_dup_col(ObPlanCacheCtx &pc_ctx, bool &contain_dup_col);
 private:
   bool is_inited_;
+  common::SpinRWLock pcv_list_lock_;
   ObPlanCacheKey pc_key_; //used for manager key memory
   common::ObIAllocator *pc_alloc_;
   common::ObString sql_;  // when adding a kv pair with sql as the key to the plan cache, this member is needed

--- a/src/sql/plan_cache/ob_plan_cache.cpp
+++ b/src/sql/plan_cache/ob_plan_cache.cpp
@@ -34,6 +34,20 @@ namespace oceanbase
 namespace sql
 {
 
+struct ObRemoveExactCacheNodeOp
+{
+  explicit ObRemoveExactCacheNodeOp(ObILibCacheNode *expected_node)
+    : expected_node_(expected_node)
+  {}
+
+  bool operator()(ObKVEntryTraverseOp::LibCacheKVEntry &entry) const
+  {
+    return entry.second == expected_node_;
+  }
+
+  ObILibCacheNode *expected_node_;
+};
+
 struct ObGetKVEntryByNsOp : public ObKVEntryTraverseOp
 {
   explicit ObGetKVEntryByNsOp(const ObLibCacheNameSpace ns,
@@ -55,6 +69,24 @@ struct ObGetKVEntryByNsOp : public ObKVEntryTraverseOp
   ObLibCacheNameSpace namespace_;
 };
 
+// SQL plans retire synchronously when their last session holder or
+// execution/diagnostic guard reference is released. The periodic task is
+// kept only for the other library-cache namespaces, which still use the
+// original eviction lifecycle.
+struct ObGetNonSqlKVEntryOp : public ObKVEntryTraverseOp
+{
+  explicit ObGetNonSqlKVEntryOp(LCKeyValueArray *key_val_list)
+    : ObKVEntryTraverseOp(key_val_list)
+  {
+  }
+
+  virtual int check_entry_match(LibCacheKVEntry &entry, bool &is_match)
+  {
+    is_match = (ObLibCacheNameSpace::NS_CRSR != entry.first->namespace_);
+    return OB_SUCCESS;
+  }
+};
+
 struct ObGetKVEntryBySQLIDOp : public ObKVEntryTraverseOp
 {
   explicit ObGetKVEntryBySQLIDOp(uint64_t db_id,
@@ -74,23 +106,13 @@ struct ObGetKVEntryBySQLIDOp : public ObKVEntryTraverseOp
       ObPCVSet *node = static_cast<ObPCVSet*>(entry.second);
       if (db_id_ != common::OB_INVALID_ID && db_id_ != key->db_id_) {
         // skip entry that has non-matched db_id
-      } else if (!contain_sql_id(node->get_sql_id())) {
+      } else if (!node->contains_sql_id(sql_id_)) {
         // skip entry which not contains same sql_id
       } else {
         is_match = true;
       }
     }
     return ret;
-  }
-  bool contain_sql_id(common::ObIArray<common::ObString> &sql_ids)
-  {
-    bool contains = false;
-    for (int64_t i = 0; !contains && i < sql_ids.count(); i++) {
-      if (sql_ids.at(i) == sql_id_) {
-        contains = true;
-      }
-    }
-    return contains;
   }
 
   uint64_t db_id_;
@@ -198,13 +220,16 @@ struct ObNodeStatFilterOp : public ObKVEntryTraverseOp
       ret = common::OB_INVALID_ARGUMENT;
       SQL_PC_LOG(WARN, "invalid argument",
       K(key_value_list_), K(entry.first), K(entry.second), K(ret));
+    } else if (ObLibCacheNameSpace::NS_CRSR == entry.first->namespace_) {
+      // SQL plan lifetime is driven by session holders and transient guards.
     } else {
-      // collect idle-expired nodes if configured
+      // Preserve idle eviction for PL/package and the other non-SQL library
+      // cache namespaces. SQL plans never enter this periodic path.
       if (idle_threshold_us_ > 0 && OB_NOT_NULL(idle_list_)) {
         const StmtStat *stat = entry.second->get_node_stat();
-        if (OB_NOT_NULL(stat) &&
-            stat->last_active_timestamp_ > 0 &&
-            now_ - stat->last_active_timestamp_ > idle_threshold_us_) {
+        if (OB_NOT_NULL(stat)
+            && stat->last_active_timestamp_ > 0
+            && now_ - stat->last_active_timestamp_ > idle_threshold_us_) {
           ObLCKeyValue idle_kv(entry.first, entry.second);
           if (OB_FAIL(idle_list_->push_back(idle_kv))) {
           } else {
@@ -270,23 +295,23 @@ struct ObIdleEvictOp
   int operator()(LibCacheKVEntry &entry)
   {
     int ret = common::OB_SUCCESS;
-    if (scanned_nodes_ >= max_scan_nodes_) {
+    if (OB_ISNULL(entry.first) || OB_ISNULL(entry.second)
+        || ObLibCacheNameSpace::NS_CRSR == entry.first->namespace_) {
+      // SQL plans retire synchronously; only non-SQL entries consume the idle
+      // scan budget and participate in eviction.
+    } else if (scanned_nodes_ >= max_scan_nodes_) {
       ret = OB_ITER_END;
     } else {
       ++scanned_nodes_;
-      if (OB_ISNULL(entry.first) || OB_ISNULL(entry.second)) {
-        // skip
-      } else {
         const StmtStat *stat = entry.second->get_node_stat();
-        if (OB_NOT_NULL(stat) &&
-            stat->last_active_timestamp_ > 0 &&
-            now_ - stat->last_active_timestamp_ > idle_threshold_us_) {
+        if (OB_NOT_NULL(stat)
+            && stat->last_active_timestamp_ > 0
+            && now_ - stat->last_active_timestamp_ > idle_threshold_us_) {
           if (OB_FAIL(to_evict_->push_back(ObLCKeyValue(entry.first, entry.second)))) {
           } else {
             entry.second->inc_ref_count();
           }
         }
-      }
     }
     return ret;
   }
@@ -299,9 +324,12 @@ ObPlanCache::ObPlanCache()
    mem_high_pct_(OB_PLAN_CACHE_EVICT_HIGH_PERCENTAGE),
    mem_low_pct_(OB_PLAN_CACHE_EVICT_LOW_PERCENTAGE),
    managed_used_(0),
+   non_sql_managed_used_(0),
+   non_sql_node_count_(0),
    bucket_num_(0),
    inner_allocator_(),
    destroy_(0),
+   sql_plan_detach_epoch_(0),
    evict_timer_(),
    idle_scan_cursor_(0),
    idle_evict_done_round_(false)
@@ -415,10 +443,10 @@ int ObPlanCache::check_after_get_plan(int tmp_ret,
   }
   // if schema expired, update pcv set;
   if (OB_OLD_SCHEMA_VERSION == ret) {
-      if (OB_FAIL(remove_cache_node(pc_ctx.key_))) {
-      } else {
-        ret = OB_SQL_PC_NOT_EXIST;
-      }
+    // get_cache_obj() evicts the exact node while it still owns a node
+    // reference.  Do not erase by logical key here: the key may already name
+    // a replacement node.
+    ret = OB_SQL_PC_NOT_EXIST;
   } else if (plan != NULL && plan->is_expired()) {
     if (pc_ctx.regenerating_expired_plan_) {
       ret = OB_SQL_PC_NOT_EXIST;
@@ -904,6 +932,32 @@ int ObPlanCache::check_can_do_insert_opt(common::ObIAllocator &allocator,
 //1.check memory limit
 //2. add plan
 //3. add plan stat
+void ObPlanCache::prepare_session_sql_plan_admission(ObPlanCacheCtx &pc_ctx)
+{
+  ObSQLSessionInfo *session = pc_ctx.sql_ctx_.session_info_;
+  if (OB_NOT_NULL(session)) {
+    const int ret = session->prune_detached_session_plan_refs(*this);
+    if (OB_SUCCESS != ret) {
+      SQL_PC_LOG(WARN, "failed to prune detached SQL plans before admission",
+                 K(ret));
+    }
+    // A retained plan may still be shared by other sessions, so releasing one
+    // reference does not necessarily lower managed memory. Keep releasing this
+    // session's LRU references until admission is possible or this session has
+    // no more references that can contribute to reclamation.
+    while (is_reach_memory_limit()
+           && session->get_session_plan_ref_count() > 0) {
+      const int tmp_ret = session->evict_lru_session_plan_ref();
+      if (OB_SUCCESS != tmp_ret) {
+        SQL_PC_LOG(WARN,
+                   "failed to evict session LRU plan before admission",
+                   K(tmp_ret));
+        break;
+      }
+    }
+  }
+}
+
 int ObPlanCache::add_plan(ObPhysicalPlan *plan, ObPlanCacheCtx &pc_ctx)
 {
   int ret = OB_SUCCESS;
@@ -911,20 +965,28 @@ int ObPlanCache::add_plan(ObPhysicalPlan *plan, ObPlanCacheCtx &pc_ctx)
   if (OB_ISNULL(plan)) {
     ret = OB_INVALID_ARGUMENT;
     SQL_PC_LOG(WARN, "invalid physical plan", K(ret));
+  } else if (plan->get_mem_size() >= get_mem_high()) {
+    // plan mem is too big, do not add plan
+  } else if (FALSE_IT(prepare_session_sql_plan_admission(pc_ctx))) {
   } else if (is_reach_memory_limit()) {
     ret = OB_REACH_MEMORY_LIMIT;
     if (REACH_TIME_INTERVAL(1000000)) { //1s, when memory reaches the upper limit, this log print will be relatively frequent, so it is printed at an interval of 1s
       SQL_PC_LOG(WARN, "plan cache memory used reach limit",
                         K(get_mem_hold()), K(get_mem_limit()), K(ret));
     }
-  } else if (plan->get_mem_size() >= get_mem_high()) {
-    // plan mem is too big, do not add plan
   } else if (OB_FAIL(construct_plan_cache_key(pc_ctx, ObLibCacheNameSpace::NS_CRSR))) {
   } else if (OB_FAIL(add_plan_cache(pc_ctx, plan))) {
     if (!is_not_supported_err(ret)
         && OB_SQL_PC_PLAN_DUPLICATE != ret
         && OB_PC_LOCK_CONFLICT != ret) {
       SQL_PC_LOG(WARN, "fail to add plan", K(ret));
+    }
+  } else if (OB_NOT_NULL(pc_ctx.sql_ctx_.session_info_)) {
+    const int tmp_ret =
+        pc_ctx.sql_ctx_.session_info_->touch_session_plan_ref(plan);
+    if (OB_SUCCESS != tmp_ret) {
+      SQL_PC_LOG(WARN, "failed to retain SQL plan for session",
+                 K(tmp_ret), KP(plan));
     }
   }
 
@@ -941,21 +1003,9 @@ int ObPlanCache::add_plan_cache(ObILibCacheCtx &ctx,
   } else {
     ObPlanCacheCtx &pc_ctx = static_cast<ObPlanCacheCtx&>(ctx);
     pc_ctx.key_ = &(pc_ctx.fp_result_.pc_key_);
-    int tmp_ret = OB_SUCCESS;
-    if (pc_ctx.regenerating_expired_plan_
-        && OB_SUCCESS != (tmp_ret = remove_cache_node(pc_ctx.key_))) {
-      SQL_PC_LOG(WARN, "fail to remove lib cache node for expired plan", K(tmp_ret));
-    }
     do {
       if (OB_FAIL(add_cache_obj(ctx, pc_ctx.key_, cache_obj)) && OB_OLD_SCHEMA_VERSION == ret) {
         SQL_PC_LOG(INFO, "table or view in plan cache value is old", K(ret));
-      }
-      if (ctx.need_destroy_node_) {
-        SQL_PC_LOG(INFO, "The cache node needs to be evict due to an invalid state", K(ret));
-        if (OB_SUCCESS != (tmp_ret = remove_cache_node(pc_ctx.key_))) {
-          ret = tmp_ret;
-          SQL_PC_LOG(WARN, "fail to remove lib cache node", K(ret));
-        }
       }
     } while (OB_OLD_SCHEMA_VERSION == ret && pc_ctx.need_retry_add_plan());
   }
@@ -974,6 +1024,28 @@ int ObPlanCache::get_plan_cache(ObILibCacheCtx &ctx,
   if (OB_FAIL(check_after_get_plan(ret, ctx, guard.cache_obj_))) {
     // overwrite ret, ret used in check_after_get_plan
   }
+  if (OB_FAIL(ret) && OB_NOT_NULL(pc_ctx.sql_ctx_.session_info_)
+      && pc_ctx.sql_ctx_.session_info_->get_session_plan_ref_count() > 0) {
+    // A miss has no returned Plan to drive touch_slow(). Prune here so a
+    // detached generation is released on the next cache access even when the
+    // replacement Plan will not be admitted.
+    const int tmp_ret =
+        pc_ctx.sql_ctx_.session_info_->prune_detached_session_plan_refs(*this);
+    if (OB_SUCCESS != tmp_ret) {
+      SQL_PC_LOG(WARN, "failed to prune detached SQL plans after cache miss",
+                 K(tmp_ret));
+    }
+  }
+  if (OB_SUCC(ret) && OB_NOT_NULL(guard.cache_obj_)
+      && guard.cache_obj_->is_sql_crsr()
+      && OB_NOT_NULL(pc_ctx.sql_ctx_.session_info_)) {
+    const int tmp_ret =
+        pc_ctx.sql_ctx_.session_info_->touch_session_plan_ref(guard.cache_obj_);
+    if (OB_SUCCESS != tmp_ret) {
+      SQL_PC_LOG(WARN, "failed to retain cached SQL plan for session",
+                 K(tmp_ret), KP(guard.cache_obj_));
+    }
+  }
   if (OB_FAIL(ret) && OB_NOT_NULL(guard.cache_obj_)) {
     co_mgr_.free(guard.cache_obj_);
     guard.cache_obj_ = NULL;
@@ -986,7 +1058,6 @@ int ObPlanCache::add_cache_obj(ObILibCacheCtx &ctx,
                                ObILibCacheObject *cache_obj)
 {
   int ret = OB_SUCCESS;
-  ctx.need_destroy_node_ = false;
   ObLibCacheWlockAndRef w_ref_lock;
   ObILibCacheNode *cache_node = NULL;
   if (OB_ISNULL(key) || OB_ISNULL(cache_obj)) {
@@ -1003,14 +1074,19 @@ int ObPlanCache::add_cache_obj(ObILibCacheCtx &ctx,
     } else if (OB_FAIL(OBLCKeyCreator::create_cache_key(cache_obj->get_ns(),
                                                         cache_node->get_allocator_ref(),
                                                         cache_key))) {
+      cache_node->unlock();
       cache_node->dec_ref_count();//cache node dec ref in alloc
+      cache_node = NULL;
       SQL_PC_LOG(WARN, "failed to create lib cache key", K(ret));
     } else if (OB_FAIL(cache_key->deep_copy(cache_node->get_allocator_ref(),
                                             static_cast<ObILibCacheKey&>(*key)))) {
+      cache_node->unlock();
       cache_node->dec_ref_count();//cache node dec ref in alloc
+      cache_node = NULL;
       SQL_PC_LOG(WARN, "failed to deep copy cache key", K(ret), KPC(key));
     }
     if (OB_SUCC(ret)) {
+      cache_node->set_cache_key(cache_key);
       cache_node->inc_ref_count(); //inc ref count in block
       int hash_err = cache_key_node_map_.set_refactored(cache_key, cache_node);
       if (OB_HASH_EXIST == hash_err) { //may be this node has been set by other thread。
@@ -1045,19 +1121,21 @@ int ObPlanCache::add_cache_obj(ObILibCacheCtx &ctx,
          * is still cached in the lib cache.
          *
          */
-        if (OB_FAIL(add_stat_for_cache_obj(ctx, cache_obj))) {
+        if (cache_obj->is_sql_crsr()
+            && OB_FAIL(cache_node->attach_cache_obj_owner(cache_obj))) {
+          LOG_ERROR("failed to attach cache object owner", K(ret), KP(cache_obj), KP(cache_node));
+        } else if (OB_FAIL(add_stat_for_cache_obj(ctx, cache_obj))) {
           LOG_WARN("failed to add stat", K(ret));
-          ObILibCacheNode *del_node = NULL;
-          int tmp_ret = cache_key_node_map_.erase_refactored(cache_key, &del_node);
-          if (OB_UNLIKELY(tmp_ret != OB_SUCCESS)
-              || OB_UNLIKELY(del_node != cache_node)) {
-            ret = OB_ERR_UNEXPECTED;
-            LOG_WARN("unexpected error", K(ret), K(tmp_ret), K(del_node), K(cache_node));
-          } else {
-            cache_node->unlock();
-            cache_node->dec_ref_count(); //cache node dec ref in block
-            cache_node->dec_ref_count(); //cache node dec ref in alloc
+        }
+        if (OB_FAIL(ret)) {
+          cache_node->unlock();
+          int tmp_ret = remove_cache_node(cache_node);
+          if (OB_SUCCESS != tmp_ret) {
+            LOG_ERROR("failed to remove incompletely initialized cache node",
+                      K(tmp_ret), KP(cache_node));
           }
+          cache_node->dec_ref_count(); //cache node dec ref in alloc
+          cache_node = NULL;
         } else {
           // Keep the node write lock while inspecting the newly cached
           // object.  Once unlocked, concurrent eviction may remove the
@@ -1076,21 +1154,33 @@ int ObPlanCache::add_cache_obj(ObILibCacheCtx &ctx,
         cache_node->dec_ref_count(); //cache node dec ref in alloc
         cache_node = NULL;
       }
-    } else {
-      if (!ctx.need_destroy_node_ && ret != OB_SQL_PC_PLAN_DUPLICATE) {
-        ctx.need_destroy_node_ = true;
-      }
     }
   } else {  /* node exist, add cache obj to it */
+    bool need_remove_node = false;
+    bool need_release_map_ref = false;
     if (cache_node->is_invalid()) {
-      ctx.need_destroy_node_ = true;
+      // This is a pinned old node which may already have been replaced under
+      // the same logical key.  Report that this object was not cached and
+      // retire only the exact node below.
+      ret = OB_PC_LOCK_CONFLICT;
+      need_remove_node = true;
     } else if (OB_FAIL(cache_node->add_cache_obj(ctx, key, cache_obj))) {
+    } else if (cache_obj->is_sql_crsr()
+               && OB_FAIL(cache_node->attach_cache_obj_owner(cache_obj))) {
     } else if (OB_FAIL(cache_node->update_node_stat(ctx))) {
     } else if (OB_FAIL(add_stat_for_cache_obj(ctx, cache_obj))) {
     }
     if (OB_FAIL(ret)) {
-      if (!ctx.need_destroy_node_ && ret != OB_SQL_PC_PLAN_DUPLICATE) {
-        ctx.need_destroy_node_ = true;
+      need_remove_node = (OB_SQL_PC_PLAN_DUPLICATE != ret);
+    }
+    if (need_remove_node) {
+      const int remove_ret = remove_cache_node_locked(*cache_node, need_release_map_ref);
+      if (OB_SUCCESS != remove_ret) {
+        SQL_PC_LOG(ERROR, "failed to remove exact invalid cache node",
+                   K(remove_ret), KP(cache_node), KP(cache_obj));
+        if (OB_SUCC(ret)) {
+          ret = remove_ret;
+        }
       }
     }
     if (OB_SUCC(ret) && cache_obj->added_lc()) {
@@ -1101,6 +1191,9 @@ int ObPlanCache::add_cache_obj(ObILibCacheCtx &ctx,
     }
     // release wlock whatever
     cache_node->unlock();
+    if (need_release_map_ref) {
+      cache_node->dec_ref_count(); // map membership reference
+    }
     cache_node->dec_ref_count();
   }
   return ret;
@@ -1113,6 +1206,8 @@ int ObPlanCache::get_cache_obj(ObILibCacheCtx &ctx,
   int ret = OB_SUCCESS;
   ObILibCacheNode *cache_node = NULL;
   ObILibCacheObject *cache_obj = NULL;
+  bool need_remove_node = false;
+  bool old_schema_node = false;
   // get the read lock and increase reference count
   ObLibCacheRlockAndRef r_ref_lock;
   if (OB_ISNULL(key)) {
@@ -1124,8 +1219,14 @@ int ObPlanCache::get_cache_obj(ObILibCacheCtx &ctx,
   } else {
     if (cache_node->is_invalid()) {
       ret = OB_SQL_PC_NOT_EXIST;
+      // A previous exact erase may have failed after publishing retirement.
+      // Retry the terminal removal so an invalid node cannot remain pinned in
+      // the key map indefinitely.
+      need_remove_node = true;
     } else if (OB_FAIL(cache_node->update_node_stat(ctx))) {
     } else if (OB_FAIL(cache_node->get_cache_obj(ctx, key, cache_obj))) {
+      old_schema_node = (OB_OLD_SCHEMA_VERSION == ret);
+      need_remove_node = old_schema_node;
       if (OB_SQL_PC_NOT_EXIST != ret) {
       }
     } else {
@@ -1133,11 +1234,24 @@ int ObPlanCache::get_cache_obj(ObILibCacheCtx &ctx,
           && static_cast<ObPhysicalPlan*>(cache_obj)->is_expired()
           && static_cast<ObPCVSet*>(cache_node)->set_expired_time()) {
         static_cast<ObPlanCacheCtx&>(ctx).regenerating_expired_plan_ = true;
+        need_remove_node = true;
       }
       guard.cache_obj_ = cache_obj;
     }
     // release lock whatever
     (void)cache_node->unlock();
+    if (need_remove_node) {
+      const int remove_ret = remove_cache_node(cache_node);
+      if (OB_SUCCESS != remove_ret) {
+        SQL_PC_LOG(WARN, "failed to remove exact stale cache node",
+                   K(remove_ret), K(old_schema_node), KP(cache_node));
+        if (old_schema_node) {
+          ret = remove_ret;
+        }
+      } else if (old_schema_node) {
+        ret = OB_SQL_PC_NOT_EXIST;
+      }
+    }
     (void)cache_node->dec_ref_count();
     NG_TRACE(pc_choose_plan);
   }
@@ -1194,9 +1308,10 @@ int ObPlanCache::foreach_cache_evict(CallBack &cb)
   } else if (OB_FAIL(batch_remove_cache_node(*to_evict_list))) {
   }
   if (OB_NOT_NULL(to_evict_list)) {
-    //decrement reference count
+    // Always release every reference already collected by the callback,
+    // including partial lists returned together with an error.
     int64_t N = to_evict_list->count();
-    for (int64_t i = 0; OB_SUCC(ret) && i < N; i++) {
+    for (int64_t i = 0; i < N; i++) {
       if (NULL != to_evict_list->at(i).node_) {
         to_evict_list->at(i).node_->dec_ref_count();
       }
@@ -1283,7 +1398,7 @@ int ObPlanCache::cache_evict()
              "cache_obj_num", get_cache_obj_size(),
              "cache_node_num", cache_key_node_map_.size());
   //determine whether it is still necessary to evict
-  if (get_mem_hold() > get_mem_high()) {
+  if (get_non_sql_managed_used() > get_mem_high()) {
     if (calc_evict_num(cache_evict_num) && cache_evict_num > 0) {
       LCKeyValueArray to_evict_keys;
       LCKeyValueArray idle_evict_keys;
@@ -1292,9 +1407,10 @@ int ObPlanCache::cache_evict()
                                 idle_threshold_us, &idle_evict_keys);
       if (OB_FAIL(foreach_cache_evict(filter))) {
       }
-      // also evict idle-expired nodes collected during the same scan
+      // The filter excludes NS_CRSR, so this retains idle cleanup for the
+      // other library-cache namespaces without putting SQL back on the timer.
       if (OB_SUCC(ret) && idle_evict_keys.count() > 0) {
-        SQL_PC_LOG(INFO, "idle eviction during memory evict",
+        SQL_PC_LOG(INFO, "non-SQL idle eviction during memory evict",
                    "idle_evict_count", idle_evict_keys.count());
         if (OB_FAIL(batch_remove_cache_node(idle_evict_keys))) {
         }
@@ -1304,7 +1420,6 @@ int ObPlanCache::cache_evict()
           }
         }
       }
-      // full scan done, reset idle cursor so cache_evict_by_idle can skip
       idle_scan_cursor_ = 0;
       idle_evict_done_round_ = true;
     }
@@ -1324,9 +1439,9 @@ int ObPlanCache::cache_evict_by_glitch_node()
   int ret = OB_SUCCESS;
   int64_t cache_evict_num = 0;
   query::check_plan_cache_access(access_service());
-  if (get_mem_hold() > get_mem_high()) {
+  if (get_non_sql_managed_used() > get_mem_high()) {
     LCKeyValueArray co_list;
-    ObKVEntryTraverseOp traverse_op(&co_list);
+    ObGetNonSqlKVEntryOp traverse_op(&co_list);
     if (OB_FAIL(cache_key_node_map_.foreach_refactored(traverse_op))) {
     } else {
       int64_t N = co_list.count();
@@ -1339,9 +1454,11 @@ int ObPlanCache::cache_evict_by_glitch_node()
              "cache_obj_num", get_cache_obj_size(),
              "cache_node_num", cache_key_node_map_.size());
       LCKeyValueArray to_evict_list;
-      std::pop_heap(co_list.begin(), co_list.end(), [](const LCKeyValue &left, const LCKeyValue &right) {
-        return left.node_->get_node_stat()->weight() > right.node_->get_node_stat()->weight();
-      });
+      if (N > 0) {
+        std::pop_heap(co_list.begin(), co_list.end(), [](const LCKeyValue &left, const LCKeyValue &right) {
+          return left.node_->get_node_stat()->weight() > right.node_->get_node_stat()->weight();
+        });
+      }
       for (int64_t i = 0; OB_SUCC(ret) && mem_to_free > 0 && i < N; i++) {
         mem_to_free -= co_list.at(i).node_->get_mem_size();
         ++cache_evict_num;
@@ -1351,7 +1468,7 @@ int ObPlanCache::cache_evict_by_glitch_node()
       if (OB_FAIL(ret)) {
       } else if (OB_FAIL(batch_remove_cache_node(to_evict_list))) {
       }
-      for (int64_t i = 0; OB_SUCC(ret) && i < N; i++) {
+      for (int64_t i = 0; i < N; i++) {
         if (nullptr != co_list.at(i).node_) {
           co_list.at(i).node_->dec_ref_count();
         }
@@ -1369,20 +1486,9 @@ int ObPlanCache::cache_evict_by_glitch_node()
   return ret;
 }
 
-// Plan cache only evicts plans when memory exceeds the high water mark,
-// so plans that are no longer accessed can stay cached indefinitely,
-// wasting memory until memory pressure triggers eviction.
-// This function adds idle-based eviction: plans not accessed within
-// IDLE_EVICT_THRESHOLD_US (default 30s) are removed proactively.
-// To avoid scanning all buckets and nodes in a single timer round
-// (which could be expensive with tens of thousands of buckets and
-// many nodes per bucket), the scan is rate-limited by two caps:
-//   - IDLE_SCAN_MAX_BUCKETS: max buckets scanned per round
-//   - IDLE_SCAN_MAX_NODES:   max nodes inspected per round
-// A cursor (idle_scan_cursor_) tracks progress across rounds so that
-// all buckets are eventually covered. Each node's existing
-// last_active_timestamp_ (already updated atomically on every access)
-// is checked against the threshold — no extra work on the hot path.
+// SQL plans retire synchronously when their last session/guard reference is
+// released. Keep the incremental idle scan only for PL/package and the other
+// non-SQL library-cache namespaces.
 int ObPlanCache::cache_evict_by_idle()
 {
   int ret = OB_SUCCESS;
@@ -1390,7 +1496,7 @@ int ObPlanCache::cache_evict_by_idle()
   if (idle_threshold_us <= 0) {
     // idle eviction disabled
   } else {
-  query::check_plan_cache_access(access_service());
+    query::check_plan_cache_access(access_service());
     const int64_t now = ObTimeUtility::current_time();
     const int64_t start_cursor = idle_scan_cursor_;
     int64_t bucket_pos = start_cursor;
@@ -1402,12 +1508,14 @@ int ObPlanCache::cache_evict_by_idle()
            && bucket_pos < bucket_num_
            && scanned_buckets < IDLE_SCAN_MAX_BUCKETS
            && op.scanned_nodes_ < IDLE_SCAN_MAX_NODES) {
-      int64_t batch_end = MIN(bucket_pos + 256, bucket_num_);
+      const int64_t batch_end = MIN(bucket_pos + 256, bucket_num_);
       scanned_buckets += (batch_end - bucket_pos);
-      int tmp_ret = cache_key_node_map_.foreach_refactored_range(op, bucket_pos, batch_end);
+      const int tmp_ret = cache_key_node_map_.foreach_refactored_range(
+          op, bucket_pos, batch_end);
       if (OB_ITER_END == tmp_ret) {
         break;
-      } else if (OB_FAIL(tmp_ret)) {
+      } else if (OB_SUCCESS != tmp_ret) {
+        ret = tmp_ret;
       }
       bucket_pos = batch_end;
     }
@@ -1415,7 +1523,7 @@ int ObPlanCache::cache_evict_by_idle()
     idle_scan_cursor_ = (bucket_pos >= bucket_num_) ? 0 : bucket_pos;
 
     if (to_evict.count() > 0) {
-      SQL_PC_LOG(INFO, "idle eviction collected plans",
+      SQL_PC_LOG(INFO, "idle eviction collected non-SQL cache nodes",
                  "idle_evict_count", to_evict.count(),
                  "scanned_nodes", op.scanned_nodes_,
                  "scanned_buckets", scanned_buckets,
@@ -1432,13 +1540,14 @@ int ObPlanCache::cache_evict_by_idle()
   }
   return ret;
 }
+
 // Calculate the number of pcv_set to be evicted from plan_cache
 // ret = true indicates normal execution, otherwise failure
 bool ObPlanCache::calc_evict_num(int64_t &plan_cache_evict_num)
 {
   bool ret = true;
   // Calculate how much memory each should evict based on their current memory proportions
-  int64_t pc_hold = get_mem_hold();
+  int64_t pc_hold = get_non_sql_managed_used();
   int64_t mem_to_free = pc_hold - get_mem_low();
   if (mem_to_free <= 0) {
     ret = false;
@@ -1447,7 +1556,8 @@ bool ObPlanCache::calc_evict_num(int64_t &plan_cache_evict_num)
   if (ret) {
     if (pc_hold > 0) {
       double evict_percent = static_cast<double>(mem_to_free) / static_cast<double>(pc_hold);
-      plan_cache_evict_num = static_cast<int64_t>(std::ceil(evict_percent * static_cast<double>(cache_key_node_map_.size())));
+      plan_cache_evict_num = static_cast<int64_t>(std::ceil(
+          evict_percent * static_cast<double>(get_non_sql_node_count())));
     } else {
       plan_cache_evict_num = 0;
     }
@@ -1461,8 +1571,17 @@ int ObPlanCache::batch_remove_cache_node(const LCKeyValueArray &to_evict)
   int ret = OB_SUCCESS;
   int64_t N = to_evict.count();
   SQL_PC_LOG(INFO, "actual evict number", "evict_value_num", to_evict.count());
-  for (int64_t i = 0; OB_SUCC(ret) && i < N; ++i) {
-    if (OB_FAIL(remove_cache_node(to_evict.at(i).key_))) {
+  for (int64_t i = 0; i < N; ++i) {
+    // The traversal pins this exact node.  Evict by pointer so a concurrent
+    // retire/reinsert of the same logical key cannot make this batch remove
+    // the replacement node.
+    int tmp_ret = remove_cache_node(to_evict.at(i).node_);
+    if (OB_SUCCESS != tmp_ret) {
+      if (OB_SUCC(ret)) {
+        ret = tmp_ret;
+      }
+      SQL_PC_LOG(WARN, "failed to remove cache node from batch",
+                 K(tmp_ret), "index", i, KP(to_evict.at(i).node_));
     }
   }
   return ret;
@@ -1471,21 +1590,189 @@ int ObPlanCache::batch_remove_cache_node(const LCKeyValueArray &to_evict)
 int ObPlanCache::remove_cache_node(ObILibCacheKey *key)
 {
   int ret = OB_SUCCESS;
-  int hash_err = OB_SUCCESS;
-  ObILibCacheNode *del_node = NULL;
-  hash_err = cache_key_node_map_.erase_refactored(key, &del_node);
-  if (OB_SUCCESS == hash_err) {
-    if (NULL != del_node) {
-      del_node->dec_ref_count();
-    } else {
-      ret = OB_ERR_UNEXPECTED;
-      SQL_PC_LOG(ERROR, "pcv_set should not be null", K(key));
-    }
-  } else if (OB_HASH_NOT_EXIST == hash_err) {
-    SQL_PC_LOG(INFO, "plan cache key is alreay be deleted", K(key));
+  ObILibCacheNode *cache_node = nullptr;
+  ObLibCacheEvictLockAndRef lock_and_ref;
+  bool need_release_map_ref = false;
+  if (OB_ISNULL(key)) {
+    ret = OB_INVALID_ARGUMENT;
+    SQL_PC_LOG(WARN, "invalid null cache key", K(ret));
+  } else if (OB_FAIL(get_value(key, cache_node, lock_and_ref))) {
+  } else if (OB_ISNULL(cache_node)) {
+    // already removed
   } else {
-    ret = hash_err;
-    SQL_PC_LOG(WARN, "failed to erase pcv_set from plan cache by key", K(key), K(hash_err));
+    ret = remove_cache_node_locked(*cache_node, need_release_map_ref);
+    cache_node->unlock();
+    if (need_release_map_ref) {
+      cache_node->dec_ref_count(); // map membership reference
+    }
+    cache_node->dec_ref_count(); // atomic lookup reference
+  }
+  return ret;
+}
+
+int ObPlanCache::remove_cache_node(ObILibCacheNode *cache_node)
+{
+  int ret = OB_SUCCESS;
+  bool need_release_map_ref = false;
+  if (OB_ISNULL(cache_node)) {
+    ret = OB_INVALID_ARGUMENT;
+    SQL_PC_LOG(WARN, "invalid null cache node", K(ret));
+  } else if (OB_FAIL(cache_node->lock_for_eviction())) {
+    SQL_PC_LOG(ERROR, "failed to lock cache node for terminal eviction", K(ret), KP(cache_node));
+  } else {
+    ret = remove_cache_node_locked(*cache_node, need_release_map_ref);
+    cache_node->unlock();
+    if (need_release_map_ref) {
+      cache_node->dec_ref_count(); // map membership reference
+    }
+  }
+  return ret;
+}
+
+int ObPlanCache::try_remove_unused_sql_plan(ObILibCacheNode *cache_node,
+                                            ObILibCacheObject *cache_obj)
+{
+  int ret = OB_SUCCESS;
+  bool need_release_map_ref = false;
+  bool need_release_membership_ref = false;
+  if (OB_ISNULL(cache_node) || OB_ISNULL(cache_obj)
+      || !cache_obj->is_sql_crsr()) {
+    ret = OB_INVALID_ARGUMENT;
+    SQL_PC_LOG(WARN, "invalid SQL plan retirement argument",
+               K(ret), KP(cache_node), KP(cache_obj));
+  } else if (OB_FAIL(cache_node->lock_for_eviction())) {
+    SQL_PC_LOG(ERROR, "failed to lock SQL plan cache node", K(ret), KP(cache_node));
+  } else {
+    bool should_fallback_to_node_eviction = false;
+    bool pcv_removed = false;
+    bool pcv_empty = false;
+    bool membership_removed = false;
+    bool membership_empty = false;
+    {
+      // Serialize the final ref-count check with owner detachment. A lookup
+      // that acquired the node read lock first increments the guard reference
+      // before this write lock can be obtained.
+      ObByteLockGuard obj_guard(cache_obj->cache_node_lock_);
+      if (cache_obj->cache_node_ != cache_node
+          || 1 != cache_obj->get_ref_count()) {
+        // The plan was already detached, or acquired a new owner meanwhile.
+      } else if (cache_node->eviction_started()) {
+        // Whole-node eviction owns the remaining cleanup.
+      } else if (OB_FAIL(static_cast<ObPCVSet *>(cache_node)->remove_plan(
+                             static_cast<ObPlanCacheObject *>(cache_obj),
+                             pcv_removed,
+                             pcv_empty))) {
+        should_fallback_to_node_eviction = true;
+        SQL_PC_LOG(ERROR, "failed to unlink physical plan from PCVSet",
+                   K(ret), KP(cache_node), KP(cache_obj));
+      } else if (!pcv_removed) {
+        ret = OB_ERR_UNEXPECTED;
+        should_fallback_to_node_eviction = true;
+        SQL_PC_LOG(ERROR, "physical plan is absent from PCVSet",
+                   K(ret), KP(cache_node), KP(cache_obj));
+      } else if (OB_FAIL(remove_cache_obj_stat_entry(cache_obj->get_object_id()))) {
+        should_fallback_to_node_eviction = true;
+        SQL_PC_LOG(ERROR, "failed to remove physical plan object-id index",
+                   K(ret), KP(cache_obj));
+      } else if (OB_FAIL(cache_node->unlink_cache_obj(
+                             cache_obj, membership_removed, membership_empty))) {
+        should_fallback_to_node_eviction = true;
+        SQL_PC_LOG(ERROR, "failed to unlink physical plan membership",
+                   K(ret), KP(cache_node), KP(cache_obj));
+      } else if (!membership_removed) {
+        ret = OB_ERR_UNEXPECTED;
+        should_fallback_to_node_eviction = true;
+        SQL_PC_LOG(ERROR, "physical plan has no node membership",
+                   K(ret), KP(cache_node), KP(cache_obj));
+      } else {
+        if (OB_UNLIKELY(pcv_empty != membership_empty)) {
+          SQL_PC_LOG(ERROR, "PCVSet and cache-object membership disagree on emptiness",
+                     K(pcv_empty), K(membership_empty), KP(cache_node), KP(cache_obj));
+        }
+        cache_obj->cache_node_ = nullptr;
+        cache_obj->set_added_lc(false);
+        need_release_membership_ref = true;
+      }
+    }
+    if (should_fallback_to_node_eviction) {
+      const int remove_ret = remove_cache_node_locked(*cache_node, need_release_map_ref);
+      if (OB_SUCCESS != remove_ret) {
+        SQL_PC_LOG(ERROR, "failed to evict inconsistent SQL plan cache node",
+                   K(remove_ret), KP(cache_node), KP(cache_obj));
+      }
+      ret = remove_ret;
+    } else if (need_release_membership_ref && membership_empty) {
+      ret = remove_cache_node_locked(*cache_node, need_release_map_ref);
+    } else if (need_release_membership_ref) {
+      refresh_cache_node(*cache_node);
+    }
+    cache_node->unlock();
+    if (need_release_map_ref) {
+      cache_node->dec_ref_count(); // map membership reference
+    }
+    if (need_release_membership_ref) {
+      co_mgr_.free(cache_obj); // physical-plan membership reference
+    }
+  }
+  return ret;
+}
+
+int ObPlanCache::remove_cache_node_locked(ObILibCacheNode &cache_node,
+                                          bool &need_release_map_ref)
+{
+  int ret = OB_SUCCESS;
+  need_release_map_ref = false;
+  int64_t detached_owner_count = 0;
+  if (OB_ISNULL(cache_node.get_cache_key())) {
+    ret = OB_ERR_UNEXPECTED;
+    SQL_PC_LOG(ERROR, "published cache node has no map key", K(ret), KP(&cache_node));
+  } else {
+    if (!cache_node.eviction_started()) {
+      // Publish retirement before removing the node from the key map.
+      cache_node.begin_eviction();
+    }
+
+    // remove_all_plan_stat() is idempotent because an already absent weak-id
+    // entry is success.  Retry it on every terminal-removal attempt and do
+    // not detach/destroy objects while a weak diagnostic pointer might remain.
+    if (OB_FAIL(cache_node.remove_all_plan_stat())) {
+      SQL_PC_LOG(ERROR, "failed to erase cache object id indexes",
+                 K(ret), KP(&cache_node));
+    } else {
+      detached_owner_count = cache_node.detach_cache_obj_owners();
+      if (detached_owner_count > 0
+          && ObLibCacheNameSpace::NS_CRSR
+              == cache_node.get_cache_key()->namespace_) {
+        // Publish only after all owner pointers were detached. A session that
+        // observes the new epoch can then safely prune every stale reference.
+        ATOMIC_AAF(&sql_plan_detach_epoch_, 1);
+      }
+
+      // Retry the exact-pointer map erase even when retirement was started by
+      // a previous call.  A transient erase failure must not strand an invalid
+      // node (and its map reference) forever.
+      ObILibCacheNode *removed_node = nullptr;
+      bool is_erased = false;
+      ObRemoveExactCacheNodeOp remove_exact(&cache_node);
+      const int hash_ret = cache_key_node_map_.erase_if(
+          cache_node.get_cache_key(), remove_exact, is_erased, &removed_node);
+      if (OB_SUCCESS == hash_ret) {
+        if (is_erased) {
+          OB_ASSERT(removed_node == &cache_node);
+          need_release_map_ref = true;
+        } else {
+          // The same logical key already names a newer node.  Retire only this
+          // old node; never erase the replacement (ABA protection).
+        }
+      } else if (OB_HASH_NOT_EXIST == hash_ret) {
+        // Be defensive for a node detached by a legacy path.  No map reference
+        // remains, but owner pointers still must be cleared before the caller
+        // releases its final node reference.
+      } else {
+        ret = hash_ret;
+        SQL_PC_LOG(ERROR, "failed to erase cache node", K(ret), KP(&cache_node));
+      }
+    }
   }
   return ret;
 }
@@ -1564,11 +1851,15 @@ int ObPlanCache::add_cache_obj_stat(ObILibCacheCtx &ctx, ObILibCacheObject *cach
     SQL_PC_LOG(WARN, "invalid argument", K(cache_obj), K(ret));
   } else if (OB_FAIL(cache_obj->update_cache_obj_stat(ctx))) {
   } else {
-    cache_obj->inc_ref_count();
+    if (!cache_obj->is_sql_crsr()) {
+      cache_obj->inc_ref_count();
+    }
     if (OB_FAIL(co_mgr_.add_cache_obj(cache_obj))) {
       LOG_WARN("failed to set element", K(ret), K(cache_obj->get_object_id()));
-      co_mgr_.free(cache_obj);
-      cache_obj = NULL;
+      if (!cache_obj->is_sql_crsr()) {
+        co_mgr_.free(cache_obj);
+        cache_obj = NULL;
+      }
     } else {
       LOG_TRACE("succeeded to add cache object stat", K(cache_obj->get_object_id()), K(cache_obj));
     }
@@ -1700,6 +1991,9 @@ void ObPlanCache::account_cache_object(ObILibCacheObject &cache_obj)
   const int64_t accounted_size = cache_obj.get_mem_size() + lib::MemoryContext::metadata_size();
   if (cache_obj.set_accounted_size_once(accounted_size)) {
     inc_managed_used(accounted_size);
+    if (!cache_obj.is_sql_crsr()) {
+      inc_non_sql_managed_used(accounted_size);
+    }
   }
 }
 
@@ -1707,21 +2001,46 @@ void ObPlanCache::refresh_cache_node(ObILibCacheNode &cache_node)
 {
   const int64_t accounted_size = cache_node.get_own_mem_size() + lib::MemoryContext::metadata_size();
   const int64_t old_size = cache_node.exchange_accounted_size(accounted_size);
+  const bool is_non_sql = OB_NOT_NULL(cache_node.get_cache_key())
+      && ObLibCacheNameSpace::NS_CRSR
+          != cache_node.get_cache_key()->namespace_;
   if (accounted_size > old_size) {
     inc_managed_used(accounted_size - old_size);
+    if (is_non_sql) {
+      inc_non_sql_managed_used(accounted_size - old_size);
+    }
   } else if (old_size > accounted_size) {
     dec_managed_used(old_size - accounted_size);
+    if (is_non_sql) {
+      dec_non_sql_managed_used(old_size - accounted_size);
+    }
+  }
+  if (is_non_sql && 0 == old_size && accounted_size > 0) {
+    ATOMIC_INC(&non_sql_node_count_);
   }
 }
 
 void ObPlanCache::release_cache_object(ObILibCacheObject &cache_obj)
 {
-  dec_managed_used(cache_obj.take_accounted_size());
+  const int64_t accounted_size = cache_obj.take_accounted_size();
+  dec_managed_used(accounted_size);
+  if (!cache_obj.is_sql_crsr()) {
+    dec_non_sql_managed_used(accounted_size);
+  }
 }
 
 void ObPlanCache::release_cache_node_memory_account(ObILibCacheNode &cache_node)
 {
-  dec_managed_used(cache_node.exchange_accounted_size(0));
+  const int64_t accounted_size = cache_node.exchange_accounted_size(0);
+  dec_managed_used(accounted_size);
+  if (OB_NOT_NULL(cache_node.get_cache_key())
+      && ObLibCacheNameSpace::NS_CRSR
+          != cache_node.get_cache_key()->namespace_) {
+    dec_non_sql_managed_used(accounted_size);
+    if (accounted_size > 0) {
+      ATOMIC_DEC(&non_sql_node_count_);
+    }
+  }
 }
 // Add plan to plan cache
 // 1. Determine if plan cache memory has reached its limit;
@@ -1777,12 +2096,14 @@ int ObPlanCache::add_ps_plan(T *plan, ObPlanCacheCtx &pc_ctx)
   if (OB_ISNULL(plan)) {
     ret = OB_INVALID_ARGUMENT;
     SQL_PC_LOG(WARN, "invalid physical plan", K(ret));
+  } else if (plan->get_mem_size() >= get_mem_high()) {
+    // plan mem is too big to reach memory highwater, do not add plan
+  } else if (plan->is_sql_crsr()
+             && FALSE_IT(prepare_session_sql_plan_admission(pc_ctx))) {
   } else if (is_reach_memory_limit()) {
     ret = OB_REACH_MEMORY_LIMIT;
     SQL_PC_LOG(TRACE, "plan cache memory used reach the high water mark",
     K(managed_used_), K(get_mem_limit()), K(ret));
-  } else if (plan->get_mem_size() >= get_mem_high()) {
-    // plan mem is too big to reach memory highwater, do not add plan
   } else if (OB_FAIL(construct_plan_cache_key(pc_ctx, ObLibCacheNameSpace::NS_CRSR))) {
   } else if (OB_ISNULL(pc_ctx.raw_sql_.ptr())) {
     ret = OB_ERR_UNEXPECTED;
@@ -1793,6 +2114,14 @@ int ObPlanCache::add_ps_plan(T *plan, ObPlanCacheCtx &pc_ctx)
     uint64_t old_stmt_id = pc_ctx.fp_result_.pc_key_.key_id_;
     pc_ctx.fp_result_.pc_key_.key_id_ = OB_INVALID_ID;
     if (OB_FAIL(add_plan_cache(pc_ctx, plan))) {
+    } else if (plan->is_sql_crsr()
+               && OB_NOT_NULL(pc_ctx.sql_ctx_.session_info_)) {
+      const int tmp_ret =
+          pc_ctx.sql_ctx_.session_info_->touch_session_plan_ref(plan);
+      if (OB_SUCCESS != tmp_ret) {
+        SQL_PC_LOG(WARN, "failed to retain PS SQL plan for session",
+                   K(tmp_ret), KP(plan));
+      }
     }
     // reset pc_ctx
     pc_ctx.fp_result_.pc_key_.name_.reset();
@@ -2296,7 +2625,7 @@ void ObPlanCacheEliminationTask::run_plan_cache_task()
   if (OB_FAIL(plan_cache_->cache_evict())) {
   }  else if (OB_FAIL(plan_cache_->cache_evict_by_glitch_node())) {
   }
-  // skip idle eviction if cache_evict() already did a full scan with idle collection
+  // A memory-pressure scan already covered every non-SQL node in this round.
   if (plan_cache_->idle_evict_done_round_) {
     plan_cache_->idle_evict_done_round_ = false;
   } else if (OB_FAIL(plan_cache_->cache_evict_by_idle())) {

--- a/src/sql/plan_cache/ob_plan_cache.cpp
+++ b/src/sql/plan_cache/ob_plan_cache.cpp
@@ -1445,7 +1445,13 @@ int ObPlanCache::cache_evict_by_glitch_node()
     if (OB_FAIL(cache_key_node_map_.foreach_refactored(traverse_op))) {
     } else {
       int64_t N = co_list.count();
-      int64_t mem_to_free = traverse_op.get_total_mem_used() / 2;
+      // The traversal callback only pins nodes. Acquire node locks after
+      // leaving the key-map bucket locks: retirement takes node -> key map.
+      int64_t total_mem_used = 0;
+      for (int64_t i = 0; i < N; ++i) {
+        total_mem_used += co_list.at(i).node_->get_mem_size();
+      }
+      int64_t mem_to_free = total_mem_used / 2;
       SQL_PC_LOG(INFO, "cache evict plan by glitch node start",
              
              "mem_hold", get_mem_hold(),
@@ -1656,7 +1662,7 @@ int ObPlanCache::try_remove_unused_sql_plan(ObILibCacheNode *cache_node,
       if (cache_obj->cache_node_ != cache_node
           || 1 != cache_obj->get_ref_count()) {
         // The plan was already detached, or acquired a new owner meanwhile.
-      } else if (cache_node->eviction_started()) {
+      } else if (cache_node->is_marked_for_eviction()) {
         // Whole-node eviction owns the remaining cleanup.
       } else if (OB_FAIL(static_cast<ObPCVSet *>(cache_node)->remove_plan(
                              static_cast<ObPlanCacheObject *>(cache_obj),
@@ -1727,9 +1733,9 @@ int ObPlanCache::remove_cache_node_locked(ObILibCacheNode &cache_node,
     ret = OB_ERR_UNEXPECTED;
     SQL_PC_LOG(ERROR, "published cache node has no map key", K(ret), KP(&cache_node));
   } else {
-    if (!cache_node.eviction_started()) {
+    if (!cache_node.is_marked_for_eviction()) {
       // Publish retirement before removing the node from the key map.
-      cache_node.begin_eviction();
+      cache_node.mark_for_eviction();
     }
 
     // remove_all_plan_stat() is idempotent because an already absent weak-id
@@ -1905,7 +1911,13 @@ int ObPlanCache::create_node_and_add_cache_obj(ObILibCacheKey *cache_key,
     cache_node = NULL;
   }
   if (NULL != cache_node) {
-    cache_node->lock(true); // add read lock
+    // The node is still private, so this cannot contend. Keep a write lock
+    // through publication and owner attachment, like insertion into an
+    // existing node.
+    if (OB_FAIL(cache_node->lock(false /* write lock */))) {
+      cache_node->dec_ref_count();
+      cache_node = nullptr;
+    }
   }
   return ret;
 }

--- a/src/sql/plan_cache/ob_plan_cache.h
+++ b/src/sql/plan_cache/ob_plan_cache.h
@@ -61,8 +61,7 @@ struct ObKVEntryTraverseOp
 {
   typedef common::hash::HashMapPair<ObILibCacheKey *, ObILibCacheNode *> LibCacheKVEntry;
   explicit ObKVEntryTraverseOp(LCKeyValueArray *key_val_list)
-    : total_mem_used_(0),
-      key_value_list_(key_val_list)
+    : key_value_list_(key_val_list)
   {
   }
 
@@ -86,15 +85,12 @@ struct ObKVEntryTraverseOp
       if (OB_FAIL(key_value_list_->push_back(ObLCKeyValue(entry.first, entry.second)))) {
       } else {
         entry.second->inc_ref_count();
-        total_mem_used_ += entry.second->get_mem_size();
       }
     }
     return ret;
   }
-  int64_t get_total_mem_used() const { return total_mem_used_; }
   LCKeyValueArray *get_key_value_list() { return key_value_list_; }
 
-  int64_t total_mem_used_;
   LCKeyValueArray *key_value_list_;
 };
 

--- a/src/sql/plan_cache/ob_plan_cache.h
+++ b/src/sql/plan_cache/ob_plan_cache.h
@@ -287,7 +287,8 @@ public:
    *    low water mark
    *    memory used
    */
-  // Background thread will check memory-related settings every 30s, if updated it will change, therefore atomic operation is needed
+  // The library-cache maintenance task periodically refreshes these settings,
+  // so reads and writes must be atomic.
   int set_mem_conf(const ObPCMemPctConf &conf);
   int update_memory_conf();
   int64_t get_mem_limit() const
@@ -312,6 +313,10 @@ public:
   void set_mem_low_pct(int64_t pct) { ATOMIC_STORE(&mem_low_pct_, pct); }
 
   int64_t get_managed_used() const { return ATOMIC_LOAD(&managed_used_); }
+  int64_t get_non_sql_managed_used() const
+  { return ATOMIC_LOAD(&non_sql_managed_used_); }
+  int64_t get_non_sql_node_count() const
+  { return ATOMIC_LOAD(&non_sql_node_count_); }
   void inc_managed_used(const int64_t mem_delta)
   {
     if (mem_delta > 0) {
@@ -330,6 +335,28 @@ public:
       if (OB_UNLIKELY(old_value < mem_delta)) {
         SQL_PC_LOG_RET(WARN, OB_ERR_UNEXPECTED,
             "plan cache managed memory accounting underflow",
+            K(mem_delta), K(old_value));
+      }
+    }
+  }
+  void inc_non_sql_managed_used(const int64_t mem_delta)
+  {
+    if (mem_delta > 0) {
+      ATOMIC_FAA(&non_sql_managed_used_, mem_delta);
+    }
+  }
+  void dec_non_sql_managed_used(const int64_t mem_delta)
+  {
+    if (mem_delta > 0) {
+      int64_t old_value = 0;
+      int64_t new_value = 0;
+      do {
+        old_value = ATOMIC_LOAD(&non_sql_managed_used_);
+        new_value = old_value > mem_delta ? old_value - mem_delta : 0;
+      } while (!ATOMIC_BCAS(&non_sql_managed_used_, old_value, new_value));
+      if (OB_UNLIKELY(old_value < mem_delta)) {
+        SQL_PC_LOG_RET(WARN, OB_ERR_UNEXPECTED,
+            "non-SQL library cache managed memory accounting underflow",
             K(mem_delta), K(old_value));
       }
     }
@@ -379,6 +406,11 @@ public:
   const ObPlanCacheStat &get_plan_cache_stat() const { return pc_stat_; }
   int remove_cache_obj_stat_entry(const ObCacheObjID cache_obj_id);
   int remove_cache_node(ObILibCacheKey *key);
+  int remove_cache_node(ObILibCacheNode *node);
+  int try_remove_unused_sql_plan(ObILibCacheNode *node,
+                                 ObILibCacheObject *cache_obj);
+  int64_t get_sql_plan_detach_epoch() const
+  { return ATOMIC_LOAD(&sql_plan_detach_epoch_); }
   ObLCObjectManager &get_cache_obj_mgr() { return co_mgr_; }
   ObLCNodeFactory &get_cache_node_factory() { return cn_factory_; }
   int alloc_cache_obj(ObCacheObjGuard& guard, ObLibCacheNameSpace ns);
@@ -441,6 +473,8 @@ private:
   bool calc_evict_num(int64_t &plan_cache_evict_num);
 
   int batch_remove_cache_node(const LCKeyValueArray &to_evict);
+  int remove_cache_node_locked(ObILibCacheNode &node,
+                               bool &need_release_map_ref);
   bool is_reach_memory_limit() { return get_managed_used() > get_mem_limit(); }
   int construct_plan_cache_key(ObPlanCacheCtx &plan_ctx, ObLibCacheNameSpace ns);
   static int construct_plan_cache_key(ObSQLSessionInfo &session,
@@ -451,6 +485,7 @@ private:
                                     ObILibCacheCtx &ctx,
                                     ObILibCacheObject *cache_obj,
                                     ObILibCacheNode *&node);
+  void prepare_session_sql_plan_admission(ObPlanCacheCtx &pc_ctx);
   int check_after_get_plan(int tmp_ret, ObILibCacheCtx &ctx, ObILibCacheObject *cache_obj);
   int get_normalized_pattern_digest(const ObPlanCacheCtx &pc_ctx, uint64_t &pattern_digest);
 private:
@@ -464,6 +499,10 @@ private:
   int64_t mem_high_pct_;                     // high water mark percentage
   int64_t mem_low_pct_;                      // low water mark percentage
   int64_t managed_used_;
+  // The shared 5-second library-cache task must not be triggered or sized by
+  // SQL plans. These counters cover PL/package/etc. only.
+  int64_t non_sql_managed_used_;
+  int64_t non_sql_node_count_;
   int64_t bucket_num_;
   lib::MemoryContext root_context_;
   common::ObMalloc inner_allocator_;
@@ -474,6 +513,10 @@ private:
   ObLCObjectManager co_mgr_;
   ObLCNodeFactory cn_factory_;
   CacheKeyNodeMap cache_key_node_map_;
+  // Advanced after SQL plans are detached from a shared cache node. Sessions
+  // compare this epoch before admission/miss handling and lazily drop stale
+  // retained references instead of requiring a global session traversal.
+  int64_t sql_plan_detach_epoch_;
   ObPlanCacheEliminationTask evict_task_;
   common::ObTimer evict_timer_;
   int64_t idle_scan_cursor_;

--- a/src/sql/plan_cache/ob_plan_cache_callback.h
+++ b/src/sql/plan_cache/ob_plan_cache_callback.h
@@ -68,6 +68,18 @@ private:
   DISALLOW_COPY_AND_ASSIGN(ObLibCacheWlockAndRef);
 };
 
+// Node retirement is a terminal lifecycle operation. Unlike normal cache
+// lookup/add, it must wait for the lock instead of leaving a permanent
+// membership-only reference after a short lock conflict.
+class ObLibCacheEvictLockAndRef : public ObLibCacheAtomicOp
+{
+public:
+  virtual int lock(ObILibCacheNode &cache_node) override
+  {
+    return cache_node.lock_for_eviction();
+  }
+};
+
 class ObLibCacheRlockAndRef : public ObLibCacheAtomicOp
 {
 public:

--- a/src/sql/plan_cache/ob_plan_cache_value.cpp
+++ b/src/sql/plan_cache/ob_plan_cache_value.cpp
@@ -985,6 +985,48 @@ int ObPlanCacheValue::add_plan(ObPlanCacheObject &plan,
   }
   return ret;
 }
+
+int ObPlanCacheValue::remove_plan(const ObPlanCacheObject *cache_obj,
+                                  bool &removed,
+                                  bool &empty)
+{
+  int ret = OB_SUCCESS;
+  removed = false;
+  empty = false;
+  if (OB_ISNULL(cache_obj)) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid null cache object", K(ret));
+  } else {
+    int64_t removed_count = 0;
+    DLIST_FOREACH_REMOVESAFE(plan_set, plan_sets_) {
+      bool removed_from_set = false;
+      if (OB_FAIL(plan_set->remove_cache_obj(cache_obj, removed_from_set))) {
+        if (OB_ENTRY_NOT_EXIST == ret) {
+          ret = OB_SUCCESS;
+        }
+      } else if (removed_from_set) {
+        ++removed_count;
+        if (plan_set->empty()) {
+          plan_sets_.remove(plan_set);
+          free_plan_set(plan_set);
+          plan_set = nullptr;
+        }
+      }
+    }
+    if (OB_SUCC(ret)) {
+      if (removed_count > 1) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_ERROR("physical plan occurs in multiple plan sets",
+                  K(ret), K(removed_count), KP(cache_obj), KP(this));
+      } else {
+        removed = (1 == removed_count);
+        empty = plan_sets_.is_empty();
+      }
+    }
+  }
+  return ret;
+}
+
 void ObPlanCacheValue::reset()
 {
   // TODO TBD: do nothing to rw_lock_

--- a/src/sql/plan_cache/ob_plan_cache_value.h
+++ b/src/sql/plan_cache/ob_plan_cache_value.h
@@ -215,6 +215,9 @@ public:
   int add_plan(ObPlanCacheObject &cache_obj,
                const common::ObIArray<PCVSchemaObj> &schema_array,
                ObPlanCacheCtx &pc_ctx);
+  int remove_plan(const ObPlanCacheObject *cache_obj,
+                  bool &removed,
+                  bool &empty);
 
   int match_and_generate_ext_params(ObPlanSet *batch_plan_set,
                                     ObPlanCacheCtx &pc_ctx);

--- a/src/sql/plan_cache/ob_plan_set.cpp
+++ b/src/sql/plan_cache/ob_plan_set.cpp
@@ -541,23 +541,6 @@ ObPlanCache *ObPlanSet::get_plan_cache() const
   return pc;
 }
 
-int ObPlanSet::remove_cache_obj_entry(const ObCacheObjID obj_id)
-{
-  int ret = OB_SUCCESS;
-  ObPlanCache *pc = NULL;
-  ObPCVSet *pcv_set = NULL;
-  if (OB_ISNULL(get_plan_cache_value())
-     || OB_ISNULL(pcv_set = get_plan_cache_value()->get_pcv_set())) {
-    ret = OB_ERR_UNEXPECTED;
-    LOG_WARN("invalid argument", K(pcv_set));
-  } else if (NULL == (pc = get_plan_cache())) {
-    LOG_WARN("invalid argument", K(pc));
-  } else if (OB_FAIL(pcv_set->remove_cache_obj_entry(obj_id))) {
-  } else if (OB_FAIL(pc->remove_cache_obj_stat_entry(obj_id))) {
-  }
-  return ret;
-}
-
 int ObPlanSet::init_new_set(const ObPlanCacheCtx &pc_ctx,
                             const ObPlanCacheObject &plan,
                             common::ObIAllocator* pc_alloc_)
@@ -1367,6 +1350,67 @@ int ObSqlPlanSet::calc_phy_plan_type_v2(const ObPlanCacheCtx &pc_ctx,
 void ObSqlPlanSet::remove_all_plan()
 {
   IGNORE_RETURN dist_plans_.remove_all_plan();
+}
+
+int ObSqlPlanSet::remove_cache_obj(const ObPlanCacheObject *cache_obj,
+                                   bool &removed)
+{
+  int ret = OB_SUCCESS;
+  int64_t owning_entry_count = 0;
+  removed = false;
+  if (OB_ISNULL(cache_obj) || !cache_obj->is_sql_crsr()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid SQL cache object", K(ret), KP(cache_obj));
+  } else {
+    const ObPhysicalPlan *plan = static_cast<const ObPhysicalPlan *>(cache_obj);
+    if (array_binding_plan_ == plan) {
+      array_binding_plan_ = nullptr;
+      ++owning_entry_count;
+    }
+    if (direct_local_plan_ == plan) {
+      direct_local_plan_ = nullptr;
+    }
+    for (int64_t i = 0; OB_SUCC(ret) && i < local_plans_.count(); ++i) {
+      if (local_plans_.at(i) == plan) {
+        if (OB_FAIL(local_plans_.remove(i))) {
+          LOG_WARN("failed to remove local plan", K(ret), K(i), KP(plan));
+        } else {
+          ++owning_entry_count;
+        }
+        break;
+      }
+    }
+    if (OB_SUCC(ret) && OB_ISNULL(direct_local_plan_) && !local_plans_.empty()) {
+      direct_local_plan_ = local_plans_.at(0);
+    }
+    if (OB_SUCC(ret)) {
+      bool dist_removed = false;
+      if (OB_FAIL(dist_plans_.remove_plan(plan, dist_removed))) {
+      } else if (dist_removed) {
+        ++owning_entry_count;
+      }
+    }
+    if (OB_SUCC(ret)) {
+      if (1 == owning_entry_count) {
+        removed = true;
+      } else if (0 == owning_entry_count) {
+        ret = OB_ENTRY_NOT_EXIST;
+      } else {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_ERROR("physical plan occurs in multiple plan-set containers",
+                  K(ret), K(owning_entry_count), KP(plan), KP(this));
+      }
+    }
+  }
+  return ret;
+}
+
+bool ObSqlPlanSet::empty() const
+{
+  return OB_ISNULL(array_binding_plan_)
+         && local_plans_.empty()
+         && OB_ISNULL(direct_local_plan_)
+         && dist_plans_.empty();
 }
 
 

--- a/src/sql/plan_cache/ob_plan_set.h
+++ b/src/sql/plan_cache/ob_plan_set.h
@@ -216,6 +216,9 @@ public:
   virtual int select_plan(ObPlanCacheCtx &pc_ctx,
                           ObPlanCacheObject *&plan) = 0;
   virtual void remove_all_plan() = 0;
+  virtual int remove_cache_obj(const ObPlanCacheObject *cache_obj,
+                               bool &removed) = 0;
+  virtual bool empty() const = 0;
   virtual int64_t get_mem_size() = 0;
   virtual void reset();
   virtual int init_new_set(const ObPlanCacheCtx &pc_ctx,
@@ -229,8 +232,6 @@ public:
                //const ParamStore & param_store,
                /*bool &same_bool_param);*/
   inline bool is_multi_stmt_plan() const { return !multi_stmt_rowkey_pos_.empty(); }
-  int remove_cache_obj_entry(const ObCacheObjID obj_id);
-
   bool get_can_skip_params_match() { return can_skip_params_match_; }
   bool get_can_delay_init_datum_store() { return can_delay_init_datum_store_; }
 
@@ -323,6 +324,9 @@ public:
   virtual int select_plan(ObPlanCacheCtx &pc_ctx,
                           ObPlanCacheObject *&cache_obj) override;
   virtual void remove_all_plan() override;
+  virtual int remove_cache_obj(const ObPlanCacheObject *cache_obj,
+                               bool &removed) override;
+  virtual bool empty() const override;
   virtual int64_t get_mem_size() override;
   virtual void reset() override;
   virtual bool is_sql_planset() override;

--- a/src/sql/session/ob_sql_session_info.cpp
+++ b/src/sql/session/ob_sql_session_info.cpp
@@ -16,6 +16,7 @@
 
 #define USING_LOG_PREFIX SQL_SESSION
 
+#include <functional>
 #include <new>
 #include "data_plane/memtable/ob_btree_iter_cache_api.h"
 #include "data_plane/transaction/ob_i_read_timestamp_service.h"
@@ -29,6 +30,8 @@
 #include "sql/pl/ob_pl_package.h"
 #include "sql/pl/ob_pl_server_cursor.h"
 #include "share/ob_server_struct.h"
+#include "sql/plan_cache/ob_cache_object_factory.h"
+#include "sql/plan_cache/ob_plan_cache.h"
 #include "sql/plan_cache/ob_ps_cache.h"
 #include "sql/optimizer/stat/ob_opt_stat_manager.h" // for ObOptStatManager
 #include "sql/session/ob_user_resource_mgr.h"
@@ -154,6 +157,7 @@ ObSQLSessionInfo::ObSQLSessionInfo() :
       conn_res_user_id_(OB_INVALID_ID),
       conn_res_mgr_(nullptr),
       session_mgr_(nullptr),
+      session_plan_ref_cache_(),
       cur_exec_ctx_(nullptr),
       in_bytes_(0),
       out_bytes_(0),
@@ -220,6 +224,7 @@ int ObSQLSessionInfo::test_init(uint32_t version, uint32_t sessid,
 void ObSQLSessionInfo::reset(bool skip_sys_var)
 {
   if (is_inited_) {
+    reset_session_plan_refs();
     // ObVersionProvider::reset();
     warnings_buf_.reset();
     show_warnings_buf_.reset();
@@ -290,6 +295,200 @@ void ObSQLSessionInfo::reset(bool skip_sys_var)
 void ObSQLSessionInfo::clean_status()
 {
   ObBasicSessionInfo::clean_status();
+}
+
+int ObSessionPlanRefCache::prune_detached(ObPlanCache &plan_cache)
+{
+  int ret = OB_SUCCESS;
+  const int64_t detach_epoch = plan_cache.get_sql_plan_detach_epoch();
+  if (detach_epoch != last_seen_sql_plan_detach_epoch_) {
+    // FLUSH and correctness eviction may detach a shared node while an idle
+    // session still owns a reference. Release those stale generations at the
+    // session's next relevant cache access; an entirely idle session releases
+    // them when the session ends.
+    for (int64_t i = 0; OB_SUCC(ret) && i < plan_refs_.count();) {
+      ObILibCacheObject *stale_plan = plan_refs_.at(i).plan_;
+      if (OB_ISNULL(stale_plan)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_ERROR("invalid null session SQL plan reference", K(ret), K(i));
+      } else if (stale_plan->is_attached_to_cache_node()) {
+        ++i;
+      } else if (OB_FAIL(plan_refs_.remove(i))) {
+        LOG_ERROR("failed to remove detached session SQL plan reference",
+                  K(ret), K(i), KP(stale_plan));
+      } else {
+        ObCacheObjectFactory::free(stale_plan);
+      }
+    }
+    if (OB_SUCC(ret)) {
+      if (plan_refs_.empty()) {
+        touch_seq_ = 0;
+      }
+      last_seen_sql_plan_detach_epoch_ = detach_epoch;
+    }
+  }
+  return ret;
+}
+
+int64_t ObSessionPlanRefCache::lower_bound(ObILibCacheObject *plan,
+                                           bool &found) const
+{
+  int64_t left = 0;
+  int64_t right = plan_refs_.count();
+  std::less<ObILibCacheObject *> less;
+  while (left < right) {
+    const int64_t middle = left + (right - left) / 2;
+    if (less(plan_refs_.at(middle).plan_, plan)) {
+      left = middle + 1;
+    } else {
+      right = middle;
+    }
+  }
+  found = left < plan_refs_.count() && plan_refs_.at(left).plan_ == plan;
+  return left;
+}
+
+uint64_t ObSessionPlanRefCache::next_touch_seq()
+{
+  if (OB_UNLIKELY(UINT64_MAX == touch_seq_)) {
+    // Preserve the exact LRU order across the practically unreachable wrap.
+    uint64_t old_seq[CAPACITY];
+    bool ranked[CAPACITY] = {};
+    for (int64_t i = 0; i < plan_refs_.count(); ++i) {
+      old_seq[i] = plan_refs_.at(i).last_touch_seq_;
+    }
+    for (int64_t rank = 1; rank <= plan_refs_.count(); ++rank) {
+      int64_t oldest_idx = -1;
+      for (int64_t i = 0; i < plan_refs_.count(); ++i) {
+        if (!ranked[i]
+            && (oldest_idx < 0 || old_seq[i] < old_seq[oldest_idx])) {
+          oldest_idx = i;
+        }
+      }
+      if (oldest_idx >= 0) {
+        plan_refs_.at(oldest_idx).last_touch_seq_ = rank;
+        ranked[oldest_idx] = true;
+      }
+    }
+    touch_seq_ = plan_refs_.count();
+  }
+  return ++touch_seq_;
+}
+
+int ObSessionPlanRefCache::evict_lru()
+{
+  int ret = OB_SUCCESS;
+  if (!plan_refs_.empty()) {
+    int64_t oldest_idx = 0;
+    for (int64_t i = 1; i < plan_refs_.count(); ++i) {
+      if (plan_refs_.at(i).last_touch_seq_
+          < plan_refs_.at(oldest_idx).last_touch_seq_) {
+        oldest_idx = i;
+      }
+    }
+    ObILibCacheObject *oldest_plan = plan_refs_.at(oldest_idx).plan_;
+    if (OB_FAIL(plan_refs_.remove(oldest_idx))) {
+      LOG_ERROR("failed to remove the oldest session SQL plan reference",
+                K(ret), K(oldest_idx), KP(oldest_plan));
+    } else {
+      ObCacheObjectFactory::free(oldest_plan);
+    }
+  }
+  return ret;
+}
+
+int ObSessionPlanRefCache::touch_slow(ObILibCacheObject *plan)
+{
+  int ret = OB_SUCCESS;
+  bool found = false;
+  int64_t plan_idx = -1;
+  if (OB_ISNULL(plan) || !plan->is_sql_crsr()) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("invalid SQL plan for session reference", K(ret), KP(plan));
+  }
+  if (OB_SUCC(ret)) {
+    plan_idx = lower_bound(plan, found);
+    if (found) {
+      plan_refs_.at(plan_idx).last_touch_seq_ = next_touch_seq();
+    } else {
+      // A new object after FLUSH is the natural point to discard detached
+      // generations while keeping the common cache-hit path free of epoch loads.
+      ObPlanCache *plan_cache = plan->get_plan_cache();
+      if (OB_NOT_NULL(plan_cache)) {
+        const int tmp_ret = prune_detached(*plan_cache);
+        if (OB_SUCCESS != tmp_ret) {
+          LOG_WARN("failed to prune detached SQL plan references",
+                   K(tmp_ret), KP(plan));
+        }
+      }
+      plan_idx = lower_bound(plan, found);
+    }
+
+    if (OB_SUCC(ret) && !found && !plan->try_inc_session_ref()) {
+      // Concurrent FLUSH detached the plan. The execution guard remains valid,
+      // but this session must not retain an unreachable generation.
+    } else if (OB_SUCC(ret) && !found) {
+      ObILibCacheObject *evicted_plan = nullptr;
+      // After taking the new strong reference, replace exactly one LRU entry.
+      // The number of published session references never exceeds CAPACITY.
+      if (plan_refs_.count() >= CAPACITY) {
+        int64_t oldest_idx = 0;
+        for (int64_t i = 1; i < plan_refs_.count(); ++i) {
+          if (plan_refs_.at(i).last_touch_seq_
+              < plan_refs_.at(oldest_idx).last_touch_seq_) {
+            oldest_idx = i;
+          }
+        }
+        ObILibCacheObject *oldest_plan = plan_refs_.at(oldest_idx).plan_;
+        if (OB_FAIL(plan_refs_.remove(oldest_idx))) {
+          LOG_ERROR("failed to remove the oldest session SQL plan reference",
+                    K(ret), K(oldest_idx), KP(oldest_plan));
+        } else {
+          evicted_plan = oldest_plan;
+        }
+        plan_idx = lower_bound(plan, found);
+      }
+
+      PlanRefEntry new_entry = {plan, 0};
+      if (OB_SUCC(ret)) {
+        new_entry.last_touch_seq_ = next_touch_seq();
+      }
+      if (OB_SUCCESS != ret) {
+        ObILibCacheObject *retained_plan = plan;
+        ObCacheObjectFactory::free(retained_plan);
+      } else if (OB_FAIL(plan_refs_.push_back(new_entry))) {
+        ObILibCacheObject *retained_plan = plan;
+        ObCacheObjectFactory::free(retained_plan);
+        LOG_WARN("failed to save session SQL plan reference", K(ret), KP(plan));
+      } else {
+        for (int64_t i = plan_refs_.count() - 1; i > plan_idx; --i) {
+          plan_refs_.at(i) = plan_refs_.at(i - 1);
+        }
+        plan_refs_.at(plan_idx) = new_entry;
+      }
+      if (OB_NOT_NULL(evicted_plan)) {
+        ObCacheObjectFactory::free(evicted_plan);
+      }
+    }
+  }
+  return ret;
+}
+
+void ObSessionPlanRefCache::reset()
+{
+  PlanRefEntry entry = {nullptr, 0};
+  while (!plan_refs_.empty()) {
+    if (OB_SUCCESS != plan_refs_.pop_back(entry)) {
+      LOG_ERROR_RET(OB_ERR_UNEXPECTED,
+                    "failed to pop session SQL plan reference");
+      break;
+    } else {
+      ObCacheObjectFactory::free(entry.plan_);
+    }
+  }
+  plan_refs_.reset();
+  touch_seq_ = 0;
+  last_seen_sql_plan_detach_epoch_ = 0;
 }
 
 int ObSQLSessionInfo::is_force_temp_table_inline(bool &force_inline) const

--- a/src/sql/session/ob_sql_session_info.cpp
+++ b/src/sql/session/ob_sql_session_info.cpp
@@ -302,97 +302,41 @@ int ObSessionPlanRefCache::prune_detached(ObPlanCache &plan_cache)
   int ret = OB_SUCCESS;
   const int64_t detach_epoch = plan_cache.get_sql_plan_detach_epoch();
   if (detach_epoch != last_seen_sql_plan_detach_epoch_) {
-    // FLUSH and correctness eviction may detach a shared node while an idle
-    // session still owns a reference. Release those stale generations at the
-    // session's next relevant cache access; an entirely idle session releases
-    // them when the session ends.
-    for (int64_t i = 0; OB_SUCC(ret) && i < plan_refs_.count();) {
-      ObILibCacheObject *stale_plan = plan_refs_.at(i).plan_;
-      if (OB_ISNULL(stale_plan)) {
-        ret = OB_ERR_UNEXPECTED;
-        LOG_ERROR("invalid null session SQL plan reference", K(ret), K(i));
-      } else if (stale_plan->is_attached_to_cache_node()) {
-        ++i;
-      } else if (OB_FAIL(plan_refs_.remove(i))) {
-        LOG_ERROR("failed to remove detached session SQL plan reference",
-                  K(ret), K(i), KP(stale_plan));
-      } else {
-        ObCacheObjectFactory::free(stale_plan);
+    // Only invalidation needs a scan; ordinary LRU eviction takes the tail.
+    DLIST_FOREACH_REMOVESAFE(entry, lru_refs_) {
+      if (!entry->plan_->is_attached_to_cache_node()
+          && OB_FAIL(remove_entry(entry))) {
+        break;
       }
     }
     if (OB_SUCC(ret)) {
-      if (plan_refs_.empty()) {
-        touch_seq_ = 0;
-      }
       last_seen_sql_plan_detach_epoch_ = detach_epoch;
     }
   }
   return ret;
 }
 
-int64_t ObSessionPlanRefCache::lower_bound(ObILibCacheObject *plan,
-                                           bool &found) const
+int ObSessionPlanRefCache::remove_entry(PlanRefEntry *entry)
 {
-  int64_t left = 0;
-  int64_t right = plan_refs_.count();
-  std::less<ObILibCacheObject *> less;
-  while (left < right) {
-    const int64_t middle = left + (right - left) / 2;
-    if (less(plan_refs_.at(middle).plan_, plan)) {
-      left = middle + 1;
-    } else {
-      right = middle;
-    }
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(plan_refs_.erase_refactored(reinterpret_cast<uint64_t>(entry->plan_)))) {
+    LOG_ERROR("failed to erase session SQL plan reference index", K(ret), KP(entry));
+  } else {
+    lru_refs_.remove(entry);
+    ObILibCacheObject *plan = entry->plan_;
+    entry->~PlanRefEntry();
+    ob_free(entry);
+    // Detach from both containers before releasing the strong reference.
+    ObCacheObjectFactory::free(plan);
   }
-  found = left < plan_refs_.count() && plan_refs_.at(left).plan_ == plan;
-  return left;
-}
-
-uint64_t ObSessionPlanRefCache::next_touch_seq()
-{
-  if (OB_UNLIKELY(UINT64_MAX == touch_seq_)) {
-    // Preserve the exact LRU order across the practically unreachable wrap.
-    uint64_t old_seq[CAPACITY];
-    bool ranked[CAPACITY] = {};
-    for (int64_t i = 0; i < plan_refs_.count(); ++i) {
-      old_seq[i] = plan_refs_.at(i).last_touch_seq_;
-    }
-    for (int64_t rank = 1; rank <= plan_refs_.count(); ++rank) {
-      int64_t oldest_idx = -1;
-      for (int64_t i = 0; i < plan_refs_.count(); ++i) {
-        if (!ranked[i]
-            && (oldest_idx < 0 || old_seq[i] < old_seq[oldest_idx])) {
-          oldest_idx = i;
-        }
-      }
-      if (oldest_idx >= 0) {
-        plan_refs_.at(oldest_idx).last_touch_seq_ = rank;
-        ranked[oldest_idx] = true;
-      }
-    }
-    touch_seq_ = plan_refs_.count();
-  }
-  return ++touch_seq_;
+  return ret;
 }
 
 int ObSessionPlanRefCache::evict_lru()
 {
   int ret = OB_SUCCESS;
-  if (!plan_refs_.empty()) {
-    int64_t oldest_idx = 0;
-    for (int64_t i = 1; i < plan_refs_.count(); ++i) {
-      if (plan_refs_.at(i).last_touch_seq_
-          < plan_refs_.at(oldest_idx).last_touch_seq_) {
-        oldest_idx = i;
-      }
-    }
-    ObILibCacheObject *oldest_plan = plan_refs_.at(oldest_idx).plan_;
-    if (OB_FAIL(plan_refs_.remove(oldest_idx))) {
-      LOG_ERROR("failed to remove the oldest session SQL plan reference",
-                K(ret), K(oldest_idx), KP(oldest_plan));
-    } else {
-      ObCacheObjectFactory::free(oldest_plan);
-    }
+  if (!lru_refs_.is_empty()) {
+    ret = remove_entry(lru_refs_.get_last());
   }
   return ret;
 }
@@ -400,74 +344,57 @@ int ObSessionPlanRefCache::evict_lru()
 int ObSessionPlanRefCache::touch_slow(ObILibCacheObject *plan)
 {
   int ret = OB_SUCCESS;
-  bool found = false;
-  int64_t plan_idx = -1;
+  PlanRefEntry *entry = nullptr;
   if (OB_ISNULL(plan) || !plan->is_sql_crsr()) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("invalid SQL plan for session reference", K(ret), KP(plan));
-  }
-  if (OB_SUCC(ret)) {
-    plan_idx = lower_bound(plan, found);
-    if (found) {
-      plan_refs_.at(plan_idx).last_touch_seq_ = next_touch_seq();
+  } else if (!plan_refs_.created()
+             && OB_FAIL(plan_refs_.create(CAPACITY, ObMemAttr("SessPlanRef")))) {
+    LOG_WARN("failed to create session SQL plan reference index", K(ret));
+  } else {
+    const int lookup_ret = plan_refs_.get_refactored(reinterpret_cast<uint64_t>(plan), entry);
+    if (OB_SUCCESS == lookup_ret) {
+      lru_refs_.remove(entry);
+      lru_refs_.add_first(entry);
+    } else if (OB_HASH_NOT_EXIST != lookup_ret) {
+      ret = lookup_ret;
+      LOG_WARN("failed to find session SQL plan reference", K(ret));
     } else {
-      // A new object after FLUSH is the natural point to discard detached
-      // generations while keeping the common cache-hit path free of epoch loads.
-      ObPlanCache *plan_cache = plan->get_plan_cache();
-      if (OB_NOT_NULL(plan_cache)) {
-        const int tmp_ret = prune_detached(*plan_cache);
+      // Keep the common hit path free of epoch checks.
+      if (OB_NOT_NULL(plan->get_plan_cache())) {
+        const int tmp_ret = prune_detached(*plan->get_plan_cache());
         if (OB_SUCCESS != tmp_ret) {
-          LOG_WARN("failed to prune detached SQL plan references",
-                   K(tmp_ret), KP(plan));
+          LOG_WARN("failed to prune detached SQL plan references", K(tmp_ret));
         }
       }
-      plan_idx = lower_bound(plan, found);
-    }
-
-    if (OB_SUCC(ret) && !found && !plan->try_inc_session_ref()) {
-      // Concurrent FLUSH detached the plan. The execution guard remains valid,
-      // but this session must not retain an unreachable generation.
-    } else if (OB_SUCC(ret) && !found) {
-      ObILibCacheObject *evicted_plan = nullptr;
-      // After taking the new strong reference, replace exactly one LRU entry.
-      // The number of published session references never exceeds CAPACITY.
-      if (plan_refs_.count() >= CAPACITY) {
-        int64_t oldest_idx = 0;
-        for (int64_t i = 1; i < plan_refs_.count(); ++i) {
-          if (plan_refs_.at(i).last_touch_seq_
-              < plan_refs_.at(oldest_idx).last_touch_seq_) {
-            oldest_idx = i;
+      if (!plan->try_inc_session_ref()) {
+        // Concurrent FLUSH detached the plan; the execution guard remains valid.
+      } else {
+        void *buf = ob_malloc(sizeof(PlanRefEntry), ObMemAttr("SessPlanRef"));
+        if (OB_ISNULL(buf)) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+        } else {
+          entry = new (buf) PlanRefEntry();
+          entry->plan_ = plan;
+          // Pin the new plan before releasing the old reference.
+          if (count() >= CAPACITY && OB_FAIL(evict_lru())) {
+            LOG_WARN("failed to evict session SQL plan reference", K(ret));
+          } else if (OB_FAIL(plan_refs_.set_refactored(reinterpret_cast<uint64_t>(plan), entry))) {
+            LOG_WARN("failed to index session SQL plan reference", K(ret));
+          } else {
+            // Fresh, unlinked entries can always be linked into this list.
+            const bool linked = lru_refs_.add_first(entry);
+            OB_ASSERT(linked);
           }
         }
-        ObILibCacheObject *oldest_plan = plan_refs_.at(oldest_idx).plan_;
-        if (OB_FAIL(plan_refs_.remove(oldest_idx))) {
-          LOG_ERROR("failed to remove the oldest session SQL plan reference",
-                    K(ret), K(oldest_idx), KP(oldest_plan));
-        } else {
-          evicted_plan = oldest_plan;
+        if (OB_FAIL(ret)) {
+          if (OB_NOT_NULL(entry)) {
+            entry->~PlanRefEntry();
+            ob_free(entry);
+          }
+          ObILibCacheObject *retained_plan = plan;
+          ObCacheObjectFactory::free(retained_plan);
         }
-        plan_idx = lower_bound(plan, found);
-      }
-
-      PlanRefEntry new_entry = {plan, 0};
-      if (OB_SUCC(ret)) {
-        new_entry.last_touch_seq_ = next_touch_seq();
-      }
-      if (OB_SUCCESS != ret) {
-        ObILibCacheObject *retained_plan = plan;
-        ObCacheObjectFactory::free(retained_plan);
-      } else if (OB_FAIL(plan_refs_.push_back(new_entry))) {
-        ObILibCacheObject *retained_plan = plan;
-        ObCacheObjectFactory::free(retained_plan);
-        LOG_WARN("failed to save session SQL plan reference", K(ret), KP(plan));
-      } else {
-        for (int64_t i = plan_refs_.count() - 1; i > plan_idx; --i) {
-          plan_refs_.at(i) = plan_refs_.at(i - 1);
-        }
-        plan_refs_.at(plan_idx) = new_entry;
-      }
-      if (OB_NOT_NULL(evicted_plan)) {
-        ObCacheObjectFactory::free(evicted_plan);
       }
     }
   }
@@ -476,18 +403,15 @@ int ObSessionPlanRefCache::touch_slow(ObILibCacheObject *plan)
 
 void ObSessionPlanRefCache::reset()
 {
-  PlanRefEntry entry = {nullptr, 0};
-  while (!plan_refs_.empty()) {
-    if (OB_SUCCESS != plan_refs_.pop_back(entry)) {
-      LOG_ERROR_RET(OB_ERR_UNEXPECTED,
-                    "failed to pop session SQL plan reference");
-      break;
-    } else {
-      ObCacheObjectFactory::free(entry.plan_);
-    }
+  // No further access to the index during reset.
+  plan_refs_.destroy();
+  while (!lru_refs_.is_empty()) {
+    PlanRefEntry *entry = lru_refs_.remove_last();
+    ObILibCacheObject *plan = entry->plan_;
+    entry->~PlanRefEntry();
+    ob_free(entry);
+    ObCacheObjectFactory::free(plan);
   }
-  plan_refs_.reset();
-  touch_seq_ = 0;
   last_seen_sql_plan_detach_epoch_ = 0;
 }
 

--- a/src/sql/session/ob_sql_session_info.h
+++ b/src/sql/session/ob_sql_session_info.h
@@ -99,6 +99,48 @@ class ObPieceCache;
 class ObIQueryResultSender;
 class ObPlanItemMgr;
 
+// Physical plans remain shared in ObPlanCache. Each entry below contributes
+// one strong reference owned by this session, so a recently used plan survives
+// between statements without being copied into the session.
+class ObSessionPlanRefCache
+{
+public:
+  static const int64_t CAPACITY = 100;
+
+  struct PlanRefEntry
+  {
+    ObILibCacheObject *plan_;
+    uint64_t last_touch_seq_;
+    TO_STRING_KV(KP_(plan), K_(last_touch_seq));
+  };
+
+  ObSessionPlanRefCache()
+    : plan_refs_(sizeof(PlanRefEntry) * CAPACITY),
+      touch_seq_(0),
+      last_seen_sql_plan_detach_epoch_(0)
+  {}
+  ~ObSessionPlanRefCache() { reset(); }
+
+  int prune_detached(ObPlanCache &plan_cache);
+  int evict_lru();
+  int touch(ObILibCacheObject *plan)
+  {
+    return touch_slow(plan);
+  }
+  void reset();
+  int64_t count() const { return plan_refs_.count(); }
+
+private:
+  int touch_slow(ObILibCacheObject *plan);
+  int64_t lower_bound(ObILibCacheObject *plan, bool &found) const;
+  uint64_t next_touch_seq();
+
+  common::ObSEArray<PlanRefEntry, 8> plan_refs_; // sorted by plan address
+  uint64_t touch_seq_;
+  int64_t last_seen_sql_plan_detach_epoch_;
+  DISALLOW_COPY_AND_ASSIGN(ObSessionPlanRefCache);
+};
+
 class SessionInfoKey
 {
 public:
@@ -413,6 +455,15 @@ public:
   void destroy(bool skip_sys_var = false);
   void reset(bool skip_sys_var);
   void clean_status();
+  int touch_session_plan_ref(ObILibCacheObject *plan)
+  { return session_plan_ref_cache_.touch(plan); }
+  int prune_detached_session_plan_refs(ObPlanCache &plan_cache)
+  { return session_plan_ref_cache_.prune_detached(plan_cache); }
+  int evict_lru_session_plan_ref()
+  { return session_plan_ref_cache_.evict_lru(); }
+  void reset_session_plan_refs() { session_plan_ref_cache_.reset(); }
+  int64_t get_session_plan_ref_count() const
+  { return session_plan_ref_cache_.count(); }
   const common::ObWarningBuffer &get_show_warnings_buffer() const { return show_warnings_buf_; }
   const common::ObWarningBuffer &get_warnings_buffer() const { return warnings_buf_; }
   common::ObWarningBuffer &get_warnings_buffer() { return warnings_buf_; }
@@ -998,6 +1049,7 @@ private:
   uint64_t conn_res_user_id_;
   ObConnectResourceMgr *conn_res_mgr_;
   ObSQLSessionMgr *session_mgr_;
+  ObSessionPlanRefCache session_plan_ref_cache_;
   bool tx_level_temp_table_;
   ApplicationInfo client_app_info_;
   char module_buf_[common::OB_MAX_MOD_NAME_LENGTH];

--- a/src/sql/session/ob_sql_session_info.h
+++ b/src/sql/session/ob_sql_session_info.h
@@ -26,6 +26,7 @@
 #include "lib/ob_name_def.h"
 #include "lib/oblog/ob_warning_buffer.h"
 #include "lib/list/ob_list.h"
+#include "lib/list/ob_dlist.h"
 #include "lib/allocator/page_arena.h"
 #include "lib/objectpool/ob_pool.h"
 #include "lib/time/ob_cur_time.h"
@@ -107,17 +108,15 @@ class ObSessionPlanRefCache
 public:
   static const int64_t CAPACITY = 100;
 
-  struct PlanRefEntry
+  struct PlanRefEntry : public common::ObDLinkBase<PlanRefEntry>
   {
+    PlanRefEntry() : plan_(nullptr) {}
     ObILibCacheObject *plan_;
-    uint64_t last_touch_seq_;
-    TO_STRING_KV(KP_(plan), K_(last_touch_seq));
+    TO_STRING_KV(KP_(plan));
   };
 
   ObSessionPlanRefCache()
-    : plan_refs_(sizeof(PlanRefEntry) * CAPACITY),
-      touch_seq_(0),
-      last_seen_sql_plan_detach_epoch_(0)
+    : last_seen_sql_plan_detach_epoch_(0)
   {}
   ~ObSessionPlanRefCache() { reset(); }
 
@@ -128,15 +127,23 @@ public:
     return touch_slow(plan);
   }
   void reset();
-  int64_t count() const { return plan_refs_.count(); }
+  int64_t count() const { return lru_refs_.get_size(); }
 
 private:
   int touch_slow(ObILibCacheObject *plan);
-  int64_t lower_bound(ObILibCacheObject *plan, bool &found) const;
-  uint64_t next_touch_seq();
+  int remove_entry(PlanRefEntry *entry);
 
-  common::ObSEArray<PlanRefEntry, 8> plan_refs_; // sorted by plan address
-  uint64_t touch_seq_;
+  // Session-owned entries: a shared Plan must not carry session LRU links.
+  // The session serializes access, so the index needs no internal lock.
+  // Small allocation batches avoid a full default allocator block per session.
+  typedef common::hash::SimpleAllocer<
+      common::hash::HashMapTypes<uint64_t, PlanRefEntry *>::AllocType,
+      8, common::hash::NoPthreadDefendMode> RefIndexAllocator;
+  common::hash::ObHashMap<uint64_t, PlanRefEntry *,
+      common::hash::NoPthreadDefendMode,
+      common::hash::hash_func<uint64_t>,
+      common::hash::equal_to<uint64_t>, RefIndexAllocator> plan_refs_;
+  common::ObDList<PlanRefEntry> lru_refs_; // MRU at front, LRU at back
   int64_t last_seen_sql_plan_detach_epoch_;
   DISALLOW_COPY_AND_ASSIGN(ObSessionPlanRefCache);
 };


### PR DESCRIPTION
### Task Description

The previous session-local plan-cache design duplicated physical plans across connections and caused unacceptable memory growth. Retain globally shared physical plans while making their lifetime follow active session usage.

### Solution Description

- Keep SQL plans shared in the tenant plan-cache lookup map and let each session retain strong references to the plans it uses.
- Bound each session to 100 retained plan references and replace the least recently used reference when full.
- Retire SQL plans synchronously after they are detached and the last session, execution, or diagnostic reference is released; exclude SQL plans from periodic idle eviction.
- Release session references on session teardown, RESET CONNECTION, and successful CHANGE USER.
- Preserve FLUSH and correctness eviction by detaching the old generation and lazily pruning stale session references.
- Keep periodic memory and idle maintenance for non-SQL library-cache objects.

### Passed Regressions

- `git diff --check`
- Built the SeekDB server target successfully.
- Lifecycle checks: two sessions share one physical plan; closing the last session releases it; FLUSH detaches the old generation and the next lookup creates a new one; one session retains at most 100 plans.
- 64-session, 32-PS point-select test with a 10-second workload warmup and 60-second measurement: 43,109.89 QPS versus 42,944.20 baseline (+0.39%), with no errors in the comparable adjacent run.
- A separate 10-second settle ABBA run measured +0.14% candidate versus baseline. Later shared-host rounds were excluded from aggregate conclusions because host load changed materially during the run.

### Upgrade Compatibility

No persistent data format, wire protocol, SQL syntax, or configuration changes. The change affects only in-memory SQL plan ownership and retirement.

### Other Information

Each session retains at most 100 shared plan references; multiple sessions using the same physical plan still share one plan object. The shared-node and object retirement concurrency path is the primary review focus.

### Release Note

Reduce SQL plan-cache memory growth by sharing physical plans across sessions and releasing plans when their last reference is gone.