### PR TITLE
Fix SQLancer optimizer regressions

### DIFF
--- a/src/sql/rewrite/ob_predicate_deduce.cpp
+++ b/src/sql/rewrite/ob_predicate_deduce.cpp
@@ -24,6 +24,74 @@
 using namespace oceanbase::sql;
 using namespace oceanbase::common;
 
+namespace
+{
+bool is_implicit_cast_expr(const ObRawExpr *expr)
+{
+  return NULL != expr &&
+         T_FUN_SYS_CAST == expr->get_expr_type() &&
+         expr->has_flag(IS_OP_OPERAND_IMPLICIT_CAST);
+}
+
+int check_one_implicit_cast_deduce_safe(const ObRawExpr *src_expr,
+                                        const ObRawExpr *dst_expr,
+                                        bool &is_safe)
+{
+  int ret = OB_SUCCESS;
+  bool need_cast = false;
+  bool ignore_dup_cast_error = false;
+  is_safe = true;
+  if (OB_ISNULL(src_expr) || OB_ISNULL(dst_expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null expr", K(ret), K(src_expr), K(dst_expr));
+  } else if (!is_implicit_cast_expr(src_expr)) {
+    // do nothing
+  } else if (OB_FAIL(ObRawExprUtils::check_need_cast_expr(src_expr->get_result_type(),
+                                                          dst_expr->get_result_type(),
+                                                          need_cast,
+                                                          ignore_dup_cast_error))) {
+    LOG_WARN("failed to check need cast expr", K(ret));
+  } else if (need_cast && !ignore_dup_cast_error) {
+    is_safe = false;
+  }
+  return ret;
+}
+
+int check_implicit_cast_deduce_safe(const ObRawExpr *first_expr,
+                                    const ObRawExpr *second_expr,
+                                    bool &is_safe)
+{
+  int ret = OB_SUCCESS;
+  bool first_safe = true;
+  bool second_safe = true;
+  if (OB_FAIL(check_one_implicit_cast_deduce_safe(first_expr, second_expr, first_safe))) {
+    LOG_WARN("failed to check first implicit cast deduce safety", K(ret));
+  } else if (OB_FAIL(check_one_implicit_cast_deduce_safe(second_expr, first_expr, second_safe))) {
+    LOG_WARN("failed to check second implicit cast deduce safety", K(ret));
+  } else {
+    is_safe = first_safe && second_safe;
+  }
+  return ret;
+}
+
+int check_predicate_implicit_cast_deduce_safe(ObRawExpr *expr, bool &is_safe)
+{
+  int ret = OB_SUCCESS;
+  is_safe = true;
+  if (OB_ISNULL(expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null expr", K(ret));
+  } else if (IS_COMPARISON_OP(expr->get_expr_type()) && 2 == expr->get_param_count()) {
+    if (OB_FAIL(check_implicit_cast_deduce_safe(expr->get_param_expr(0),
+                                                expr->get_param_expr(1),
+                                                is_safe))) {
+      LOG_WARN("failed to check implicit cast deduce safety", K(ret));
+    }
+  }
+  return ret;
+}
+}
+
 int ObPredicateDeduce::add_predicate(ObRawExpr *pred, bool &is_added)
 {
   int ret = OB_SUCCESS;
@@ -345,8 +413,15 @@ int ObPredicateDeduce::create_simple_preds(ObTransformerCtx &ctx,
       const uint8_t edge = chosen.at(i * N + j);
       pred = NULL;
       if (OB_SUCC(ret) && has(edge, EQ)) {
+        bool is_safe = true;
         clear(chosen, i, j, EQ);
-        if (OB_FAIL(ObRawExprUtils::create_double_op_expr(
+        if (OB_FAIL(check_implicit_cast_deduce_safe(input_exprs_.at(i),
+                                                    input_exprs_.at(j),
+                                                    is_safe))) {
+          LOG_WARN("failed to check implicit cast deduce safety", K(ret));
+        } else if (!is_safe) {
+          // do nothing
+        } else if (OB_FAIL(ObRawExprUtils::create_double_op_expr(
                       *expr_factory, session_info, T_OP_EQ,
                       pred, input_exprs_.at(i), input_exprs_.at(j)))) {
         } else if (OB_FAIL(pred->pull_relation_id())) {
@@ -354,8 +429,15 @@ int ObPredicateDeduce::create_simple_preds(ObTransformerCtx &ctx,
         }
       }
       if (OB_SUCC(ret) && has(edge, GT)) {
+        bool is_safe = true;
         clear(chosen, i, j, GT);
-        if (OB_FAIL(ObRawExprUtils::create_double_op_expr(
+        if (OB_FAIL(check_implicit_cast_deduce_safe(input_exprs_.at(i),
+                                                    input_exprs_.at(j),
+                                                    is_safe))) {
+          LOG_WARN("failed to check implicit cast deduce safety", K(ret));
+        } else if (!is_safe) {
+          // do nothing
+        } else if (OB_FAIL(ObRawExprUtils::create_double_op_expr(
                       *expr_factory, session_info, T_OP_GT,
                       pred, input_exprs_.at(i), input_exprs_.at(j)))) {
         } else if (OB_FAIL(pred->pull_relation_id())) {
@@ -363,8 +445,15 @@ int ObPredicateDeduce::create_simple_preds(ObTransformerCtx &ctx,
         }
       }
       if (OB_SUCC(ret) && has(edge, GE)) {
+        bool is_safe = true;
         clear(chosen, i, j, GE);
-        if (OB_FAIL(ObRawExprUtils::create_double_op_expr(
+        if (OB_FAIL(check_implicit_cast_deduce_safe(input_exprs_.at(i),
+                                                    input_exprs_.at(j),
+                                                    is_safe))) {
+          LOG_WARN("failed to check implicit cast deduce safety", K(ret));
+        } else if (!is_safe) {
+          // do nothing
+        } else if (OB_FAIL(ObRawExprUtils::create_double_op_expr(
                       *expr_factory, session_info, T_OP_GE,
                       pred, input_exprs_.at(i), input_exprs_.at(j)))) {
         } else if (OB_FAIL(pred->pull_relation_id())) {
@@ -510,6 +599,10 @@ int ObPredicateDeduce::check_type_safe(int64_t first, int64_t second, bool &type
                        second_expr->get_result_type()))) {
   } else {
     type_safe = (cmp_meta == cmp_type_);
+    if (type_safe &&
+        OB_FAIL(check_implicit_cast_deduce_safe(first_expr, second_expr, type_safe))) {
+      LOG_WARN("failed to check implicit cast deduce safety", K(ret));
+    }
   }
   return ret;
 }
@@ -534,12 +627,17 @@ int ObPredicateDeduce::deduce_general_predicates(ObTransformerCtx &ctx,
     }
     for (int64_t j = 0; OB_SUCC(ret) && j < equal_exprs.count(); ++j) {
       ObRawExpr *new_pred = NULL;
+      bool is_safe = true;
       if (OB_FAIL(ObRawExprCopier::copy_expr_node(*ctx.expr_factory_,
                                                   general_preds.at(i),
                                                   new_pred))) {
       } else {
         new_pred->get_param_expr(0) = equal_exprs.at(j);
-        if (OB_FAIL(new_pred->formalize(ctx.session_info_))) {
+        if (OB_FAIL(check_predicate_implicit_cast_deduce_safe(new_pred, is_safe))) {
+          LOG_WARN("failed to check implicit cast deduce safety", K(ret));
+        } else if (!is_safe) {
+          // do nothing
+        } else if (OB_FAIL(new_pred->formalize(ctx.session_info_))) {
         } else if (OB_FAIL(new_pred->pull_relation_id())) {
         } else if (OB_FAIL(result.push_back(new_pred))) {
         }
@@ -574,9 +672,14 @@ int ObPredicateDeduce::deduce_general_predicates(ObTransformerCtx &ctx,
       }
       for (int64_t j = 0; OB_SUCC(ret) && j < equal_exprs.count(); ++j) {
         ObRawExpr *new_pred = NULL;
+        bool is_safe = true;
         ObRawExprCopier copier(*ctx.expr_factory_);
         if (OB_FAIL(copier.add_replaced_expr(cast_expr, equal_exprs.at(j)))) {
         } else if (OB_FAIL(copier.copy_on_replace(pred, new_pred))) {
+        } else if (OB_FAIL(check_predicate_implicit_cast_deduce_safe(new_pred, is_safe))) {
+          LOG_WARN("failed to check implicit cast deduce safety", K(ret));
+        } else if (!is_safe) {
+          // do nothing
         } else if (OB_FAIL(new_pred->formalize(ctx.session_info_))) {
         } else if (OB_FAIL(new_pred->pull_relation_id())) {
         } else if (OB_FAIL(result.push_back(new_pred))) {
@@ -1017,4 +1120,3 @@ int ObPredicateDeduce::check_lossless_cast_table_filter(ObRawExpr *expr,
   }
   return ret;
 }
-

--- a/src/sql/rewrite/ob_transform_join_elimination.cpp
+++ b/src/sql/rewrite/ob_transform_join_elimination.cpp
@@ -2309,7 +2309,9 @@ int ObTransformJoinElimination::check_semi_join_condition(ObDMLStmt *stmt,
         /* do nothing */
       } else if (!expr->get_relation_ids().has_member(left_idx)) {
         target_tables_have_filter = true;
-        if (T_OP_OR == expr->get_expr_type()) { // complex right table filter
+        if (expr->get_relation_ids().num_members() > 1) {
+          is_simple_join_condition = false;
+        } else if (T_OP_OR == expr->get_expr_type()) { // complex right table filter
           is_simple_filter = false;
         } else { /*do nothing*/ }
       } else if (T_OP_EQ != expr->get_expr_type()) {
@@ -2410,7 +2412,9 @@ int ObTransformJoinElimination::check_semi_join_condition(ObDMLStmt *stmt,
         /* do nothing */
       } else if (!expr->get_relation_ids().has_member(left_idx)) {
         target_tables_have_filter = true;
-        if (T_OP_OR == expr->get_expr_type()) { // complex right table filter
+        if (expr->get_relation_ids().num_members() > 1) {
+          is_simple_join_condition = false;
+        } else if (T_OP_OR == expr->get_expr_type()) { // complex right table filter
           is_simple_filter = false;
         } else { /*do nothing*/ }
       } else if (T_OP_EQ != expr->get_expr_type()) {

--- a/src/sql/rewrite/ob_transform_simplify_expr.cpp
+++ b/src/sql/rewrite/ob_transform_simplify_expr.cpp
@@ -912,12 +912,24 @@ int ObTransformSimplifyExpr::adjust_dummy_expr(const ObIArray<int64_t> &true_exp
   } else {
     ObRawExpr *op_expr = NULL;
     ObSEArray<ObRawExpr*, 4> op_params;
+    bool is_error_free = true;
+    bool cur_error_free = true;
     const PreCalcExprExpectResult expect_result = ((is_and_op && !false_exprs.empty())
                                                    || (!is_and_op && true_exprs.empty()))
         ? PreCalcExprExpectResult::PRE_CALC_RESULT_FALSE
         : PreCalcExprExpectResult::PRE_CALC_RESULT_TRUE;
     if (OB_FAIL(ObTransformUtils::extract_target_exprs_by_idx(adjust_exprs, true_exprs, op_params))) {
     } else if (OB_FAIL(ObTransformUtils::extract_target_exprs_by_idx(adjust_exprs, false_exprs, op_params))) {
+    } else {
+      for (int64_t i = 0; OB_SUCC(ret) && is_error_free && i < op_params.count(); ++i) {
+        if (OB_FAIL(ObTransformUtils::check_error_free_expr(op_params.at(i), cur_error_free))) {
+        } else {
+          is_error_free = cur_error_free;
+        }
+      }
+    }
+    if (OB_FAIL(ret) || !is_error_free) {
+      // Keep the original predicate when a removed branch may raise warnings/errors at runtime.
     } else if (remove_all) {
       //to keep the or/and expr contains at least 2 params.
       const bool b_value = is_and_op ? false : true;
@@ -943,7 +955,7 @@ int ObTransformSimplifyExpr::adjust_dummy_expr(const ObIArray<int64_t> &true_exp
       }
     }
 
-    if (OB_FAIL(ret)) {
+    if (OB_FAIL(ret) || !is_error_free) {
     } else if (is_and_op && OB_FAIL(ObRawExprUtils::build_and_expr(*ctx_->expr_factory_,
                                                                    op_params, op_expr))) {
       LOG_WARN("failed to build and expr", K(ret));
@@ -1184,7 +1196,45 @@ int ObTransformSimplifyExpr::inner_remove_dummy_nvl(ObDMLStmt *stmt,
   if (OB_SUCC(ret)
       && (T_FUN_SYS_NVL == expr->get_expr_type() 
       || T_FUN_SYS_IFNULL == expr->get_expr_type())) {
-    if (ObOptimizerUtil::find_item(ignore_exprs, expr)) {
+    ObOpRawExpr *op_expr = static_cast<ObOpRawExpr *>(expr);
+    ObRawExpr *child_0 = NULL;
+    ObRawExpr *cur = NULL;
+    int64_t not_cnt = 0;
+    if (op_expr->get_param_count() != 2 || OB_ISNULL(ctx_) || OB_ISNULL(ctx_->expr_factory_) ||
+        OB_ISNULL(ctx_->session_info_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected nvl expr", K(ret), KPC(expr), K(ctx_));
+    } else if (OB_ISNULL(child_0 = op_expr->get_param_expr(0))) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected null child expr", K(ret), KPC(expr));
+    } else {
+      cur = child_0;
+      while (OB_SUCC(ret) && T_OP_NOT == cur->get_expr_type()) {
+        ++not_cnt;
+        if (OB_UNLIKELY(1 != cur->get_param_count()) ||
+            OB_ISNULL(cur = cur->get_param_expr(0))) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("unexpected not expr", K(ret), KPC(child_0));
+        }
+      }
+      if (OB_SUCC(ret) && not_cnt > 1 && 0 == not_cnt % 2) {
+        ObRawExpr *new_child = NULL;
+        if (OB_FAIL(ObRawExprUtils::try_create_bool_expr(cur, new_child, *ctx_->expr_factory_))) {
+        } else if (OB_ISNULL(new_child)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("unexpected null bool expr", K(ret));
+        } else if (OB_FAIL(new_child->formalize(ctx_->session_info_))) {
+        } else {
+          op_expr->get_param_expr(0) = new_child;
+          if (OB_FAIL(expr->formalize(ctx_->session_info_))) {
+          } else {
+            trans_happened = true;
+          }
+        }
+      }
+    }
+    if (OB_FAIL(ret)) {
+    } else if (ObOptimizerUtil::find_item(ignore_exprs, expr)) {
       // nvl expr is rollup expr, do nothing
     } else if (OB_FAIL(do_remove_dummy_nvl(stmt,
                                     expr,
@@ -1220,6 +1270,7 @@ int ObTransformSimplifyExpr::do_remove_dummy_nvl(ObDMLStmt *stmt,
         LOG_WARN("get unexpecte null", K(child_0), K(child_1), K(ret));
       } else {
         bool not_null = false;
+        bool is_error_free = false;
         ObRawExpr *new_expr = NULL;
         ObArray<ObRawExpr *> not_null_constraints;
         if (OB_FAIL(ObTransformUtils::is_expr_not_null(not_null_ctx,
@@ -1228,7 +1279,12 @@ int ObTransformSimplifyExpr::do_remove_dummy_nvl(ObDMLStmt *stmt,
                                                        &not_null_constraints))) {
         } else if (not_null){
           // NVL(child_0, child_1) -> child_0  IF child_0 is not null
-          if (OB_FAIL(ObTransformUtils::add_param_not_null_constraint(*ctx_, not_null_constraints))) {
+          if (child_0->has_flag(CNT_NOT)) {
+            // NOT chains can be simplified later; keep IFNULL/NVL to avoid unsafe not-null constraints.
+          } else if (OB_FAIL(ObTransformUtils::check_error_free_expr(child_0, is_error_free))) {
+          } else if (!is_error_free) {
+            // Keep IFNULL/NVL if the input may raise conversion/runtime errors.
+          } else if (OB_FAIL(ObTransformUtils::add_param_not_null_constraint(*ctx_, not_null_constraints))) {
           } else {
             new_expr = child_0;
           }

--- a/src/sql/rewrite/ob_transform_simplify_groupby.cpp
+++ b/src/sql/rewrite/ob_transform_simplify_groupby.cpp
@@ -492,6 +492,15 @@ int ObTransformSimplifyGroupby::check_stmt_group_by_can_be_removed(ObSelectStmt 
       } else if (OB_FAIL(check_aggr_win_can_be_removed(select_stmt, expr, can_be))) {
       }
     }
+    for (int64_t i = 0; OB_SUCC(ret) && can_be && i < select_stmt->get_having_expr_size(); ++i) {
+      ObRawExpr *expr = select_stmt->get_having_exprs().at(i);
+      if (OB_ISNULL(expr)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("NULL pointer error", K(ret));
+      } else if (expr->has_flag(CNT_AGG)) {
+        can_be = false;
+      }
+    }
   } else {
     //do nothing
   }

--- a/src/sql/rewrite/ob_transform_temp_table.cpp
+++ b/src/sql/rewrite/ob_transform_temp_table.cpp
@@ -640,11 +640,17 @@ int ObTransformTempTable::check_stmt_can_extract_temp_table(ObSelectStmt *first,
                                                             bool &is_valid)
 {
   int ret = OB_SUCCESS;
+  bool has_const_minmax_like = false;
   is_valid = false;
   if (OB_ISNULL(first) || OB_ISNULL(second)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("stmt is null", K(ret));
   } else if (first->is_scala_group_by() ^ second->is_scala_group_by()) {
+    is_valid = false;
+  } else if (OB_FAIL(check_like_expr_with_const_minmax(*first, has_const_minmax_like))) {
+  } else if (!has_const_minmax_like &&
+             OB_FAIL(check_like_expr_with_const_minmax(*second, has_const_minmax_like))) {
+  } else if (has_const_minmax_like) {
     is_valid = false;
   } else if (second->is_set_stmt()) {
     is_valid = QueryRelation::QUERY_EQUAL == relation && map_info.is_order_equal_;
@@ -663,6 +669,101 @@ int ObTransformTempTable::check_stmt_can_extract_temp_table(ObSelectStmt *first,
     } else if (!is_valid) {
       // do nothing
     } else if (OB_FAIL(check_index_condition_match(*first, *second, map_info, is_valid))) {
+    }
+  }
+  return ret;
+}
+
+int ObTransformTempTable::check_like_expr_with_const_minmax(const ObSelectStmt &stmt,
+                                                            bool &has_const_minmax)
+{
+  int ret = OB_SUCCESS;
+  has_const_minmax = false;
+  const ObIArray<ObRawExpr*> &conditions = stmt.get_condition_exprs();
+  const ObIArray<ObRawExpr*> &having_exprs = stmt.get_having_exprs();
+  for (int64_t i = 0; OB_SUCC(ret) && !has_const_minmax && i < conditions.count(); ++i) {
+    if (OB_FAIL(SMART_CALL(check_like_expr_with_const_minmax(conditions.at(i),
+                                                            has_const_minmax)))) {
+    }
+  }
+  for (int64_t i = 0; OB_SUCC(ret) && !has_const_minmax && i < having_exprs.count(); ++i) {
+    if (OB_FAIL(SMART_CALL(check_like_expr_with_const_minmax(having_exprs.at(i),
+                                                            has_const_minmax)))) {
+    }
+  }
+  return ret;
+}
+
+int ObTransformTempTable::check_like_expr_with_const_minmax(const ObRawExpr *expr,
+                                                            bool &has_const_minmax)
+{
+  int ret = OB_SUCCESS;
+  has_const_minmax = false;
+  if (OB_ISNULL(expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null expr", K(ret));
+  } else if (T_OP_LIKE == expr->get_expr_type() ||
+             T_OP_NOT_LIKE == expr->get_expr_type()) {
+    for (int64_t i = 0; OB_SUCC(ret) && !has_const_minmax && i < expr->get_param_count(); ++i) {
+      if (OB_FAIL(SMART_CALL(check_expr_has_const_minmax(expr->get_param_expr(i),
+                                                        has_const_minmax)))) {
+      }
+    }
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && !has_const_minmax && i < expr->get_param_count(); ++i) {
+      if (OB_FAIL(SMART_CALL(check_like_expr_with_const_minmax(expr->get_param_expr(i),
+                                                              has_const_minmax)))) {
+      }
+    }
+  }
+  return ret;
+}
+
+int ObTransformTempTable::check_expr_has_const_minmax(const ObRawExpr *expr,
+                                                      bool &has_const_minmax)
+{
+  int ret = OB_SUCCESS;
+  has_const_minmax = false;
+  if (OB_ISNULL(expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null expr", K(ret));
+  } else if (expr->is_aggr_expr()) {
+    if (OB_FAIL(check_const_minmax(static_cast<const ObAggFunRawExpr*>(expr),
+                                  has_const_minmax))) {
+    }
+  } else if (expr->has_flag(CNT_AGG)) {
+    for (int64_t i = 0; OB_SUCC(ret) && !has_const_minmax && i < expr->get_param_count(); ++i) {
+      if (OB_FAIL(SMART_CALL(check_expr_has_const_minmax(expr->get_param_expr(i),
+                                                        has_const_minmax)))) {
+      }
+    }
+  }
+  return ret;
+}
+
+int ObTransformTempTable::check_const_minmax(const ObAggFunRawExpr *aggr,
+                                             bool &has_const_minmax)
+{
+  int ret = OB_SUCCESS;
+  has_const_minmax = false;
+  if (OB_ISNULL(aggr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected null aggregate expr", K(ret));
+  } else if (T_FUN_MIN != aggr->get_expr_type() &&
+             T_FUN_MAX != aggr->get_expr_type()) {
+    // do nothing
+  } else if (aggr->get_real_param_count() <= 0) {
+    // do nothing
+  } else {
+    has_const_minmax = true;
+    for (int64_t i = 0; OB_SUCC(ret) && has_const_minmax && i < aggr->get_real_param_count(); ++i) {
+      const ObRawExpr *param = aggr->get_real_param_exprs().at(i);
+      if (OB_ISNULL(param)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("unexpected null aggregate param", K(ret));
+      } else {
+        has_const_minmax = param->is_const_expr();
+      }
     }
   }
   return ret;

--- a/src/sql/rewrite/ob_transform_temp_table.h
+++ b/src/sql/rewrite/ob_transform_temp_table.h
@@ -124,6 +124,14 @@ public:
                                         QueryRelation relation,
                                         bool check_basic,
                                         bool &is_valid);
+  int check_like_expr_with_const_minmax(const ObSelectStmt &stmt,
+                                        bool &has_const_minmax);
+  int check_like_expr_with_const_minmax(const ObRawExpr *expr,
+                                        bool &has_const_minmax);
+  int check_expr_has_const_minmax(const ObRawExpr *expr,
+                                  bool &has_const_minmax);
+  int check_const_minmax(const ObAggFunRawExpr *aggr,
+                         bool &has_const_minmax);
   int check_equal_join_condition_match(ObSelectStmt &first,
                                        ObSelectStmt &second,
                                        const ObStmtMapInfo &map_info,

--- a/tools/deploy/mysql_test/r/mysql/sqlancer_optimizer_regressions.result
+++ b/tools/deploy/mysql_test/r/mysql/sqlancer_optimizer_regressions.result
@@ -1,0 +1,27 @@
+drop database if exists sqlancer_optimizer_regressions;
+create database sqlancer_optimizer_regressions character set utf8mb4;
+use sqlancer_optimizer_regressions;
+create table d0_t0(c0 decimal(27, 6) zerofill unique key comment 'asdf', c1 decimal zerofill, primary key(c0, c1)) partition by key (c0) partitions 8;
+create table d0_t1(c0 tinyint(132) null, c1 longtext, c2 float zerofill) auto_increment = 5559037122261584;
+insert into d0_t0(c0, c1) values (2, 25022638), (3, 7644), (400.378255, 85);
+insert into d0_t1(c0, c1, c2) values (4, '', 240975987), (-2, 'Kc', 6), (6, 'RIFF_N[D', 4);
+select count(*) as d0_where_expr_count from (select /*+ no_use_nl */ d0_t1.c0 from d0_t1 left join d0_t0 on (d0_t1.c0) != (concat(d0_t0.c1,'')) where (if((3680881746) != (10), ((760187400) < (1513041260)) >= ((9285266.166385) > (0.832418)), ((d0_t1.c1,0) not in (("J",-8))) like ("%G"))) not in ((((2,'V') not in ((d0_t1.c0,"1602998041"), (-2,'Kc'))) = (ifnull((not ((not ((cast(((ifnull(((340395148) < (1913548270)) > ("X3"), (not (exists (select 1))))) or (((exists (select 1)) is not true) in (("6") is not true, (((true) <= (7)) xor ((cast((concat(d0_t1.c2,'')) is true as signed)) is null)) is null))) < (concat(d0_t1.c2,'')) as signed)) like ("%Q"))))), exists (select 1 from dual where false)))) = (concat(d0_t0.c1,''))) ) q;
+d0_where_expr_count
+9
+create table d3_t1(c0 decimal(45, 9) not null unique, c1 double(17, 0), primary key(c0));
+create table d3_t2 like d3_t1;
+insert into d3_t1(c1, c0) values (61, 0.930735627), (2358, -23);
+insert into d3_t2(c1, c0) values (-4753350, 752.730158025), (0.07497, -127), (99, 8.345450292);
+select count(*) as d3_original_count from (select /*+ use_merge(d3_t2, d3_t1) */ d3_t1.c0 from d3_t1 inner join d3_t2 on (d3_t1.c1) > (d3_t2.c1) where (d3_t2.c0,d3_t1.c0) not in (select all d3_t1.c0, d3_t1.c0 from d3_t1)) q;
+d3_original_count
+5
+select count(*) as d3_tlp_count from ((select /*+ use_merge(d3_t2, d3_t1) */ d3_t1.c0 from d3_t1 inner join d3_t2 on (d3_t1.c1) > (d3_t2.c1) where ((d3_t2.c0,d3_t1.c0) not in (select d3_t1.c0, d3_t1.c0 from d3_t1)) and (675468602)) union all (select /*+ use_merge(d3_t2, d3_t1) */ d3_t1.c0 from d3_t1 cross join d3_t2 on (d3_t1.c1) > (d3_t2.c1) where ((d3_t2.c0,d3_t1.c0) not in (select all d3_t1.c0, d3_t1.c0 from d3_t1)) and ((not (675468602)))) union all (select /*+ use_merge(d3_t2, d3_t1) */ all d3_t1.c0 from d3_t1 cross join d3_t2 on (d3_t1.c1) > (d3_t2.c1) where ((d3_t2.c0,d3_t1.c0) not in (select d3_t1.c0, d3_t1.c0 from d3_t1)) and ((675468602) is null))) q;
+d3_tlp_count
+5
+create table d5_t0(c0 varchar(500), c1 longtext comment 'asdf', c2 double(40, 8) zerofill unique);
+drop index c2 on d5_t0;
+insert into d5_t0(c2, c1, c0) values (4.70805083, '', ''), (37.25662755, 'x', 'y'), (34450.07331221, 'z', 'w');
+select count(*) as d5_having_tlp_count from ((select /*+ no_use_hash */ max(distinct d5_t0.c2) as af0 from d5_t0 having ((not ((af0) in (cast(af0 as signed))))) and ((cast(((false) in ((0), (-1))) or ((af0,0,0) not in ((false,-1,0))) as signed)) && ((min("")) like ("224617187%")))) union all (select /*+ no_use_hash */ max(distinct d5_t0.c2) as af0 from d5_t0 having (! (((! ((af0) in (cast(af0 as signed))))) and ((cast(((false) in ((0), (-1))) or ((af0,0,0) not in ((false,-1,0))) as signed)) && ((min("")) like ("224617187%")))))) union all (select /*+ no_use_hash */ all max(distinct d5_t0.c2) as af0 from d5_t0 having (((! ((af0) in (cast(af0 as signed))))) and ((cast(((false) in ((0), (-1))) or ((af0,0,0) not in ((false,-1,0))) as signed)) && ((min("")) like ("224617187%")))) is null)) q;
+d5_having_tlp_count
+1
+drop database if exists sqlancer_optimizer_regressions;

--- a/tools/deploy/mysql_test/t/sqlancer_optimizer_regressions.test
+++ b/tools/deploy/mysql_test/t/sqlancer_optimizer_regressions.test
@@ -1,0 +1,37 @@
+#owner: minan
+#owner group: sql
+#description: Regression checks for SQLancer optimizer failures from SEEK-576.
+
+--disable_warnings
+drop database if exists sqlancer_optimizer_regressions;
+--enable_warnings
+
+create database sqlancer_optimizer_regressions character set utf8mb4;
+use sqlancer_optimizer_regressions;
+
+--disable_warnings
+create table d0_t0(c0 decimal(27, 6) zerofill unique key comment 'asdf', c1 decimal zerofill, primary key(c0, c1)) partition by key (c0) partitions 8;
+create table d0_t1(c0 tinyint(132) null, c1 longtext, c2 float zerofill) auto_increment = 5559037122261584;
+insert into d0_t0(c0, c1) values (2, 25022638), (3, 7644), (400.378255, 85);
+insert into d0_t1(c0, c1, c2) values (4, '', 240975987), (-2, 'Kc', 6), (6, 'RIFF_N[D', 4);
+--enable_warnings
+
+select count(*) as d0_where_expr_count from (select /*+ no_use_nl */ d0_t1.c0 from d0_t1 left join d0_t0 on (d0_t1.c0) != (concat(d0_t0.c1,'')) where (if((3680881746) != (10), ((760187400) < (1513041260)) >= ((9285266.166385) > (0.832418)), ((d0_t1.c1,0) not in (("J",-8))) like ("%G"))) not in ((((2,'V') not in ((d0_t1.c0,"1602998041"), (-2,'Kc'))) = (ifnull((not ((not ((cast(((ifnull(((340395148) < (1913548270)) > ("X3"), (not (exists (select 1))))) or (((exists (select 1)) is not true) in (("6") is not true, (((true) <= (7)) xor ((cast((concat(d0_t1.c2,'')) is true as signed)) is null)) is null))) < (concat(d0_t1.c2,'')) as signed)) like ("%Q"))))), exists (select 1 from dual where false)))) = (concat(d0_t0.c1,''))) ) q;
+
+create table d3_t1(c0 decimal(45, 9) not null unique, c1 double(17, 0), primary key(c0));
+create table d3_t2 like d3_t1;
+insert into d3_t1(c1, c0) values (61, 0.930735627), (2358, -23);
+insert into d3_t2(c1, c0) values (-4753350, 752.730158025), (0.07497, -127), (99, 8.345450292);
+
+select count(*) as d3_original_count from (select /*+ use_merge(d3_t2, d3_t1) */ d3_t1.c0 from d3_t1 inner join d3_t2 on (d3_t1.c1) > (d3_t2.c1) where (d3_t2.c0,d3_t1.c0) not in (select all d3_t1.c0, d3_t1.c0 from d3_t1)) q;
+select count(*) as d3_tlp_count from ((select /*+ use_merge(d3_t2, d3_t1) */ d3_t1.c0 from d3_t1 inner join d3_t2 on (d3_t1.c1) > (d3_t2.c1) where ((d3_t2.c0,d3_t1.c0) not in (select d3_t1.c0, d3_t1.c0 from d3_t1)) and (675468602)) union all (select /*+ use_merge(d3_t2, d3_t1) */ d3_t1.c0 from d3_t1 cross join d3_t2 on (d3_t1.c1) > (d3_t2.c1) where ((d3_t2.c0,d3_t1.c0) not in (select all d3_t1.c0, d3_t1.c0 from d3_t1)) and ((not (675468602)))) union all (select /*+ use_merge(d3_t2, d3_t1) */ all d3_t1.c0 from d3_t1 cross join d3_t2 on (d3_t1.c1) > (d3_t2.c1) where ((d3_t2.c0,d3_t1.c0) not in (select d3_t1.c0, d3_t1.c0 from d3_t1)) and ((675468602) is null))) q;
+
+create table d5_t0(c0 varchar(500), c1 longtext comment 'asdf', c2 double(40, 8) zerofill unique);
+drop index c2 on d5_t0;
+insert into d5_t0(c2, c1, c0) values (4.70805083, '', ''), (37.25662755, 'x', 'y'), (34450.07331221, 'z', 'w');
+
+select count(*) as d5_having_tlp_count from ((select /*+ no_use_hash */ max(distinct d5_t0.c2) as af0 from d5_t0 having ((not ((af0) in (cast(af0 as signed))))) and ((cast(((false) in ((0), (-1))) or ((af0,0,0) not in ((false,-1,0))) as signed)) && ((min("")) like ("224617187%")))) union all (select /*+ no_use_hash */ max(distinct d5_t0.c2) as af0 from d5_t0 having (! (((! ((af0) in (cast(af0 as signed))))) and ((cast(((false) in ((0), (-1))) or ((af0,0,0) not in ((false,-1,0))) as signed)) && ((min("")) like ("224617187%")))))) union all (select /*+ no_use_hash */ all max(distinct d5_t0.c2) as af0 from d5_t0 having (((! ((af0) in (cast(af0 as signed))))) and ((cast(((false) in ((0), (-1))) or ((af0,0,0) not in ((false,-1,0))) as signed)) && ((min("")) like ("224617187%")))) is null)) q;
+
+--disable_warnings
+drop database if exists sqlancer_optimizer_regressions;
+--enable_warnings

--- a/tools/deploy/mysql_test/test_suite/window_function/r/mysql/sqlancer_const_prop_cast.result
+++ b/tools/deploy/mysql_test/test_suite/window_function/r/mysql/sqlancer_const_prop_cast.result
@@ -1,0 +1,9 @@
+drop database if exists sqlancer_const_prop_cast;
+create database sqlancer_const_prop_cast;
+use sqlancer_const_prop_cast;
+create table t1(c3 decimal(33, 7));
+create table t2(c3 decimal(33, 7));
+select count(*) as cnt from ((select * from (select t2.c3 as c3, t1.c3 as c7, dense_rank() over(order by t2.c3 desc) as wf2 from t2 cross join t1 on t2.c3 = t1.c3) l0 where ifnull(0, wf2) = c3) union all (select * from (select t2.c3 as c3, t1.c3 as c7, dense_rank() over(order by t2.c3 desc) as wf2 from t2 cross join t1 on t2.c3 = t1.c3) l0 where not (ifnull(0, wf2) = c3))) q;
+cnt
+0
+drop database if exists sqlancer_const_prop_cast;

--- a/tools/deploy/mysql_test/test_suite/window_function/t/sqlancer_const_prop_cast.test
+++ b/tools/deploy/mysql_test/test_suite/window_function/t/sqlancer_const_prop_cast.test
@@ -1,0 +1,19 @@
+#owner: minan
+#owner group: sql
+#description: Regression for const propagation of implicit casts in window derived-table predicates.
+
+--disable_warnings
+drop database if exists sqlancer_const_prop_cast;
+--enable_warnings
+
+create database sqlancer_const_prop_cast;
+use sqlancer_const_prop_cast;
+
+create table t1(c3 decimal(33, 7));
+create table t2(c3 decimal(33, 7));
+
+select count(*) as cnt from ((select * from (select t2.c3 as c3, t1.c3 as c7, dense_rank() over(order by t2.c3 desc) as wf2 from t2 cross join t1 on t2.c3 = t1.c3) l0 where ifnull(0, wf2) = c3) union all (select * from (select t2.c3 as c3, t1.c3 as c7, dense_rank() over(order by t2.c3 desc) as wf2 from t2 cross join t1 on t2.c3 = t1.c3) l0 where not (ifnull(0, wf2) = c3))) q;
+
+--disable_warnings
+drop database if exists sqlancer_const_prop_cast;
+--enable_warnings

--- a/tools/deploy/mysqltest_config.yaml
+++ b/tools/deploy/mysqltest_config.yaml
@@ -78,6 +78,7 @@ runtime_configs:
       - special_stmt
       - sq_from
       - sq_from_2
+      - sqlancer_optimizer_regressions
       - substring_index
       - table_column_related_views
       - topk


### PR DESCRIPTION
## Summary
- Guard predicate deduction and simplification rewrites that can change error/conversion behavior.
- Preserve aggregate HAVING semantics for temp-table extraction when LIKE depends on constant MIN/MAX.
- Add focused SQLancer mysqltest regression coverage.

## Links
- [SEEK-576](https://antmultica.alipay.com/seekdb/issues/SEEK-576)
- [SEEK-577](https://antmultica.alipay.com/seekdb/issues/SEEK-577)

## Validation
- `./build.sh release --make -j8 seekdb`
- Focused repros: database0 `where_expr_count=9`, database3 `original_count=5` / `tlp_count=5`, database5 `having_tlp_count=1`
- New mysqltest SQL file executed directly via mysql: `9`, `5`, `5`, `1`

CI may still be running after PR creation.