### PR TITLE
SEEK-569: fix macOS telemetry assign_ptr ambiguity

### DIFF
--- a/src/share/ob_telemetry.cpp
+++ b/src/share/ob_telemetry.cpp
@@ -1343,7 +1343,7 @@ static int read_telemetry_file(ObIAllocator &allocator, ObString &json_str)
       } else if (0 == size) {
         ret = OB_INVALID_ARGUMENT;
       } else {
-        json_str.assign_ptr(buf, size);
+        json_str.assign_ptr(buf, static_cast<int64_t>(size));
       }
     }
     fclose(fp);


### PR DESCRIPTION
### Task Description

Fix the macOS ARM64 build failure caused by an ambiguous `ObString::assign_ptr()` overload in `read_telemetry_file()`.

Issue: [SEEK-569](https://antmultica.alipay.com/seekdb/issues/SEEK-569)

`fread()` returns `size_t`. On Linux, its underlying type matches the existing `uint64_t` overload, while on macOS it does not exactly match any of the `int32_t`, `int64_t`, `uint64_t`, or `uint32_t` overloads. AppleClang therefore rejects the call as ambiguous.

### Solution Description

Cast the bounded `fread()` result to `int64_t` before calling `assign_ptr()`. This selects the existing `int64_t` overload consistently across platforms and preserves its length validation.

The read size is capped at 64 KiB, and the `size == max_size` case is rejected before this call, so the conversion is lossless.

### Passed Regressions

- Reproduced the original four-overload ambiguity with AppleClang 17.0.0 on macOS ARM64.
- Verified the same reproducer passes with `static_cast<int64_t>(size)` using `clang++ -std=c++11 -fsyntax-only`.
- `git diff --check` passes.
- Full SeekDB build was not run locally because the investigation workspace uses a sparse checkout; repository CI should validate the complete build.

### Upgrade Compatibility

Fully compatible. This changes compile-time overload selection only and does not change the accepted runtime length range or telemetry file behavior.

### Other Information

The regression was introduced when `read_telemetry_file()` was added. Later apparent macOS successes reused an older package; a real build of the updated source exposed the ambiguity.

### Release Note

Fix macOS compilation of telemetry file loading.
