### PR TITLE
fix: clear log_restore_source when promoting standby

### DIFF
--- a/src/share/config/ob_config_storage.cpp
+++ b/src/share/config/ob_config_storage.cpp
@@ -262,6 +262,56 @@ int ObConfigStorage::upsert_config(
   return ret;
 }
 
+int ObConfigStorage::update_config_pair(
+    const char *first_name, const char *first_value,
+    const char *second_name, const char *second_value)
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited()) {
+    ret = OB_NOT_INIT;
+  } else if (OB_ISNULL(first_name) || OB_ISNULL(first_value)
+             || OB_ISNULL(second_name) || OB_ISNULL(second_value)
+             || 0 == STRCMP(first_name, second_name)) {
+    ret = OB_INVALID_ARGUMENT;
+  } else {
+    share::ObSQLiteConnectionGuard guard(pool_);
+    if (!guard) {
+      ret = OB_ERR_UNEXPECTED;
+    } else if (OB_FAIL(guard->begin_transaction())) {
+    } else {
+      const char *sql = "UPDATE __all_sys_parameter SET value = ?, gmt_modified = ? WHERE name = ?";
+      const char *names[] = {first_name, second_name};
+      const char *values[] = {first_value, second_value};
+      const int64_t now = ObTimeUtility::current_time();
+      for (int64_t i = 0; OB_SUCC(ret) && i < 2; ++i) {
+        int64_t affected_rows = 0;
+        auto binder = [&](share::ObSQLiteBinder &b) -> int {
+          b.bind_text(values[i]);
+          b.bind_int64(now);
+          b.bind_text(names[i]);
+          return OB_SUCCESS;
+        };
+        if (OB_FAIL(guard->execute(sql, binder, &affected_rows))) {
+          LOG_WARN("failed to update config pair", KR(ret), "name", names[i]);
+        } else if (1 != affected_rows) {
+          ret = OB_ENTRY_NOT_EXIST;
+          LOG_WARN("config pair entry does not exist", KR(ret), "name", names[i]);
+        }
+      }
+      if (OB_SUCC(ret) && OB_FAIL(guard->commit())) {
+        LOG_WARN("failed to commit config pair", KR(ret));
+      }
+      if (OB_FAIL(ret)) {
+        const int rollback_ret = guard->rollback();
+        if (OB_SUCCESS != rollback_ret) {
+          LOG_WARN("failed to roll back config pair", K(rollback_ret));
+        }
+      }
+    }
+  }
+  return ret;
+}
+
 
 } // namespace common
 } // namespace oceanbase

--- a/src/share/config/ob_config_storage.h
+++ b/src/share/config/ob_config_storage.h
@@ -49,6 +49,10 @@ public:
       const char *source,
       const char *edit_level);
 
+  // Atomically update two existing configuration values without replacing metadata.
+  int update_config_pair(const char *first_name, const char *first_value,
+                         const char *second_name, const char *second_value);
+
   bool is_inited() const { return nullptr != pool_; }
 
 private:

