### PR TITLE
fix(optimizer): guard TLP and HAVING rewrites

### DIFF
--- a/src/sql/rewrite/ob_transform_join_elimination.cpp
+++ b/src/sql/rewrite/ob_transform_join_elimination.cpp
@@ -2309,7 +2309,9 @@ int ObTransformJoinElimination::check_semi_join_condition(ObDMLStmt *stmt,
         /* do nothing */
       } else if (!expr->get_relation_ids().has_member(left_idx)) {
         target_tables_have_filter = true;
-        if (T_OP_OR == expr->get_expr_type()) { // complex right table filter
+        if (expr->get_relation_ids().num_members() > 1) {
+          is_simple_join_condition = false;
+        } else if (T_OP_OR == expr->get_expr_type()) { // complex right table filter
           is_simple_filter = false;
         } else { /*do nothing*/ }
       } else if (T_OP_EQ != expr->get_expr_type()) {
@@ -2410,7 +2412,9 @@ int ObTransformJoinElimination::check_semi_join_condition(ObDMLStmt *stmt,
         /* do nothing */
       } else if (!expr->get_relation_ids().has_member(left_idx)) {
         target_tables_have_filter = true;
-        if (T_OP_OR == expr->get_expr_type()) { // complex right table filter
+        if (expr->get_relation_ids().num_members() > 1) {
+          is_simple_join_condition = false;
+        } else if (T_OP_OR == expr->get_expr_type()) { // complex right table filter
           is_simple_filter = false;
         } else { /*do nothing*/ }
       } else if (T_OP_EQ != expr->get_expr_type()) {

--- a/src/sql/rewrite/ob_transform_simplify_groupby.cpp
+++ b/src/sql/rewrite/ob_transform_simplify_groupby.cpp
@@ -492,6 +492,15 @@ int ObTransformSimplifyGroupby::check_stmt_group_by_can_be_removed(ObSelectStmt 
       } else if (OB_FAIL(check_aggr_win_can_be_removed(select_stmt, expr, can_be))) {
       }
     }
+    for (int64_t i = 0; OB_SUCC(ret) && can_be && i < select_stmt->get_having_expr_size(); ++i) {
+      ObRawExpr *expr = select_stmt->get_having_exprs().at(i);
+      if (OB_ISNULL(expr)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("NULL pointer error", K(ret));
+      } else if (expr->has_flag(CNT_AGG)) {
+        can_be = false;
+      }
+    }
   } else {
     //do nothing
   }


### PR DESCRIPTION
This fixes two independent SQLancer failures from GitLab pipeline 248990.

The UNION/TLP failure came from join elimination on an anti semi join produced from tuple `NOT IN`. When a semi condition referenced the right table and another outer table that was not the current candidate source table, the transform still treated it as a simple right-table filter. That allowed `ELIMINATE_JOIN` to remove the anti side and collapse the TLP union result. The transform now rejects those multi-table right-side correlated conditions for semi self-key elimination.

The HAVING failure came from simplify-group-by removing a unique `GROUP BY` while `HAVING` still contained aggregate expressions, including the aggregate alias path from SQLancer. That moved an aggregate-dependent HAVING predicate into the normal condition path and raised `4016 Internal error`. The transform now keeps the grouped form when HAVING contains aggregates.

A mysqltest regression, `sqlancer_248990`, uses synthetic data to cover both paths without embedding CI snapshot data.

Validation:
- Built successfully with `./build.sh release --make -j8`.
- Replayed the original database2 failure state on the patched binary: original count = 748, TLP union count = 748.
- Replayed the original database0 HAVING SQL: old binary returns `ERROR 4016`, patched binary returns no error.
- Smoke-tested the synthetic regression SQL on the patched binary: original = 5358, TLP = 5358, `having_ok` returned.
