### PR TITLE
fix(build): cross-compile Rust sql-nio for Android

### DIFF
--- a/cmake/Rust.cmake
+++ b/cmake/Rust.cmake
@@ -48,6 +48,19 @@ else()
   set(_cargo_out_subdir "release")
 endif()
 
+# Cargo otherwise builds for the macOS host during an Android CMake cross-build.
+# Keep the Rust static library on the same target and API level as the C++ code.
+set(_cargo_target_args)
+set(_cargo_target_subdir)
+if(ANDROID)
+  if(NOT CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
+    message(FATAL_ERROR "[rust] unsupported Android ABI: ${CMAKE_ANDROID_ARCH_ABI}")
+  endif()
+  set(_rust_target_triple "aarch64-linux-android")
+  list(APPEND _cargo_target_args "--target" "${_rust_target_triple}")
+  set(_cargo_target_subdir "${_rust_target_triple}/")
+endif()
+
 # Keep all cargo output inside the CMake build tree (isolated per build dir).
 set(RUST_TARGET_DIR "${CMAKE_BINARY_DIR}/rust-target")
 # Cargo's staticlib artifact name is platform-specific: libsql_nio.a on
@@ -55,7 +68,7 @@ set(RUST_TARGET_DIR "${CMAKE_BINARY_DIR}/rust-target")
 if(WIN32)
   set(RUST_STATICLIB "${RUST_TARGET_DIR}/${_cargo_out_subdir}/sql_nio.lib")
 else()
-  set(RUST_STATICLIB "${RUST_TARGET_DIR}/${_cargo_out_subdir}/libsql_nio.a")
+  set(RUST_STATICLIB "${RUST_TARGET_DIR}/${_cargo_target_subdir}${_cargo_out_subdir}/libsql_nio.a")
 endif()
 
 # Sources whose change should retrigger a rebuild of the staticlib.
@@ -71,6 +84,19 @@ list(APPEND _rust_sources
 # discovers on PATH.
 set(_rust_build_env "CARGO_TARGET_DIR=${RUST_TARGET_DIR}"
                     "CC=${CMAKE_C_COMPILER}" "AR=${CMAKE_AR}")
+if(ANDROID)
+  string(REGEX REPLACE "^android-" "" _android_api "${ANDROID_PLATFORM}")
+  get_filename_component(_ndk_toolchain_bin "${CMAKE_C_COMPILER}" DIRECTORY)
+  set(_android_clang "${_ndk_toolchain_bin}/aarch64-linux-android${_android_api}-clang")
+  set(_android_ar "${_ndk_toolchain_bin}/llvm-ar")
+  if(NOT EXISTS "${_android_clang}")
+    message(FATAL_ERROR "[rust] Android clang wrapper not found: ${_android_clang}")
+  endif()
+  list(APPEND _rust_build_env
+       "CC_aarch64_linux_android=${_android_clang}"
+       "AR_aarch64_linux_android=${_android_ar}"
+       "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${_android_clang}")
+endif()
 if(WIN32)
   # rustup treats an exact-version override and the stable alias as distinct
   # installed toolchains, even when stable currently is that exact version.
@@ -121,7 +147,7 @@ endif()
 add_custom_command(
   OUTPUT "${RUST_STATICLIB}"
   COMMAND "${CMAKE_COMMAND}" -E env ${_rust_build_env}
-          "${CARGO}" build ${_cargo_profile_flag}
+          "${CARGO}" build ${_cargo_profile_flag} ${_cargo_target_args}
           --manifest-path "${RUST_WORKSPACE_DIR}/Cargo.toml"
           --package sql-nio
   WORKING_DIRECTORY "${RUST_WORKSPACE_DIR}"
@@ -141,7 +167,7 @@ if(WIN32)
 else()
   find_package(Threads REQUIRED)
   set(_rust_syslibs Threads::Threads ${CMAKE_DL_LIBS} m)
-  if(NOT APPLE)
+  if(NOT APPLE AND NOT ANDROID)
     list(APPEND _rust_syslibs rt)
   endif()
 endif()

--- a/docs/developer-guide/en/toolchain.md
+++ b/docs/developer-guide/en/toolchain.md
@@ -18,6 +18,7 @@ The repository pins Rust `1.97.1`, includes the `clippy` component, and uses the
 ```text
 x86_64-unknown-linux-gnu
 x86_64-pc-windows-gnu
+aarch64-linux-android
 ```
 
 The CMake build invokes Cargo from the Rust workspace when compiling the `sql-nio` library. Rustup then reads `rust/rust-toolchain.toml` and installs the pinned toolchain, components, and targets automatically. The first build may also download the locked Cargo dependencies; configure a crates.io mirror if the host cannot reach the default registry.

--- a/docs/developer-guide/zh/toolchain.md
+++ b/docs/developer-guide/zh/toolchain.md
@@ -40,6 +40,7 @@ index = "sparse+https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"
 ```text
 x86_64-unknown-linux-gnu
 x86_64-pc-windows-gnu
+aarch64-linux-android
 ```
 
 CMake 编译 `sql-nio` 库时会从 Rust 工作区调用 Cargo，rustup 随后会自动读取 `rust/rust-toolchain.toml`，并安装固定版本的工具链、组件和目标。首次构建还可能下载 Cargo 的锁定依赖；如果主机无法访问默认 registry，请配置 crates.io 镜像。

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -4,12 +4,13 @@
 # with different compilers. Bump deliberately, in its own reviewed commit.
 [toolchain]
 channel = "1.97.1"
-# The windows-gnu target exists only for `cargo check`: it keeps the
-# cfg(windows) transport code compiling without a Windows runner in CI.
+# The cross-compilation targets keep Android builds and Windows `cargo check`
+# on the same pinned toolchain as native builds. The windows-gnu target keeps
+# the cfg(windows) transport code compiling without a Windows runner in CI.
 # gnu, not msvc: ring (rustls) compiles C in its build script, and mingw
 # is the only Windows C toolchain a Linux/mac host can provide. The
 # production Windows target stays msvc and is exercised by a real runner.
-targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu", "aarch64-linux-android"]
 # clippy gates CI (`cargo clippy -- -D warnings`); ship it with the toolchain
 # so the minimal-profile CI install has it too.
 components = ["clippy"]


### PR DESCRIPTION
### Task Description

The Android CMake build cross-compiles the C/C++ code for `arm64-v8a`, but Cargo previously built `sql-nio` for the host platform. On macOS this produced a Mach-O static library that could not be linked into the Android AArch64 executable. After targeting Android, `ring` also needed the API-specific NDK compiler and the final link needed to avoid Linux-only `librt`.

### Solution Description

- Build `sql-nio` with Cargo target `aarch64-linux-android` when CMake is targeting Android.
- Resolve the Rust static library from Cargo's target-specific output directory.
- Pass the NDK API-specific Clang wrapper, `llvm-ar`, and Cargo linker to Rust build scripts so dependencies such as `ring` use the Android toolchain.
- Do not link `librt` on Android.
- Add the Android Rust standard-library target to the pinned rustup toolchain and document it in both toolchain guides.

All build behavior changes in `cmake/Rust.cmake` are guarded by `ANDROID`; the existing Linux, macOS, and Windows paths remain unchanged.

### Passed Regressions

- `./build.sh release --android --make -j6` — completed the full seekdb build.
- NDK `llvm-readelf` — both `seekdb` and `libsql_nio.a` are ELF64/AArch64.
- Verified the generated Android seekdb link command contains no `-lrt`.
- Native macOS `cargo build --release --manifest-path rust/Cargo.toml --package sql-nio` — passed with the original host output layout.
- Manual Android 16/API 36 ARM64 emulator test — seekdb startup, MySQL protocol connection, DDL/DML, HNSW L2 vector search, and restart persistence passed.

### Upgrade Compatibility

No data-format or runtime upgrade impact. This is an Android build-toolchain fix; non-Android build paths are unchanged.

### Other Information

Tested with Android NDK `27.3.13750724`, target ABI `arm64-v8a`, and compile API 28.

### Release Note

Fix Android ARM64 builds by cross-compiling the Rust `sql-nio` library with the Android NDK toolchain.