--- a/src/standby/control/ob_standby_role_transition_service.cpp
+++ b/src/standby/control/ob_standby_role_transition_service.cpp
@@ -73,7 +73,7 @@ int commit_primary_role(StandbyStateStore &state_store, share::ObServerInfo &ser
   server_info.pending_role_.reset();
   server_info.switchover_status_ = share::NORMAL_SWITCHOVER_STATUS;
   server_info.cutover_scn_.reset();
-  if (OB_FAIL(state_store.update(server_info))) {
+  if (OB_FAIL(state_store.commit_primary_and_clear_source(server_info))) {
     LOG_WARN("failed to commit durable primary role", KR(ret), K(server_info));
   }
   return ret;
@@ -179,11 +179,13 @@ int stop_recovery_tasks(
   return ret;
 }
 
-int finish_committed_promotion()
+int finish_committed_promotion(StandbyStateStore &state_store)
 {
   int ret = OB_SUCCESS;
   storage::ObLSService *ls_service = nullptr;
   if (OB_FAIL(get_ls_service(ls_service))) {
+  } else if (OB_FAIL(state_store.refresh_config())) {
+    LOG_WARN("failed to refresh committed primary configuration", KR(ret));
   } else if (OB_FAIL(ls_service->activate_local_append())) {
     LOG_WARN("failed to activate primary local append runtime", KR(ret));
   } else {
@@ -231,7 +233,7 @@ int complete_promotion(
       LOG_WARN("failed to commit primary role after runtime preparation", KR(ret));
     } else if (OB_FAIL(DEBUG_SYNC(common::AFTER_STANDBY_PRIMARY_ROLE_COMMITTED))) {
       LOG_WARN("debug sync failed after primary role commit", KR(ret));
-    } else if (OB_FAIL(finish_committed_promotion())) {
+    } else if (OB_FAIL(finish_committed_promotion(state_store))) {
       LOG_WARN("failed to publish committed primary runtime", KR(ret));
     }
   }
@@ -301,7 +303,7 @@ int prepare_to_primary(
   if (OB_FAIL(load_server_info(state_store, server_info))) {
   } else if (server_info.is_primary() && !server_info.has_pending_role()) {
     if (!is_verify && !share::server_is_write_enabled()
-        && OB_FAIL(finish_committed_promotion())) {
+        && OB_FAIL(finish_committed_promotion(state_store))) {
       LOG_WARN("failed to resume committed primary publication", KR(ret), K(server_info));
     } else {
       LOG_INFO("server is already running with primary profile", K(server_info), K(is_verify));
@@ -458,7 +460,7 @@ int ObStandbyRoleTransitionService::resume_pending_promotion()
     LOG_WARN("failed to load pending standby promotion", KR(ret));
   } else if (server_info.is_primary() && !server_info.has_pending_role()) {
     if (!share::server_is_write_enabled()
-        && OB_FAIL(finish_committed_promotion())) {
+        && OB_FAIL(finish_committed_promotion(*state_store_))) {
       LOG_WARN("failed to resume committed primary publication", KR(ret));
     }
   } else if (!server_info.is_standby()

--- a/src/standby/control/standby_state_store.cpp
+++ b/src/standby/control/standby_state_store.cpp
@@ -289,5 +289,36 @@ int StandbyStateStore::update(const share::ObServerInfo &server_info) const
       : save_to_config(*config_manager_, server_info);
 }
 
+int StandbyStateStore::refresh_config() const
+{
+  return nullptr == config_manager_ ? OB_NOT_INIT : config_manager_->got_version();
+}
+
+int StandbyStateStore::commit_primary_and_clear_source(
+    const share::ObServerInfo &server_info) const
+{
+  int ret = OB_SUCCESS;
+  common::ObArenaAllocator allocator(ObModIds::OB_TEMP_VARIABLES);
+  common::ObString value;
+  if (OB_ISNULL(config_manager_)) {
+    ret = OB_NOT_INIT;
+  } else if (!server_info.is_valid() || !server_info.is_primary()
+             || server_info.has_pending_role()) {
+    ret = OB_INVALID_ARGUMENT;
+  } else if (OB_FAIL(serialize_server_info(server_info, value, allocator))) {
+    LOG_WARN("failed to serialize promoted server role", KR(ret));
+  } else {
+    // Both entries exist after standby bootstrap. Commit them together so a
+    // crash cannot leave either a standby without its source or a promoted
+    // primary with the obsolete source. Do not clear on ordinary primary
+    // startup or an idempotent promotion: a new source may be preconfigured.
+    if (OB_FAIL(config_manager_->get_storage().update_config_pair(
+        SERVER_ROLE_STATE_CONFIG, value.ptr(), "log_restore_source", ""))) {
+      LOG_WARN("failed to commit primary role and clear source", KR(ret));
+    }
+  }
+  return ret;
+}
+
 } // namespace standby
 } // namespace oceanbase

--- a/src/standby/control/standby_state_store.h
+++ b/src/standby/control/standby_state_store.h
@@ -42,6 +42,8 @@ public:
   int load(share::ObServerInfo &server_info) const;
   int initialize() const;
   int update(const share::ObServerInfo &server_info) const;
+  int refresh_config() const;
+  int commit_primary_and_clear_source(const share::ObServerInfo &server_info) const;
   int get_server_info(share::ObServerInfo &server_info) const override
   {
     return load(server_info);

--- a/tools/obtest/r/stanby/basic.result
+++ b/tools/obtest/r/stanby/basic.result
@@ -23,6 +23,8 @@ count(*)
 1
 ALTER SYSTEM SWITCHOVER TO PRIMARY;
 db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 120;
+db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
+db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and log_restore_source = '', 1, 5;
 insert into test_table_primary values(2, 2);
 ERROR 25006: Cannot execute statement in a READ ONLY transaction.
 rollback;
@@ -63,8 +65,18 @@ STANDBY
 db_s.force_stop;
 ALTER SYSTEM ACTIVATE STANDBY;
 db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 60;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and log_restore_source = '', 1, 5;
 create table if not exists test_table_failover_primary(a int primary key, b int);
 insert into test_table_failover_primary values(1, 1);
+db_p.force_stop;
+db_p.nstart;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and log_restore_source = '', 1, 60;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
+db_p.check_until_timeout select count(*) from test_table_failover_primary where a = 1, 1, 5;
+db_p.mysql alter system set log_restore_source = '127.0.0.1:42001';
+db_p.mysql ALTER SYSTEM ACTIVATE STANDBY;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '127.0.0.1:42001', 1, 5;
 Case 3 completed: Standby cluster successfully failed over to primary
 ========== Test Summary ==========
 All test cases completed successfully:

--- a/tools/obtest/r/stanby/failover_switchover_reentry.result
+++ b/tools/obtest/r/stanby/failover_switchover_reentry.result
@@ -22,6 +22,7 @@ db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_server_sta
 db_s.force_stop;
 db_s.nstart;
 db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 60;
+db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
 db_p.force_stop;
 db_p.nstart;
 db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'STANDBY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 60;
@@ -45,6 +46,7 @@ ERROR HY000: standby tenant is read only
 db_p.force_stop;
 db_p.nstart;
 db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 60;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
 db_s.force_stop;
 db_s.nstart;
 db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'STANDBY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 60;

--- a/tools/obtest/t/stanby/basic.test
+++ b/tools/obtest/t/stanby/basic.test
@@ -73,6 +73,8 @@ ob_connect(conn_admin_s, db_s.z1.obs0, root@sys, , oceanbase, , USE_MYSQL_CONNEC
 connection conn_admin_s;
 ALTER SYSTEM SWITCHOVER TO PRIMARY;
 db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 120;
+db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
+db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and log_restore_source = '', 1, 5;
 
 # promotion 不断开已有读连接，旧事务仍只读；下一事务立即可写
 connection conn_sys_s;
@@ -157,10 +159,20 @@ ALTER SYSTEM ACTIVATE STANDBY;
 
 # 验证 active role 已在线切换，连接未重建
 db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 60;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and log_restore_source = '', 1, 5;
 
 # 验证新主库（failover 后）可以执行 DDL 和 INSERT
 create table if not exists test_table_failover_primary(a int primary key, b int);
 insert into test_table_failover_primary values(1, 1);
+db_p.force_stop;
+db_p.nstart;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and log_restore_source = '', 1, 60;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
+db_p.check_until_timeout select count(*) from test_table_failover_primary where a = 1, 1, 5;
+db_p.mysql alter system set log_restore_source = '127.0.0.1:42001';
+db_p.mysql ALTER SYSTEM ACTIVATE STANDBY;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '127.0.0.1:42001', 1, 5;
 
 # 故障旧主不重返拓扑，也不再验证其可写性
 

--- a/tools/obtest/t/stanby/failover_switchover_reentry.test
+++ b/tools/obtest/t/stanby/failover_switchover_reentry.test
@@ -81,6 +81,7 @@ reap;
 --enable_result_log
 db_s.nstart;
 db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 60;
+db_s.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
 ob_connect(conn_b, db_s.z1.obs0, root@sys, , oceanbase, , USE_MYSQL_CONNECTOR);
 
 # Restart the old source as the new standby only after the new primary is ready.
@@ -147,6 +148,7 @@ reap;
 --enable_result_log
 db_p.nstart;
 db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_server_stat where role = 'PRIMARY' and pending_role = 'INVALID' and switchover_status = 'NORMAL', 1, 60;
+db_p.check_until_timeout select count(*) from oceanbase.__all_virtual_sys_parameter_stat where name = 'log_restore_source' and value = '', 1, 5;
 ob_connect(conn_a, db_p.z1.obs0, root@sys, , oceanbase, , USE_MYSQL_CONNECTOR);
 
 # Restart the fenced db_s as standby and verify it follows db_p again.


### PR DESCRIPTION
Superseded: this change is now included in #1369.

After a standby is promoted, log_restore_source still contains the former upstream in SQLite, SHOW PARAMETERS, and __all_virtual_server_stat. Atomically persist the PRIMARY role and clear the obsolete source, then refresh in-memory configuration before enabling primary writes.

The shared promotion path covers both ACTIVATE STANDBY and SWITCHOVER TO PRIMARY. Interrupted promotion retains its source until the role commit; a crash after commit reloads PRIMARY with an empty source. Retrying runtime publication refreshes configuration again. Ordinary primary startup and an already-completed promotion do not clear a newly preconfigured source for a future demotion.

Add a transactional helper for updating two existing configuration values, preserving their metadata and rolling back if either row is missing or either write fails. Extend basic and crash-reentry obtest cases with source cleanup, restart persistence, and preservation of a newly configured source on repeated activation.

Validation:
- All three modified C++ translation units passed Clang 17 -fsyntax-only with worktree source headers and existing generated/dependency headers.
- Extracted-method C++ harness, using the production update_config_pair method body with a small SQLite connection adapter and real SQLite, passed success, rollback on a missing second entry, rollback on an injected second-write failure, retry, and argument validation. This is not a full configuration-manager integration test.
- git diff --check and regression command/expected-output consistency checks passed.
- Full build and execution of the updated obtest scenarios have not been performed.
